### PR TITLE
feat(preview): marker/edit mode toggle with per-language edits

### DIFF
--- a/docs/superpowers/specs/2026-04-14-preview-edit-mode-design.md
+++ b/docs/superpowers/specs/2026-04-14-preview-edit-mode-design.md
@@ -153,8 +153,9 @@ Unchanged from current behavior. The current `SPA.addMarker`,
 ### Edit mode — add
 
 `SPA.addEdit()`:
-1. `lang = previewState.srtLang` (current `srt-lang-select`).
-2. `blocks = SPA.srtByLang[lang]`. If absent → toast `no_srt`, return.
+1. `lang = previewState.srtLang` (current `srt-lang-select` value).
+2. `blocks = previewState.subtitles` (already parsed for the current
+   language by `loadSubtitleLang`). If empty → toast `no_srt`, return.
 3. `idx = findActiveSubtitleIdx(blocks, currentTimeMs)`.
    If `-1` → toast `no_active_subtitle`, return.
 4. `previewState.player.pause()`.
@@ -164,6 +165,17 @@ Unchanged from current behavior. The current `SPA.addMarker`,
 6. Else → `edits[lang][idx] = blocks[idx].text` (initial text = original),
    `renderEditList()`, focus the new row.
 7. `savePreviewState()`, `updateClearBtn()`.
+
+New helper (added next to the existing `findActiveSubtitle`):
+
+```js
+function findActiveSubtitleIdx(subs, ms) {
+  for (var i = 0; i < subs.length; i++) {
+    if (ms >= subs[i].startMs && ms < subs[i].endMs) return i;
+  }
+  return -1;
+}
+```
 
 ### Edit row DOM
 
@@ -213,9 +225,11 @@ The `.tc` click seeks the player to the block start (reuses marker
 
 ### Language switch
 
-`srt-lang-select` onchange already updates overlay state. Extend it: if
-`previewState.mode === 'edit'`, re-render the edit list with
-`edits[newLang]`.
+`SPA.switchSubLang(lang)` already loads the new SRT into
+`previewState.subtitles` and updates the overlay. Extend it: if
+`previewState.mode === 'edit'`, re-render the edit list so rows reflect
+`edits[newLang]` with original texts from the newly-loaded
+`previewState.subtitles`.
 
 ### Clear all
 
@@ -236,16 +250,20 @@ The `.tc` click seeks the player to the block start (reuses marker
 
 ### `Open in GitHub Editor` (edit mode)
 
-`SPA.openPreviewEditor()`:
-1. `blocks = SPA.srtByLang[currentLang]`
-2. Rebuild an SRT string: for each block, substitute
-   `edits[currentLang][idx]` where present, keep block numbering and
-   original timecodes.
-3. Target path:
-   `talks/<talkId>/<videoSlug>/final/<currentLang>.srt`
-4. Open `https://github.com/<REPO>/edit/main/<path>?value=<encoded>`.
-   This is the same mechanism the review page uses
-   (`SPA.openEditor` at `site/index.html:2690`).
+`SPA.openPreviewEditor()` mirrors the review-page `SPA.openEditor`
+exactly (`site/index.html:2690-2739`):
+
+1. `lang = previewState.srtLang`
+2. `filePath = talks/<talkId>/<videoSlug>/final/<lang>.srt`
+3. `url = https://github.com/<REPO>/edit/main/<filePath>` — bare URL,
+   **no `?value=` query param** (GitHub's edit endpoint does not accept
+   one).
+4. If `edits[lang]` is non-empty:
+   - Rebuild the SRT from `previewState.subtitles`: keep block numbering
+     and timecodes, substitute `edits[lang][idx]` where present.
+   - `navigator.clipboard.writeText(rebuilt)` → alert the user that the
+     SRT is on the clipboard → `window.open(url)`.
+5. Else → open the editor URL directly.
 
 ## Tests (TDD)
 

--- a/docs/superpowers/specs/2026-04-14-preview-edit-mode-design.md
+++ b/docs/superpowers/specs/2026-04-14-preview-edit-mode-design.md
@@ -1,0 +1,318 @@
+# Preview page: Marker ↔ Edit modes
+
+**Status:** approved
+**Date:** 2026-04-14
+**Scope:** `site/index.html` (SPA preview view) + tests
+
+## Goal
+
+Extend the preview page with two switchable modes:
+
+1. **Marker mode** (current behavior, default for new/migrated state)
+   — drop a timestamped note on the current subtitle moment, collect a list,
+   copy/export, create a GitHub issue with the marker set.
+2. **Edit mode** (new) — edit the text of individual SRT blocks while
+   watching the video. Edits accumulate locally per video and per language,
+   and can be exported as a GitHub issue (Before/After) or opened in the
+   GitHub web editor as a fully-rebuilt SRT (same flow the review page uses
+   for its `Open in GitHub Editor` action).
+
+No backend changes. All state is client-side in `localStorage`.
+
+## Non-goals
+
+- Timecode editing. Only block text is editable.
+- Bulk import of edits from an issue/PR.
+- Undo/history beyond "reset to original".
+- Changes to SRT/whisper parsers, optimizer, or build pipeline.
+
+## Layout
+
+Preview `.header` becomes a single row that matches the review page
+pattern: `<h1>` on the left, `.header-actions` on the right.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ ← Index · <title> [video▾]   [📌|✏️]  [action buttons ...]   │  .header
+├──────────────────────────────────────────────────────────────┤
+│ <iframe video>                                               │
+│ <overlay>                                                    │
+│ [00:00:00] [lang▾] [📌 Mark / ✏️ Edit] [⛶]                  │  .controls
+├──────────────────────────────────────────────────────────────┤
+│ ▼ Markers (N)   | Edits (N)                                  │
+│   <rows>                                                     │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### `.header-actions` contents
+
+Always visible:
+- **Mode segmented control** `[📌 Markers | ✏️ Edit]` — two toggleable
+  buttons, the active one highlighted. Not shown as a `<select>` since there
+  are only two options.
+
+Visible only in **marker** mode:
+- `Copy all`
+- `Create issue`
+- `Clear all` — hidden unless `markers.length > 0`
+
+Visible only in **edit** mode:
+- `Create issue`
+- `Open in GitHub Editor` (the PR flow)
+- `Clear all` — hidden unless `edits[currentLang]` has any keys
+
+### Player `.controls` (under the iframe)
+
+Keeps: time display, lang select, Mark/Edit button, fullscreen.
+
+The Mark/Edit button stays in player controls (per user decision). Its
+label and handler depend on `previewState.mode`:
+- marker mode → `📌 Mark` → `SPA.addMarker()`
+- edit mode → `✏️ Edit` → `SPA.addEdit()`
+
+### Video switcher (new)
+
+A `<select id="preview-video-select">` is added inside the `<h1>` next to
+the title (same pattern as `#review-mode-select` on the review page).
+
+- Hidden (`display:none`) when `meta.videos.length <= 1`.
+- Populated from `meta.videos` with `{value: slug, text: title}`.
+- `onchange` → `location.hash = '#/preview/' + talkId + '/' + newSlug`.
+  This triggers the normal route → `showPreview` re-entry, which loads the
+  new video's own localStorage entry (state is per-video, not per-talk).
+
+### List container
+
+The existing `.markers > <details>` block is renamed `.preview-list`. Its
+`<summary>` label toggles between "Markers (N)" and "Edits (N)" per mode.
+The body swaps between a marker list and an edit list.
+
+## State model
+
+### Shape
+
+```js
+// localStorage key: preview_<talkId>_<videoSlug>
+{
+  mode: 'marker' | 'edit',
+  markers: [
+    { time: 12.34, tc: '00:00:12', text: '...', comment: '...' }
+  ],
+  edits: {
+    uk: { 0: 'edited text', 5: '...' },
+    en: { ... }
+  }
+}
+```
+
+- `mode` is persisted per video.
+- `markers` is a flat list, independent of SRT language (as today).
+- `edits` is keyed by language (`srt-lang-select` value), then by the
+  0-based index of the block in the parsed SRT for that language.
+
+### Migration
+
+When `showPreview(talkId, videoSlug)` runs:
+
+1. If `preview_<talkId>_<videoSlug>` exists → parse and use.
+2. Else if legacy `markers_preview_<talkId>_<videoSlug>` exists →
+   build `{mode: 'marker', markers: <legacy>, edits: {}}`, write the new
+   key, delete the legacy key.
+3. Else → default `{mode: 'marker', markers: [], edits: {}}`.
+
+### In-memory
+
+```js
+previewState.mode     // 'marker' | 'edit'
+previewState.markers  // as today
+previewState.edits    // { <lang>: { <idx>: text } }
+```
+
+`savePreviewState()` replaces `saveMarkers()` and writes the whole object.
+It is called after any mutation to markers, edits, or mode.
+
+## Behavior
+
+### Mode switch
+
+`SPA.setPreviewMode(newMode)`:
+1. No-op if already in `newMode`.
+2. Update `previewState.mode`, `savePreviewState()`.
+3. Toggle segmented-control active class.
+4. Update `.controls` Mark/Edit button label and handler.
+5. Swap visible button group in `.header-actions`.
+6. Update list summary label and count, re-render list.
+7. Update `Clear all` visibility.
+
+### Marker mode
+
+Unchanged from current behavior. The current `SPA.addMarker`,
+`SPA.copyMarkers`, `SPA.createPreviewIssue` (marker variant),
+`SPA.clearMarkers`, `renderMarkers()` stay.
+
+### Edit mode — add
+
+`SPA.addEdit()`:
+1. `lang = previewState.srtLang` (current `srt-lang-select`).
+2. `blocks = SPA.srtByLang[lang]`. If absent → toast `no_srt`, return.
+3. `idx = findActiveSubtitleIdx(blocks, currentTimeMs)`.
+   If `-1` → toast `no_active_subtitle`, return.
+4. `previewState.player.pause()`.
+5. If `edits[lang][idx]` already exists → `renderEditList()`
+   (no duplicate), then focus the existing row's contenteditable and
+   place cursor at end.
+6. Else → `edits[lang][idx] = blocks[idx].text` (initial text = original),
+   `renderEditList()`, focus the new row.
+7. `savePreviewState()`, `updateClearBtn()`.
+
+### Edit row DOM
+
+```html
+<li class="edit-item" data-idx="{idx}">
+  <span class="tc">00:01:23</span>
+  <div class="orig">{original block text}</div>
+  <div class="edited" contenteditable="true" data-idx="{idx}"
+       oninput="SPA.onEditInput({idx}, this)"
+       onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();this.blur();SPA.resumePlayer();}">
+    {current edit text}
+  </div>
+  <button class="del" onclick="SPA.deleteEdit({idx})">×</button>
+</li>
+```
+
+The `.tc` click seeks the player to the block start (reuses marker
+`seek-to-time` helper).
+
+### Edit row — input handling
+
+`SPA.onEditInput(idx, el)`:
+- `text = el.innerText`
+- `orig = SPA.srtByLang[currentLang][idx].text`
+- If `text === orig` → `delete edits[currentLang][idx]`, remove `.edited`
+  class from the row.
+- Else → `edits[currentLang][idx] = text`, add `.edited` class.
+- `savePreviewState()`, `updateClearBtn()`.
+- **Does not** re-render the list (cursor preservation).
+
+### Enter / resume / seek
+
+- `Enter` (without Shift) inside `.edited` → `blur()` → `resumePlayer()`.
+- `Shift+Enter` → literal newline (multiline edit allowed).
+- Arrow keys seek the video **only when focus is outside** a
+  contenteditable (existing `isTyping` guard).
+- `M` / `m` → in marker mode calls `addMarker`, in edit mode calls
+  `addEdit`. Guard: ignored if focus is in a contenteditable or input.
+- Space → play/pause as today (guard the same way).
+- `F` → fullscreen as today.
+
+### Edit row — delete
+
+`SPA.deleteEdit(idx)`:
+- `delete edits[currentLang][idx]`, remove the `<li>` from DOM.
+- `savePreviewState()`, `updateClearBtn()`.
+
+### Language switch
+
+`srt-lang-select` onchange already updates overlay state. Extend it: if
+`previewState.mode === 'edit'`, re-render the edit list with
+`edits[newLang]`.
+
+### Clear all
+
+`SPA.clearAll()` (context-aware):
+- marker mode → confirm dialog → `markers = []` → save → re-render.
+- edit mode → confirm dialog → `edits[currentLang] = {}` → save → re-render.
+  **Only the current language is cleared.** Edits for other languages are
+  not touched.
+
+### `Create issue` (edit mode)
+
+`SPA.createPreviewIssue()` learns the mode:
+- marker mode → current behavior (unchanged).
+- edit mode → generate an issue body with a Before/After table for each
+  `edits[currentLang][idx]`, showing block timecode, original, edited.
+  Label `review:pending`, same URL-length fallback (clipboard) as the
+  review page.
+
+### `Open in GitHub Editor` (edit mode)
+
+`SPA.openPreviewEditor()`:
+1. `blocks = SPA.srtByLang[currentLang]`
+2. Rebuild an SRT string: for each block, substitute
+   `edits[currentLang][idx]` where present, keep block numbering and
+   original timecodes.
+3. Target path:
+   `talks/<talkId>/<videoSlug>/final/<currentLang>.srt`
+4. Open `https://github.com/<REPO>/edit/main/<path>?value=<encoded>`.
+   This is the same mechanism the review page uses
+   (`SPA.openEditor` at `site/index.html:2690`).
+
+## Tests (TDD)
+
+### Node unit tests — `tests/test_preview_state.js` (new)
+
+- `describe('previewState shape')`
+  - default empty → `{mode:'marker', markers:[], edits:{}}`
+  - JSON round-trip preserves shape
+- `describe('migrateLegacyMarkers')`
+  - legacy only → new object with `markers` copied, legacy removed
+  - new only → legacy untouched, new wins
+  - both → new wins, legacy removed
+  - neither → default
+- `describe('applyEditsToSrt')`
+  - empty edits → original SRT (byte-equal)
+  - one edit replaces one block
+  - edit equal to original → noop
+  - multiline edit preserved in output
+  - block numbering and timecodes unchanged
+
+### Playwright tests — extend `tests/test_preview_spa.py`
+
+Mode / layout:
+1. `test_mode_default_marker`
+2. `test_mode_toggle_updates_buttons_and_list`
+3. `test_mode_persisted_per_video`
+4. `test_mode_per_video_independent`
+5. `test_legacy_marker_migration`
+6. `test_video_switcher_hidden_for_single_video`
+7. `test_video_switcher_visible_for_multi_video`
+
+Marker mode regression:
+8. `test_add_marker_still_works`
+
+Edit mode:
+9. `test_add_edit_creates_item_and_focuses`
+10. `test_add_edit_existing_idx_focuses_not_duplicates`
+11. `test_add_edit_no_active_subtitle_shows_toast`
+12. `test_edit_text_persists_to_storage`
+13. `test_edit_reset_to_original_removes_entry`
+14. `test_edit_enter_resumes_video`
+15. `test_edit_per_language_isolation`
+16. `test_edit_delete_row_removes_from_storage`
+
+Clear / actions:
+17. `test_clear_all_marker_mode`
+18. `test_clear_all_edit_mode_current_lang_only`
+19. `test_clear_btn_hidden_when_empty`
+
+PR / Issue:
+20. `test_openeditor_builds_srt_from_edits`
+21. `test_create_issue_edit_mode_generates_before_after`
+
+Keyboard:
+22. `test_keyboard_m_edit_mode_calls_addEdit`
+23. `test_keyboard_arrows_seek_when_not_in_contenteditable`
+
+Commands:
+```
+node --test tests/test_preview_state.js tests/test_preview_srt_parser.js tests/test_spa_cache.js
+pytest tests/test_preview_spa.py -v
+```
+
+## Delivery
+
+- Branch: `feature/preview-edit-mode` off `main`.
+- TDD-ordered commits: test → impl → test → ...
+- Local dev server: `python3 -m http.server --directory site 8000`.
+- PR after all tests green. PR description includes both mode screenshots
+  and a test checklist.

--- a/site/index.html
+++ b/site/index.html
@@ -631,12 +631,6 @@ function alignSubtitlesByTime(enBlocks, ukBlocks) {
 }
 // ALIGN_END
 
-function findActiveSubtitle(subs, ms) {
-  for (var i = 0; i < subs.length; i++) {
-    if (ms >= subs[i].startMs && ms < subs[i].endMs) return subs[i];
-  }
-  return null;
-}
 function findActiveSubtitleIdx(subs, ms) {
   for (var i = 0; i < subs.length; i++) {
     if (ms >= subs[i].startMs && ms < subs[i].endMs) return i;
@@ -644,9 +638,8 @@ function findActiveSubtitleIdx(subs, ms) {
   return -1;
 }
 
-// Preview state helpers — mirrors tools/preview_state.js so the Node
-// unit tests and the live SPA share the same shape and migration
-// logic. Keep the two in sync when editing.
+// Mirror of tools/preview_state.js — the Node test suite exercises
+// the module; the browser uses this inlined copy.
 function defaultPreviewStateShape() {
   return { mode: 'marker', markers: [], edits: {} };
 }
@@ -1567,31 +1560,38 @@ window.addEventListener('hashchange', function() {
 // --- Subtitle language switching ---
 function loadSubtitleLang(lang) {
   var s = previewState;
-  if (!s) return Promise.resolve();
+  if (!s) return Promise.resolve(false);
   var shaKey = s.videoSlug + '/' + lang;
   var sha = (s.talk && s.talk._srtSha && s.talk._srtSha[shaKey]) || '';
   var url = RAW + '/talks/' + s.talkId + '/' + s.videoSlug + '/final/' + lang + '.srt' + (sha ? '?v=' + sha.substring(0, 8) : '');
-  s.srtLang = lang;
   return fetch(url)
-    .then(function(r) { return r.ok ? r.text() : Promise.reject('SRT fetch failed: HTTP ' + r.status); })
+    .then(function(r) {
+      if (!r.ok) throw new Error('SRT fetch failed: HTTP ' + r.status);
+      return r.text();
+    })
     .then(function(text) {
+      // Only mutate previewState on success so a failed switch leaves
+      // the previous lang/subtitles intact — otherwise the edit list
+      // and overlay would silently mix the new srtLang with stale blocks.
       s.subtitles = parseSRT(text);
+      s.srtLang = lang;
       console.log('[SPA] SRT loaded (' + lang + '):', s.subtitles.length, 'blocks');
+      return true;
     })
     .catch(function(err) {
       console.warn('[SPA] SRT error:', err);
       document.getElementById('subtitle-overlay').textContent = t('error.srt');
+      return false;
     });
 }
 
 SPA.switchSubLang = function(lang) {
-  // Persist the choice synchronously so a fast reload or fetch failure
-  // doesn't drop it. Fetch races have historically lost the save when
-  // write happened inside the .then() callback.
-  if (previewState) localStorage.setItem('sy_srt_lang_' + previewState.talkId, lang);
-  loadSubtitleLang(lang).then(function() {
+  loadSubtitleLang(lang).then(function(ok) {
+    if (!ok) return;
     document.getElementById('subtitle-overlay').textContent = '';
-    // Edit list is lang-scoped — re-render when lang changes.
+    // Persist only on confirmed success so a broken lang doesn't get
+    // stuck as the default on next load.
+    if (previewState) localStorage.setItem('sy_srt_lang_' + previewState.talkId, lang);
     if (previewState && previewState.mode === 'edit') {
       renderEditList();
       updateClearBtn();
@@ -2136,7 +2136,6 @@ function showPreview(talkId, videoSlug) {
   if (embedUrl) iframe.src = embedUrl + '&texttrack=false';
   oldIframe.parentNode.replaceChild(iframe, oldIframe);
 
-  // Determine available subtitle languages (restore saved per-video choice)
   var availLangs = (talk && talk._srtLangs && talk._srtLangs[videoSlug]) || ['uk'];
   var savedSrtLang = localStorage.getItem('sy_srt_lang_' + talkId);
   var defaultLang = (savedSrtLang && availLangs.indexOf(savedSrtLang) !== -1) ? savedSrtLang
@@ -2171,7 +2170,6 @@ function showPreview(talkId, videoSlug) {
     }
   }
 
-  // Render preview video switcher (talks with 2+ videos)
   var videoSel = document.getElementById('preview-video-select');
   if (videoSel) {
     var videos = (talk && talk.videos) || [];
@@ -2206,8 +2204,8 @@ function showPreview(talkId, videoSlug) {
       && previewState.videoSlug === entryVideoSlug;
   }
 
-  var srtLoaded = loadSubtitleLang(defaultLang).then(function() {
-    if (stillOnSameVideo() && previewState.mode === 'edit') renderEditList();
+  var srtLoaded = loadSubtitleLang(defaultLang).then(function(ok) {
+    if (ok && stillOnSameVideo() && previewState.mode === 'edit') renderEditList();
   });
 
   // Cache the two hot-path DOM nodes written from timeupdate so the
@@ -2483,7 +2481,6 @@ SPA.addEdit = function() {
     renderEditList();
     updateClearBtn();
   }
-  // Focus the row for that idx and place cursor at the end.
   var row = document.querySelector('.edit-item[data-idx="' + idx + '"] .edited');
   if (row) {
     row.focus();

--- a/site/index.html
+++ b/site/index.html
@@ -177,6 +177,13 @@ textarea.input { resize: vertical; font-family: monospace; font-size: 13px; }
 .preview-mode-toggle button { background: var(--bg4); color: var(--fg5); border: 0; padding: 6px 12px; font-size: 13px; cursor: pointer; border-radius: 0; }
 .preview-mode-toggle button + button { border-left: 1px solid var(--border3); }
 .preview-mode-toggle button.active { background: var(--primary-bg); color: var(--primary-fg); }
+/* Preview header layout: h1 left, mode toggle centered, actions right.
+   The 1fr/auto/1fr grid keeps the toggle visually centered when there's
+   enough breathing room, and lets each side push in when content grows. */
+.header.preview-header { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; column-gap: 12px; }
+.header.preview-header > h1 { justify-self: start; margin: 0; }
+.header.preview-header > .preview-mode-toggle { justify-self: center; }
+.header.preview-header > .header-actions { justify-self: end; }
 .marker-list, .edit-list { list-style: none; }
 .marker-item { padding: 6px 0; border-bottom: 1px solid var(--border); font-size: 14px; }
 .marker-item .tc { color: var(--link); cursor: pointer; font-family: monospace; }
@@ -262,6 +269,10 @@ textarea.input { resize: vertical; font-family: monospace; font-size: 13px; }
   .header h1 { font-size: 16px; flex: 1 1 100%; }
   .header-actions { flex-wrap: wrap; gap: 6px; width: 100%; }
   .header-actions button { min-height: 44px; padding: 8px 12px; flex: 1 1 auto; font-size: 13px; }
+  /* Preview header collapses to a single-column stack on narrow screens:
+     title, then the centered mode toggle, then the action row. */
+  .header.preview-header { display: flex; flex-direction: column; align-items: stretch; }
+  .header.preview-header > .preview-mode-toggle { align-self: center; }
   .grid { grid-template-columns: 1fr; }
   .col-header.en { display: none; }
   /* Stack EN above its UK partner instead of hiding EN: a translation
@@ -371,14 +382,14 @@ body.sync-player-resizing, body.sync-player-resizing * {
 
 <!-- === PREVIEW VIEW === -->
 <div id="view-preview" class="view">
-  <div class="header">
+  <div class="header preview-header">
     <h1><a href="#/" data-i18n="nav.back">&larr; Index</a> &middot; <span id="p-title"></span>
       <select id="preview-video-select" class="select-chip" style="display:none;margin-left:8px;vertical-align:middle" onchange="SPA.switchPreviewVideo(this.value)"></select>
     </h1>
+    <div class="preview-mode-toggle" role="group">
+      <button type="button" data-mode="marker" class="chip active" onclick="SPA.setPreviewMode('marker')" data-i18n="preview.mode_marker">&#x1F4CC; Marker</button><button type="button" data-mode="edit" class="chip" onclick="SPA.setPreviewMode('edit')" data-i18n="preview.mode_edit">&#x270E; Edit</button>
+    </div>
     <div class="header-actions">
-      <div class="preview-mode-toggle" role="group">
-        <button type="button" data-mode="marker" class="chip active" onclick="SPA.setPreviewMode('marker')" data-i18n="preview.mode_marker">&#x1F4CC; Marker</button><button type="button" data-mode="edit" class="chip" onclick="SPA.setPreviewMode('edit')" data-i18n="preview.mode_edit">&#x270E; Edit</button>
-      </div>
       <button id="btn-copy-all" onclick="SPA.copyMarkers()" data-i18n="btn.copy_all">Copy all</button>
       <button id="btn-preview-issue" class="issue" onclick="SPA.createPreviewIssue()" data-i18n="btn.create_issue">Create issue</button>
       <button id="btn-preview-editor" class="primary" style="display:none" onclick="SPA.openPreviewEditor()" data-i18n="btn.open_editor">Open in GitHub Editor</button>
@@ -1560,7 +1571,7 @@ SPA.switchSubLang = function(lang) {
   loadSubtitleLang(lang).then(function() {
     document.getElementById('subtitle-overlay').textContent = '';
     // Save per-video language choice
-    if (previewState) localStorage.setItem('sy_srt_lang_' + previewState.talkId + '_' + previewState.videoSlug, lang);
+    if (previewState) localStorage.setItem('sy_srt_lang_' + previewState.talkId, lang);
     // Edit list is lang-scoped — re-render when lang changes.
     if (previewState && previewState.mode === 'edit') {
       renderEditList();
@@ -1849,7 +1860,12 @@ function showIndex() {
 }
 
 var expertMode = localStorage.getItem('sy_expert_mode') === '1';
-var activeFilter = expertMode ? 'pending' : 'needs-review';
+function filterKey(isExpert) { return isExpert ? 'sy_filter_expert' : 'sy_filter_normal'; }
+function loadSavedFilter(isExpert) {
+  var saved = localStorage.getItem(filterKey(isExpert));
+  return saved || (isExpert ? 'pending' : 'needs-review');
+}
+var activeFilter = loadSavedFilter(expertMode);
 var expandedTalkId = null;
 
 function renderIndex(el) {
@@ -1952,6 +1968,7 @@ function renderIndex(el) {
 
 SPA.filterTalks = function(filter) {
   activeFilter = (activeFilter === filter && filter !== 'all') ? 'all' : filter;
+  localStorage.setItem(filterKey(expertMode), activeFilter);
   document.querySelectorAll('.stat-card').forEach(function(c) {
     c.classList.toggle('active', c.dataset.filter === activeFilter);
   });
@@ -2090,7 +2107,7 @@ function showPreview(talkId, videoSlug) {
 
   // Determine available subtitle languages (restore saved per-video choice)
   var availLangs = (talk && talk._srtLangs && talk._srtLangs[videoSlug]) || ['uk'];
-  var savedSrtLang = localStorage.getItem('sy_srt_lang_' + talkId + '_' + videoSlug);
+  var savedSrtLang = localStorage.getItem('sy_srt_lang_' + talkId);
   var defaultLang = (savedSrtLang && availLangs.indexOf(savedSrtLang) !== -1) ? savedSrtLang
     : availLangs.indexOf('uk') !== -1 ? 'uk' : availLangs[0];
 
@@ -2147,8 +2164,11 @@ function showPreview(talkId, videoSlug) {
   renderEditList();
   updateClearBtn();
 
-  // Load SRT
-  var srtLoaded = loadSubtitleLang(defaultLang);
+  // Load SRT — once it arrives, re-render the edit list so rows that
+  // depend on parsed blocks (original text, timecodes) actually show.
+  var srtLoaded = loadSubtitleLang(defaultLang).then(function() {
+    if (previewState && previewState.mode === 'edit') renderEditList();
+  });
 
   // Setup player events — wait for both player ready and SRT
   if (embedUrl) {
@@ -3643,7 +3663,7 @@ updateFooter();
 SPA.toggleExpert = function() {
   expertMode = !expertMode;
   localStorage.setItem('sy_expert_mode', expertMode ? '1' : '0');
-  activeFilter = expertMode ? 'pending' : 'needs-review';
+  activeFilter = loadSavedFilter(expertMode);
   applyExpertMode();
   if (manifest) { renderStats(); renderIndex(document.getElementById('index-content')); }
 };

--- a/site/index.html
+++ b/site/index.html
@@ -170,14 +170,14 @@ textarea.input { resize: vertical; font-family: monospace; font-size: 13px; }
   padding: 8px 16px; font-size: 14px; cursor: pointer; touch-action: manipulation; }
 .controls button:active { background: var(--border3); }
 #time-display { color: var(--fg6); font-size: 13px; font-family: monospace; }
-.markers { max-width: 960px; margin: 0 auto; padding: 0 8px; }
-.markers summary { color: var(--fg5); cursor: pointer; padding: 8px; font-size: 14px; }
-.marker-actions { display: flex; gap: 8px; padding: 8px 0; }
-.marker-actions button { background: var(--primary-bg); color: var(--primary-fg); border: 1px solid var(--primary-border); border-radius: 6px;
-  padding: 6px 14px; font-size: 13px; cursor: pointer; }
-.marker-actions button.issue { background: var(--issue-bg); color: var(--issue-fg); border-color: var(--issue-border); }
-.marker-actions button.danger { background: var(--danger-bg); color: var(--danger-fg); border-color: var(--danger-border); }
-.marker-list { list-style: none; }
+.markers, .preview-list { max-width: 960px; margin: 0 auto; padding: 0 8px; }
+.markers summary, .preview-list summary { color: var(--fg5); cursor: pointer; padding: 8px; font-size: 14px; }
+#btn-clear-all { background: var(--danger-bg); color: var(--danger-fg); border-color: var(--danger-border); }
+.preview-mode-toggle { display: inline-flex; border: 1px solid var(--border3); border-radius: 6px; overflow: hidden; }
+.preview-mode-toggle button { background: var(--bg4); color: var(--fg5); border: 0; padding: 6px 12px; font-size: 13px; cursor: pointer; border-radius: 0; }
+.preview-mode-toggle button + button { border-left: 1px solid var(--border3); }
+.preview-mode-toggle button.active { background: var(--primary-bg); color: var(--primary-fg); }
+.marker-list, .edit-list { list-style: none; }
 .marker-item { padding: 6px 0; border-bottom: 1px solid var(--border); font-size: 14px; }
 .marker-item .tc { color: var(--link); cursor: pointer; font-family: monospace; }
 .marker-item .tc:hover { text-decoration: underline; }
@@ -187,6 +187,17 @@ textarea.input { resize: vertical; font-family: monospace; font-size: 13px; }
 .marker-item .comment { width: 100%; background: var(--bg5); color: var(--fg2); border: 1px solid var(--border2);
   border-radius: 4px; padding: 4px 8px; font-size: 13px; margin-top: 4px; }
 .marker-item .comment:focus { border-color: var(--link); outline: none; }
+.edit-item { padding: 8px 0; border-bottom: 1px solid var(--border); font-size: 14px;
+  display: grid; grid-template-columns: auto 1fr auto; gap: 4px 10px; align-items: start; }
+.edit-item .tc { color: var(--link); cursor: pointer; font-family: monospace; grid-row: 1 / span 2; align-self: center; }
+.edit-item .tc:hover { text-decoration: underline; }
+.edit-item .orig { color: var(--fg6); font-size: 12px; font-style: italic; }
+.edit-item .edited { color: var(--fg2); background: var(--bg5); border: 1px solid var(--border2);
+  border-radius: 4px; padding: 4px 8px; min-height: 1.4em; outline: none; white-space: pre-wrap; }
+.edit-item .edited:focus { border-color: var(--link); }
+.edit-item .edited.edited-dirty { border-color: var(--primary-border); background: var(--primary-bg); color: var(--primary-fg); }
+.edit-item .del { color: var(--fg6); cursor: pointer; padding: 0 4px; grid-row: 1 / span 2; align-self: center; }
+.edit-item .del:hover { color: var(--accent-red); }
 
 /* --- Review --- */
 .grid { display: grid; grid-template-columns: 1fr 1fr; max-width: 1400px; margin: 0 auto; }
@@ -320,7 +331,8 @@ body.sync-player-resizing, body.sync-player-resizing * {
 /* --- Fullscreen preview mode --- */
 #view-preview.fs-mode { position: fixed; inset: 0; z-index: 9999; background: #000; display: flex; flex-direction: column; overflow: hidden; }
 #view-preview.fs-mode .header { display: none !important; }
-#view-preview.fs-mode .markers { display: none !important; }
+#view-preview.fs-mode .markers,
+#view-preview.fs-mode .preview-list { display: none !important; }
 #view-preview.fs-mode #btn-mark { display: none !important; }
 #view-preview.fs-mode .player-container { flex: 1; max-width: 100%; margin: 0; width: 100%; display: flex; flex-direction: column; overflow: hidden; }
 #view-preview.fs-mode .video-wrap { flex: 1; padding-bottom: 0; height: 100%; }
@@ -360,7 +372,18 @@ body.sync-player-resizing, body.sync-player-resizing * {
 <!-- === PREVIEW VIEW === -->
 <div id="view-preview" class="view">
   <div class="header">
-    <h1><a href="#/" data-i18n="nav.back">&larr; Index</a> &middot; <span id="p-title"></span></h1>
+    <h1><a href="#/" data-i18n="nav.back">&larr; Index</a> &middot; <span id="p-title"></span>
+      <select id="preview-video-select" class="select-chip" style="display:none;margin-left:8px;vertical-align:middle" onchange="SPA.switchPreviewVideo(this.value)"></select>
+    </h1>
+    <div class="header-actions">
+      <div class="preview-mode-toggle" role="group">
+        <button type="button" data-mode="marker" class="chip active" onclick="SPA.setPreviewMode('marker')" data-i18n="preview.mode_marker">&#x1F4CC; Marker</button><button type="button" data-mode="edit" class="chip" onclick="SPA.setPreviewMode('edit')" data-i18n="preview.mode_edit">&#x270E; Edit</button>
+      </div>
+      <button id="btn-copy-all" onclick="SPA.copyMarkers()" data-i18n="btn.copy_all">Copy all</button>
+      <button id="btn-preview-issue" class="issue" onclick="SPA.createPreviewIssue()" data-i18n="btn.create_issue">Create issue</button>
+      <button id="btn-preview-editor" class="primary" style="display:none" onclick="SPA.openPreviewEditor()" data-i18n="btn.open_editor">Open in GitHub Editor</button>
+      <button id="btn-clear-all" class="danger" style="display:none" onclick="SPA.clearAll()" data-i18n="btn.clear_all">Clear all</button>
+    </div>
   </div>
   <div class="player-container">
     <div class="video-wrap"><iframe id="vimeo-player" allow="autoplay; fullscreen" allowfullscreen></iframe></div>
@@ -368,19 +391,15 @@ body.sync-player-resizing, body.sync-player-resizing * {
     <div class="controls">
       <span id="time-display">00:00:00</span>
       <select id="srt-lang-select" class="select-chip" style="display:none" data-i18n-title="title.srt_lang"></select>
-      <button id="btn-mark" onclick="SPA.addMarker()" data-i18n-title="btn.mark_title" data-i18n="btn.mark">&#x1F4CC; Mark</button>
+      <button id="btn-mark" onclick="SPA.addMarkOrEdit()" data-i18n-title="btn.mark_title" data-i18n="btn.mark">&#x1F4CC; Mark</button>
       <button id="btn-fullscreen" onclick="SPA.toggleFullscreen()" title="F = fullscreen" style="padding:4px 10px;font-size:16px;">&#x2922;</button>
     </div>
   </div>
-  <div class="markers">
+  <div class="preview-list">
     <details open>
-      <summary><span data-i18n="markers.summary">Markers</span> (<span id="marker-count">0</span>)</summary>
-      <div class="marker-actions">
-        <button onclick="SPA.copyMarkers()" data-i18n="btn.copy_all">Copy all</button>
-        <button class="issue" onclick="SPA.createPreviewIssue()" data-i18n="btn.create_issue">Create issue</button>
-        <button class="danger" onclick="SPA.clearMarkers()" data-i18n="btn.clear_all">Clear all</button>
-      </div>
+      <summary><span id="preview-list-label" data-i18n="markers.summary">Markers</span> (<span id="marker-count">0</span>)</summary>
       <ul class="marker-list" id="marker-list"></ul>
+      <ul class="edit-list" id="edit-list" style="display:none"></ul>
     </details>
   </div>
 </div>
@@ -608,6 +627,76 @@ function findActiveSubtitle(subs, ms) {
   }
   return null;
 }
+function findActiveSubtitleIdx(subs, ms) {
+  for (var i = 0; i < subs.length; i++) {
+    if (ms >= subs[i].startMs && ms < subs[i].endMs) return i;
+  }
+  return -1;
+}
+
+// Preview state helpers — mirrors tools/preview_state.js so the Node
+// unit tests and the live SPA share the same shape and migration
+// logic. Keep the two in sync when editing.
+function defaultPreviewStateShape() {
+  return { mode: 'marker', markers: [], edits: {} };
+}
+function coercePreviewStateShape(raw) {
+  var out = defaultPreviewStateShape();
+  if (!raw || typeof raw !== 'object') return out;
+  if (raw.mode === 'edit' || raw.mode === 'marker') out.mode = raw.mode;
+  if (Array.isArray(raw.markers)) out.markers = raw.markers;
+  if (raw.edits && typeof raw.edits === 'object' && !Array.isArray(raw.edits)) {
+    out.edits = raw.edits;
+  }
+  return out;
+}
+function loadPreviewStateFromStorage(talkId, videoSlug) {
+  var newKey = 'preview_' + talkId + '_' + videoSlug;
+  var legacyKey = 'markers_preview_' + talkId + '_' + videoSlug;
+  var rawNew = localStorage.getItem(newKey);
+  if (rawNew != null) {
+    var parsed = null;
+    try { parsed = JSON.parse(rawNew); } catch(_) {}
+    if (localStorage.getItem(legacyKey) != null) localStorage.removeItem(legacyKey);
+    return coercePreviewStateShape(parsed);
+  }
+  var rawLegacy = localStorage.getItem(legacyKey);
+  if (rawLegacy != null) {
+    var legacyMarkers = [];
+    try {
+      var p = JSON.parse(rawLegacy);
+      if (Array.isArray(p)) legacyMarkers = p;
+    } catch(_) {}
+    var migrated = defaultPreviewStateShape();
+    migrated.markers = legacyMarkers;
+    localStorage.setItem(newKey, JSON.stringify(migrated));
+    localStorage.removeItem(legacyKey);
+    return migrated;
+  }
+  return defaultPreviewStateShape();
+}
+function msToSrtTime(ms) {
+  var h = Math.floor(ms / 3600000);
+  var m = Math.floor((ms % 3600000) / 60000);
+  var s = Math.floor((ms % 60000) / 1000);
+  var mmm = ms % 1000;
+  return String(h).padStart(2, '0') + ':' + String(m).padStart(2, '0') + ':' +
+    String(s).padStart(2, '0') + ',' + String(mmm).padStart(3, '0');
+}
+function applyEditsToSrt(blocks, edits) {
+  if (!blocks || !blocks.length) return '';
+  var e = edits || {};
+  var lines = [];
+  for (var i = 0; i < blocks.length; i++) {
+    var b = blocks[i];
+    var text = Object.prototype.hasOwnProperty.call(e, i) ? e[i] : b.text;
+    lines.push(String(i + 1));
+    lines.push(msToSrtTime(b.startMs) + ' --> ' + msToSrtTime(b.endMs));
+    lines.push(text);
+    lines.push('');
+  }
+  return lines.join('\n');
+}
 
 // ============================================================
 // Config
@@ -657,6 +746,15 @@ var I18N = {
     'index.loading': '\u0417\u0430\u0432\u0430\u043D\u0442\u0430\u0436\u0435\u043D\u043D\u044F...',
     'nav.back': '\u2190 \u0413\u043E\u043B\u043E\u0432\u043D\u0430',
     'btn.mark': '\u{1F4CC} \u041C\u0430\u0440\u043A\u0435\u0440',
+    'btn.edit': '\u270E \u0420\u0435\u0434\u0430\u0433\u0443\u0432\u0430\u0442\u0438',
+    'btn.edit_title': 'M = \u0440\u0435\u0434\u0430\u0433\u0443\u0432\u0430\u0442\u0438 \u0431\u043B\u043E\u043A, Enter = \u0437\u0431\u0435\u0440\u0435\u0433\u0442\u0438, Space = \u043F\u043B\u0435\u0439/\u043F\u0430\u0443\u0437\u0430, \u2190\u2192 = 5\u0441',
+    'preview.mode_marker': '\u{1F4CC} \u041C\u0430\u0440\u043A\u0435\u0440\u0438',
+    'preview.mode_edit': '\u270E \u0420\u0435\u0434\u0430\u0433\u0443\u0432\u0430\u043D\u043D\u044F',
+    'edits.summary': '\u0420\u0435\u0434\u0430\u0433\u0443\u0432\u0430\u043D\u043D\u044F',
+    'toast.edits_cleared': '\u0420\u0435\u0434\u0430\u0433\u0443\u0432\u0430\u043D\u043D\u044F \u043E\u0447\u0438\u0449\u0435\u043D\u043E',
+    'toast.no_active_subtitle': '\u041D\u0435\u043C\u0430\u0454 \u0430\u043A\u0442\u0438\u0432\u043D\u043E\u0433\u043E \u0441\u0443\u0431\u0442\u0438\u0442\u0440\u0443',
+    'confirm.clear_edits': '\u041E\u0447\u0438\u0441\u0442\u0438\u0442\u0438 \u0432\u0441\u0456 {n} \u0440\u0435\u0434\u0430\u0433\u0443\u0432\u0430\u043D\u044C ({lang})?',
+    'link.preview': '\u25B6 \u041F\u0435\u0440\u0435\u0433\u043B\u044F\u043D\u0443\u0442\u0438 \u043F\u0435\u0440\u0435\u043A\u043B\u0430\u0434',
     'markers.summary': '\u041C\u0430\u0440\u043A\u0435\u0440\u0438',
     'btn.copy_all': '\u041A\u043E\u043F\u0456\u044E\u0432\u0430\u0442\u0438 \u0432\u0441\u0435',
     'btn.create_issue': '\u0421\u0442\u0432\u043E\u0440\u0438\u0442\u0438 issue',
@@ -748,6 +846,15 @@ var I18N = {
     'index.loading': 'Loading...',
     'nav.back': '\u2190 Home',
     'btn.mark': '\u{1F4CC} Mark',
+    'btn.edit': '\u270E Edit',
+    'btn.edit_title': 'M = edit block, Enter = save, Space = play/pause, \u2190\u2192 = seek 5s',
+    'preview.mode_marker': '\u{1F4CC} Markers',
+    'preview.mode_edit': '\u270E Edit',
+    'edits.summary': 'Edits',
+    'toast.edits_cleared': 'Edits cleared',
+    'toast.no_active_subtitle': 'No active subtitle at this time',
+    'confirm.clear_edits': 'Clear all {n} edits ({lang})?',
+    'link.preview': '\u25B6 View translation',
     'markers.summary': 'Markers',
     'btn.copy_all': 'Copy all',
     'btn.create_issue': 'Create issue',
@@ -1454,6 +1561,11 @@ SPA.switchSubLang = function(lang) {
     document.getElementById('subtitle-overlay').textContent = '';
     // Save per-video language choice
     if (previewState) localStorage.setItem('sy_srt_lang_' + previewState.talkId + '_' + previewState.videoSlug, lang);
+    // Edit list is lang-scoped — re-render when lang changes.
+    if (previewState && previewState.mode === 'edit') {
+      renderEditList();
+      updateClearBtn();
+    }
   });
 };
 
@@ -1777,12 +1889,11 @@ function renderIndex(el) {
       var href = st.issue_number ? 'https://github.com/' + REPO + '/issues/' + st.issue_number : '#';
       badge = '<a href="' + href + '" target="_blank" class="review-badge ' + bc + '">' + bt + '</a>';
     }
+    var firstVideo = (tk.videos || []).find(function(v) { return v.hasSrt && v.vimeo_url; });
     var videoLinks = '';
-    (tk.videos || []).forEach(function(v) {
-      if (v.hasSrt && v.vimeo_url) {
-        videoLinks += '<a href="#/preview/' + tk.id + '/' + v.slug + '" class="preview-link">&#x25B6; ' + esc(v.title) + '</a>';
-      }
-    });
+    if (firstVideo) {
+      videoLinks = '<a href="#/preview/' + tk.id + '/' + firstVideo.slug + '" class="preview-link">' + esc(t('link.preview')) + '</a>';
+    }
     var reviewLink = '';
     if (tk.hasEn && tk.hasUk) {
       reviewLink = '<a href="#/review/' + tk.id + '" class="review-link">&#x270E; ' + t('link.review') + '</a>';
@@ -1983,7 +2094,20 @@ function showPreview(talkId, videoSlug) {
   var defaultLang = (savedSrtLang && availLangs.indexOf(savedSrtLang) !== -1) ? savedSrtLang
     : availLangs.indexOf('uk') !== -1 ? 'uk' : availLangs[0];
 
-  previewState = { talkId: talkId, videoSlug: videoSlug, talk: talk, video: video, subtitles: [], markers: [], currentTime: 0, lastText: '', srtLang: defaultLang };
+  var persisted = loadPreviewStateFromStorage(talkId, videoSlug);
+  previewState = {
+    talkId: talkId,
+    videoSlug: videoSlug,
+    talk: talk,
+    video: video,
+    subtitles: [],
+    mode: persisted.mode,
+    markers: persisted.markers,
+    edits: persisted.edits,
+    currentTime: 0,
+    lastText: '',
+    srtLang: defaultLang,
+  };
 
   // Render subtitle language selector
   var langSel = document.getElementById('srt-lang-select');
@@ -1999,10 +2123,29 @@ function showPreview(talkId, videoSlug) {
     }
   }
 
-  // Load markers from localStorage
-  var mkey = 'markers_preview_' + talkId + '_' + videoSlug;
-  try { previewState.markers = JSON.parse(localStorage.getItem(mkey) || '[]'); } catch(e) {}
+  // Render preview video switcher (talks with 2+ videos)
+  var videoSel = document.getElementById('preview-video-select');
+  if (videoSel) {
+    var videos = (talk && talk.videos) || [];
+    while (videoSel.firstChild) videoSel.removeChild(videoSel.firstChild);
+    if (videos.length > 1) {
+      videos.forEach(function(v) {
+        var opt = document.createElement('option');
+        opt.value = v.slug;
+        opt.textContent = v.title || v.slug;
+        if (v.slug === videoSlug) opt.selected = true;
+        videoSel.appendChild(opt);
+      });
+      videoSel.style.display = 'inline-block';
+    } else {
+      videoSel.style.display = 'none';
+    }
+  }
+
+  applyPreviewMode();
   renderMarkers();
+  renderEditList();
+  updateClearBtn();
 
   // Load SRT
   var srtLoaded = loadSubtitleLang(defaultLang);
@@ -2043,20 +2186,93 @@ function vimeoEmbed(url) {
   return m ? 'https://player.vimeo.com/video/' + m[1] + '?h=' + m[2] : url;
 }
 
+// --- Preview state persistence ---
+function savePreviewState() {
+  if (!previewState || !previewState.talkId) return;
+  var key = 'preview_' + previewState.talkId + '_' + previewState.videoSlug;
+  var payload = {
+    mode: previewState.mode || 'marker',
+    markers: previewState.markers || [],
+    edits: previewState.edits || {},
+  };
+  localStorage.setItem(key, JSON.stringify(payload));
+}
+
+// --- Mode switching ---
+function applyPreviewMode() {
+  var mode = previewState.mode || 'marker';
+  // Segmented control active state
+  document.querySelectorAll('.preview-mode-toggle button').forEach(function(b) {
+    if (b.dataset.mode === mode) b.classList.add('active');
+    else b.classList.remove('active');
+  });
+  // Mark/Edit button label + title
+  var markBtn = document.getElementById('btn-mark');
+  if (markBtn) {
+    markBtn.textContent = mode === 'edit' ? t('btn.edit') : t('btn.mark');
+    markBtn.title = mode === 'edit' ? t('btn.edit_title') : t('btn.mark_title');
+  }
+  // Header action buttons: copy visible only in marker mode,
+  // editor visible only in edit mode.
+  var copyBtn = document.getElementById('btn-copy-all');
+  if (copyBtn) copyBtn.style.display = mode === 'marker' ? 'inline-block' : 'none';
+  var editorBtn = document.getElementById('btn-preview-editor');
+  if (editorBtn) editorBtn.style.display = mode === 'edit' ? 'inline-block' : 'none';
+  // List summary label + list visibility
+  var label = document.getElementById('preview-list-label');
+  if (label) label.textContent = mode === 'edit' ? t('edits.summary') : t('markers.summary');
+  var markerList = document.getElementById('marker-list');
+  var editList = document.getElementById('edit-list');
+  if (markerList) markerList.style.display = mode === 'marker' ? '' : 'none';
+  if (editList) editList.style.display = mode === 'edit' ? '' : 'none';
+}
+
+SPA.setPreviewMode = function(mode) {
+  if (mode !== 'marker' && mode !== 'edit') return;
+  if (previewState.mode === mode) return;
+  previewState.mode = mode;
+  savePreviewState();
+  applyPreviewMode();
+  renderMarkers();
+  renderEditList();
+  updateClearBtn();
+};
+
+SPA.switchPreviewVideo = function(newSlug) {
+  if (!previewState || !previewState.talkId || !newSlug) return;
+  if (newSlug === previewState.videoSlug) return;
+  location.hash = '#/preview/' + previewState.talkId + '/' + newSlug;
+};
+
+// --- Dispatch for the Mark/Edit button under the player ---
+SPA.addMarkOrEdit = function() {
+  if (previewState.mode === 'edit') SPA.addEdit();
+  else SPA.addMarker();
+};
+
 // --- Markers ---
 SPA.addMarker = function() {
-  var t = previewState.currentTime;
+  var tSec = previewState.currentTime;
   var text = previewState.lastText || '(no subtitle)';
-  previewState.markers.push({ time: t, tc: fmtTime(t), text: text, comment: '' });
+  previewState.markers.push({ time: tSec, tc: fmtTime(tSec), text: text, comment: '' });
   if (previewState.player) previewState.player.pause();
-  saveMarkers();
+  savePreviewState();
   renderMarkers();
+  updateClearBtn();
   var inputs = document.querySelectorAll('.marker-item .comment');
   if (inputs.length) inputs[inputs.length - 1].focus();
 };
 
-SPA.removeMarker = function(i) { previewState.markers.splice(i, 1); saveMarkers(); renderMarkers(); };
-SPA.updateMarkerComment = function(i, val) { previewState.markers[i].comment = val; saveMarkers(); };
+SPA.removeMarker = function(i) {
+  previewState.markers.splice(i, 1);
+  savePreviewState();
+  renderMarkers();
+  updateClearBtn();
+};
+SPA.updateMarkerComment = function(i, val) {
+  previewState.markers[i].comment = val;
+  savePreviewState();
+};
 SPA.seekTo = function(sec) { if (previewState.player) previewState.player.setCurrentTime(sec); };
 SPA.seek = function(delta) {
   if (!previewState.player) return;
@@ -2093,63 +2309,241 @@ document.addEventListener('fullscreenchange', function() {
   }
 });
 
-function saveMarkers() {
-  var key = 'markers_preview_' + previewState.talkId + '_' + previewState.videoSlug;
-  localStorage.setItem(key, JSON.stringify(previewState.markers));
-}
-
 function renderMarkers() {
   var list = document.getElementById('marker-list');
   var count = document.getElementById('marker-count');
-  count.textContent = previewState.markers.length;
-  list.innerHTML = '';
+  if (previewState.mode === 'marker') count.textContent = previewState.markers.length;
+  if (!list) return;
+  while (list.firstChild) list.removeChild(list.firstChild);
   previewState.markers.forEach(function(m, i) {
     var li = document.createElement('li');
     li.className = 'marker-item';
-    var c = (m.comment || '').replace(/"/g, '&quot;').replace(/</g, '&lt;');
-    li.innerHTML = '<div style="display:flex;align-items:center;gap:8px;width:100%">' +
-      '<span class="tc" onclick="SPA.seekTo(' + m.time + ')">' + m.tc + '</span>' +
-      '<span class="text">' + esc(m.text) + '</span></div>' +
-      '<div style="display:flex;align-items:center;gap:4px">' +
-      '<input class="comment" type="text" placeholder="comment..." value="' + c + '" ' +
-      'onchange="SPA.updateMarkerComment(' + i + ', this.value)" ' +
-      'onkeydown="if(event.key==\'Enter\'){this.blur();SPA.resumePlayer();}">' +
-      '<span class="del" onclick="SPA.removeMarker(' + i + ')">&#x2715;</span></div>';
+    var rowTop = document.createElement('div');
+    rowTop.style.cssText = 'display:flex;align-items:center;gap:8px;width:100%';
+    var tcSpan = document.createElement('span');
+    tcSpan.className = 'tc';
+    tcSpan.textContent = m.tc;
+    tcSpan.addEventListener('click', function() { SPA.seekTo(m.time); });
+    var textSpan = document.createElement('span');
+    textSpan.className = 'text';
+    textSpan.textContent = m.text;
+    rowTop.appendChild(tcSpan);
+    rowTop.appendChild(textSpan);
+    var rowBottom = document.createElement('div');
+    rowBottom.style.cssText = 'display:flex;align-items:center;gap:4px';
+    var input = document.createElement('input');
+    input.className = 'comment';
+    input.type = 'text';
+    input.placeholder = 'comment...';
+    input.value = m.comment || '';
+    input.addEventListener('change', function() { SPA.updateMarkerComment(i, input.value); });
+    input.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter') { input.blur(); SPA.resumePlayer(); }
+    });
+    var del = document.createElement('span');
+    del.className = 'del';
+    del.textContent = '\u2715';
+    del.addEventListener('click', function() { SPA.removeMarker(i); });
+    rowBottom.appendChild(input);
+    rowBottom.appendChild(del);
+    li.appendChild(rowTop);
+    li.appendChild(rowBottom);
     list.appendChild(li);
   });
 }
 
-SPA.clearMarkers = function() {
-  if (!previewState.markers.length) return;
-  if (!confirm(t('confirm.clear_markers').replace('{n}', previewState.markers.length))) return;
-  previewState.markers = [];
-  saveMarkers();
-  renderMarkers();
-  showToast(t('toast.markers_cleared'));
+// --- Edit list rendering ---
+function renderEditList() {
+  var list = document.getElementById('edit-list');
+  var count = document.getElementById('marker-count');
+  if (!list) return;
+  var lang = previewState.srtLang || 'uk';
+  var langEdits = (previewState.edits && previewState.edits[lang]) || {};
+  var idxs = Object.keys(langEdits).map(Number).sort(function(a, b) { return a - b; });
+  if (previewState.mode === 'edit') count.textContent = idxs.length;
+  while (list.firstChild) list.removeChild(list.firstChild);
+  var blocks = previewState.subtitles || [];
+  idxs.forEach(function(idx) {
+    var block = blocks[idx];
+    if (!block) return;
+    var li = document.createElement('li');
+    li.className = 'edit-item';
+    li.dataset.idx = String(idx);
+    var tc = document.createElement('span');
+    tc.className = 'tc';
+    tc.textContent = msToSrtTime(block.startMs).slice(0, 8);
+    tc.addEventListener('click', function() { SPA.seekTo(block.startMs / 1000); });
+    var orig = document.createElement('div');
+    orig.className = 'orig';
+    orig.textContent = block.text;
+    var edited = document.createElement('div');
+    edited.className = 'edited';
+    edited.setAttribute('contenteditable', 'true');
+    edited.dataset.idx = String(idx);
+    edited.textContent = langEdits[idx];
+    if (langEdits[idx] !== block.text) edited.classList.add('edited-dirty');
+    edited.addEventListener('input', function() { SPA.onEditInput(idx, edited); });
+    edited.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        edited.blur();
+        SPA.resumePlayer();
+      }
+    });
+    var del = document.createElement('span');
+    del.className = 'del';
+    del.textContent = '\u2715';
+    del.addEventListener('click', function() { SPA.deleteEdit(idx); });
+    li.appendChild(tc);
+    li.appendChild(orig);
+    li.appendChild(edited);
+    li.appendChild(del);
+    list.appendChild(li);
+  });
+}
+
+SPA.addEdit = function() {
+  var blocks = previewState.subtitles || [];
+  if (!blocks.length) { showToast(t('error.srt')); return; }
+  var ms = Math.round((previewState.currentTime || 0) * 1000);
+  var idx = findActiveSubtitleIdx(blocks, ms);
+  if (idx === -1) { showToast(t('toast.no_active_subtitle')); return; }
+  var lang = previewState.srtLang || 'uk';
+  if (!previewState.edits) previewState.edits = {};
+  if (!previewState.edits[lang]) previewState.edits[lang] = {};
+  if (previewState.player) previewState.player.pause();
+  if (previewState.edits[lang][idx] === undefined) {
+    previewState.edits[lang][idx] = blocks[idx].text;
+    savePreviewState();
+    renderEditList();
+    updateClearBtn();
+  }
+  // Focus the row for that idx and place cursor at the end.
+  var row = document.querySelector('.edit-item[data-idx="' + idx + '"] .edited');
+  if (row) {
+    row.focus();
+    try {
+      var sel = window.getSelection();
+      var range = document.createRange();
+      range.selectNodeContents(row);
+      range.collapse(false);
+      sel.removeAllRanges();
+      sel.addRange(range);
+    } catch (_) {}
+  }
 };
+
+SPA.onEditInput = function(idx, el) {
+  var lang = previewState.srtLang || 'uk';
+  if (!previewState.edits[lang]) previewState.edits[lang] = {};
+  var blocks = previewState.subtitles || [];
+  var orig = blocks[idx] ? blocks[idx].text : '';
+  var text = el.innerText;
+  if (text === orig) {
+    delete previewState.edits[lang][idx];
+    el.classList.remove('edited-dirty');
+  } else {
+    previewState.edits[lang][idx] = text;
+    el.classList.add('edited-dirty');
+  }
+  savePreviewState();
+  updateClearBtn();
+};
+
+SPA.deleteEdit = function(idx) {
+  var lang = previewState.srtLang || 'uk';
+  if (previewState.edits && previewState.edits[lang]) {
+    delete previewState.edits[lang][idx];
+    savePreviewState();
+    renderEditList();
+    updateClearBtn();
+  }
+};
+
+function updateClearBtn() {
+  var btn = document.getElementById('btn-clear-all');
+  if (!btn) return;
+  var show = false;
+  if (previewState.mode === 'edit') {
+    var lang = previewState.srtLang || 'uk';
+    var langEdits = (previewState.edits && previewState.edits[lang]) || {};
+    show = Object.keys(langEdits).length > 0;
+  } else {
+    show = (previewState.markers || []).length > 0;
+  }
+  btn.style.display = show ? 'inline-block' : 'none';
+}
+
+SPA.clearAll = function() {
+  if (previewState.mode === 'edit') {
+    var lang = previewState.srtLang || 'uk';
+    var langEdits = (previewState.edits && previewState.edits[lang]) || {};
+    var n = Object.keys(langEdits).length;
+    if (!n) return;
+    if (!confirm(t('confirm.clear_edits').replace('{n}', n).replace('{lang}', lang.toUpperCase()))) return;
+    previewState.edits[lang] = {};
+    savePreviewState();
+    renderEditList();
+    updateClearBtn();
+    showToast(t('toast.edits_cleared'));
+  } else {
+    if (!previewState.markers.length) return;
+    if (!confirm(t('confirm.clear_markers').replace('{n}', previewState.markers.length))) return;
+    previewState.markers = [];
+    savePreviewState();
+    renderMarkers();
+    updateClearBtn();
+    showToast(t('toast.markers_cleared'));
+  }
+};
+
+// Backwards-compat alias — some tests and keybindings still call clearMarkers.
+SPA.clearMarkers = function() { SPA.clearAll(); };
 
 SPA.copyMarkers = function() {
   var lines = ['# ' + document.title, ''];
   previewState.markers.forEach(function(m) {
     var line = '- **' + m.tc + '** ' + m.text;
-    if (m.comment) line += ' — _' + m.comment + '_';
+    if (m.comment) line += ' \u2014 _' + m.comment + '_';
     lines.push(line);
   });
-  navigator.clipboard.writeText(lines.join('\n')).then(function() { showToast(t('toast.copied_markers').replace('{n}', previewState.markers.length)); });
+  navigator.clipboard.writeText(lines.join('\n')).then(function() {
+    showToast(t('toast.copied_markers').replace('{n}', previewState.markers.length));
+  });
 };
 
 SPA.createPreviewIssue = function() {
   var s = previewState;
   var gh = 'https://github.com/' + REPO;
+  var lang = s.srtLang || 'uk';
+  var title = (s.talk ? s.talk.title : s.talkId) + ' \u2014 ' + (s.video ? s.video.title : s.videoSlug);
+  var srtPath = 'talks/' + s.talkId + '/' + s.videoSlug + '/final/' + lang + '.srt';
   var lines = [
-    '## ' + (s.talk ? s.talk.title : s.talkId) + ' — ' + (s.video ? s.video.title : s.videoSlug),
+    '## ' + title,
     '', '| | |', '|---|---|',
-    '| SRT | [`talks/' + s.talkId + '/' + s.videoSlug + '/final/uk.srt`](' + gh + '/blob/main/talks/' + s.talkId + '/' + s.videoSlug + '/final/uk.srt) |',
+    '| SRT | [`' + srtPath + '`](' + gh + '/blob/main/' + srtPath + ') |',
     '| Transcript | [`talks/' + s.talkId + '/transcript_uk.txt`](' + gh + '/blob/main/talks/' + s.talkId + '/transcript_uk.txt) |',
-    '', '### Markers', '', '| Time | Subtitle | Comment |', '|------|----------|---------|'
+    ''
   ];
-  previewState.markers.forEach(function(m) { lines.push('| ' + m.tc + ' | ' + m.text + ' | ' + (m.comment || '') + ' |'); });
-  var issueTitle = 'Subtitle review: ' + (s.video ? s.video.title : s.videoSlug);
+  if (s.mode === 'edit') {
+    var langEdits = (s.edits && s.edits[lang]) || {};
+    var idxs = Object.keys(langEdits).map(Number).sort(function(a, b) { return a - b; });
+    var blocks = s.subtitles || [];
+    lines.push('### Suggested edits (' + lang + ')', '');
+    idxs.forEach(function(idx) {
+      var blk = blocks[idx];
+      var tc = blk ? msToSrtTime(blk.startMs).slice(0, 8) : '';
+      var orig = blk ? blk.text : '';
+      var next = langEdits[idx];
+      lines.push('<details><summary><b>' + tc + '</b></summary>', '', '**Before:**', '> ' + orig, '', '**After:**', '> ' + next, '', '</details>', '');
+    });
+  } else {
+    lines.push('### Markers', '', '| Time | Subtitle | Comment |', '|------|----------|---------|');
+    s.markers.forEach(function(m) {
+      lines.push('| ' + m.tc + ' | ' + m.text + ' | ' + (m.comment || '') + ' |');
+    });
+  }
+  var issueTitle = (s.mode === 'edit' ? 'Subtitle edits: ' : 'Subtitle review: ') + (s.video ? s.video.title : s.videoSlug);
   var issueBody = lines.join('\n');
   var url = gh + '/issues/new?title=' + encodeURIComponent(issueTitle) + '&labels=review:pending&body=' + encodeURIComponent(issueBody);
   var shortUrl = gh + '/issues/new?title=' + encodeURIComponent(issueTitle) + '&labels=review:pending';
@@ -2165,11 +2559,31 @@ SPA.createPreviewIssue = function() {
   }
 };
 
+SPA.openPreviewEditor = function() {
+  var s = previewState;
+  var lang = s.srtLang || 'uk';
+  var filePath = 'talks/' + s.talkId + '/' + s.videoSlug + '/final/' + lang + '.srt';
+  var url = 'https://github.com/' + REPO + '/edit/main/' + filePath;
+  var langEdits = (s.edits && s.edits[lang]) || {};
+  if (Object.keys(langEdits).length > 0) {
+    var full = applyEditsToSrt(s.subtitles || [], langEdits);
+    navigator.clipboard.writeText(full).then(function() {
+      alert(t('editor.clipboard_alert'));
+      window.open(url);
+    }).catch(function() {
+      window.open(url);
+    });
+  } else {
+    window.open(url);
+  }
+};
+
 document.addEventListener('keydown', function(e) {
   if (!document.getElementById('view-preview').classList.contains('active')) return;
   if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+  if (e.target && e.target.isContentEditable) return;
   if (e.key === 'f' || e.key === 'F') { SPA.toggleFullscreen(); return; }
-  if (e.key === 'm' || e.key === 'M') { SPA.addMarker(); return; }
+  if (e.key === 'm' || e.key === 'M') { SPA.addMarkOrEdit(); return; }
   if (e.key === 'ArrowLeft') { e.preventDefault(); SPA.seek(-5); return; }
   if (e.key === 'ArrowRight') { e.preventDefault(); SPA.seek(5); return; }
   if (e.key === ' ') { e.preventDefault(); SPA.togglePlay(); return; }

--- a/site/index.html
+++ b/site/index.html
@@ -1074,6 +1074,17 @@ var SyncPlayer = (function() {
     while (mount.firstChild) mount.removeChild(mount.firstChild);
   }
 
+  function videoHasPlayer(talkId, videoSlug) {
+    var talk = (typeof reviewState !== 'undefined' && reviewState && reviewState.talk && reviewState.talk.id === talkId)
+      ? reviewState.talk
+      : (typeof manifest !== 'undefined' && manifest
+          ? manifest.talks.find(function(t) { return t.id === talkId; })
+          : null);
+    if (!talk || !talk.videos) return false;
+    var v = talk.videos.find(function(x) { return x.slug === videoSlug; });
+    return !!(v && v.vimeo_url);
+  }
+
   function init(talkId, videoSlug) {
     cacheDom();
     state = freshState(talkId, videoSlug);
@@ -1097,9 +1108,18 @@ var SyncPlayer = (function() {
     if (resizeHandle) resizeHandle.addEventListener('pointerdown', onResizeStart);
     document.addEventListener('keydown', onGlobalKeydown);
     window.addEventListener('scroll', onWindowScroll, { passive: true });
-    if (btnSync) btnSync.style.display = '';
+    // Only expose the sync-player toggle when the current video actually
+    // has a playable source. Without this check the button lingered with
+    // stale "Hide video" text after switching to a video that has no
+    // vimeo_url at all.
+    var playable = videoHasPlayer(talkId, videoSlug);
+    if (btnSync) btnSync.style.display = playable ? '' : 'none';
+    // Refresh the button label off the fresh state so stale text from a
+    // previous video (e.g. "Hide video" after we tore down an open bar)
+    // doesn't carry over.
+    updateToggleBtn();
     // Defer one tick so the caller finishes populating reviewState before show() reads it.
-    if (saved && saved.open === true) setTimeout(show, 0);
+    if (playable && saved && saved.open === true) setTimeout(show, 0);
   }
 
   function destroy() {

--- a/site/index.html
+++ b/site/index.html
@@ -1104,9 +1104,15 @@ var SyncPlayer = (function() {
 
   function destroy() {
     if (!state) return;
-    hide();
+    // Flush any in-flight throttled persist before we tear down, so the
+    // most recent lastTime / barHeightVh isn't lost on route leave.
     if (persistTimer) { clearTimeout(persistTimer); persistTimer = null; }
+    persistNow();
+    // DOM-level hide: remove the bar visually without touching state.open,
+    // so the saved "open" flag survives the navigation away from review.
+    if (bar) bar.setAttribute('hidden', '');
     if (state.player) {
+      try { state.player.pause(); } catch (_) {}
       try { state.player.destroy(); } catch (_) {}
     }
     clearMount();

--- a/site/index.html
+++ b/site/index.html
@@ -784,7 +784,7 @@ var I18N = {
     'freshness.refreshed': '\u2713 \u041E\u043D\u043E\u0432\u043B\u0435\u043D\u043E!',
     'freshness.up_to_date': '\u2713 \u0412\u0436\u0435 \u0430\u043A\u0442\u0443\u0430\u043B\u044C\u043D\u043E',
     'freshness.error': '\u2717 \u041F\u043E\u043C\u0438\u043B\u043A\u0430:',
-    'link.review': '\u043F\u0435\u0440\u0435\u0432\u0456\u0440\u0438\u0442\u0438 \u043F\u0435\u0440\u0435\u043A\u043B\u0430\u0434',
+    'link.review': '\u041F\u0435\u0440\u0435\u0432\u0456\u0440\u0438\u0442\u0438 \u043F\u0435\u0440\u0435\u043A\u043B\u0430\u0434',
     'link.amruta': '\u0412\u0456\u0434\u043A\u0440\u0438\u0442\u0438 \u043D\u0430 amruta.org',
 
     'add.title': '\u0414\u043E\u0434\u0430\u0442\u0438 \u043F\u0440\u043E\u043C\u043E\u0432\u0443',
@@ -884,7 +884,7 @@ var I18N = {
     'freshness.refreshed': '\u2713 Refreshed!',
     'freshness.up_to_date': '\u2713 Up to date',
     'freshness.error': '\u2717 Error:',
-    'link.review': 'review translation',
+    'link.review': 'Review translation',
     'link.amruta': 'Open on amruta.org',
 
     'add.title': 'Add Talk',

--- a/site/index.html
+++ b/site/index.html
@@ -2160,8 +2160,15 @@ function showPreview(talkId, videoSlug) {
         player.on('timeupdate', function(data) {
           previewState.currentTime = data.seconds;
           var ms = Math.round(data.seconds * 1000);
-          var active = findActiveSubtitle(previewState.subtitles, ms);
-          var text = active ? active.text : '';
+          var idx = findActiveSubtitleIdx(previewState.subtitles, ms);
+          var text = '';
+          if (idx !== -1) {
+            var lang = previewState.srtLang || 'uk';
+            var langEdits = (previewState.edits && previewState.edits[lang]) || {};
+            text = Object.prototype.hasOwnProperty.call(langEdits, idx)
+              ? langEdits[idx]
+              : previewState.subtitles[idx].text;
+          }
           if (text !== previewState.lastText) {
             document.getElementById('subtitle-overlay').textContent = text;
             previewState.lastText = text;

--- a/site/index.html
+++ b/site/index.html
@@ -170,8 +170,8 @@ textarea.input { resize: vertical; font-family: monospace; font-size: 13px; }
   padding: 8px 16px; font-size: 14px; cursor: pointer; touch-action: manipulation; }
 .controls button:active { background: var(--border3); }
 #time-display { color: var(--fg6); font-size: 13px; font-family: monospace; }
-.markers, .preview-list { max-width: 960px; margin: 0 auto; padding: 0 8px; }
-.markers summary, .preview-list summary { color: var(--fg5); cursor: pointer; padding: 8px; font-size: 14px; }
+.preview-list { max-width: 960px; margin: 0 auto; padding: 0 8px; }
+.preview-list summary { color: var(--fg5); cursor: pointer; padding: 8px; font-size: 14px; }
 #btn-clear-all { background: var(--danger-bg); color: var(--danger-fg); border-color: var(--danger-border); }
 .preview-mode-toggle { display: inline-flex; border: 1px solid var(--border3); border-radius: 6px; overflow: hidden; }
 .preview-mode-toggle button { background: var(--bg4); color: var(--fg5); border: 0; padding: 6px 12px; font-size: 13px; cursor: pointer; border-radius: 0; }
@@ -342,7 +342,6 @@ body.sync-player-resizing, body.sync-player-resizing * {
 /* --- Fullscreen preview mode --- */
 #view-preview.fs-mode { position: fixed; inset: 0; z-index: 9999; background: #000; display: flex; flex-direction: column; overflow: hidden; }
 #view-preview.fs-mode .header { display: none !important; }
-#view-preview.fs-mode .markers,
 #view-preview.fs-mode .preview-list { display: none !important; }
 #view-preview.fs-mode #btn-mark { display: none !important; }
 #view-preview.fs-mode .player-container { flex: 1; max-width: 100%; margin: 0; width: 100%; display: flex; flex-direction: column; overflow: hidden; }
@@ -685,14 +684,6 @@ function loadPreviewStateFromStorage(talkId, videoSlug) {
     return migrated;
   }
   return defaultPreviewStateShape();
-}
-function msToSrtTime(ms) {
-  var h = Math.floor(ms / 3600000);
-  var m = Math.floor((ms % 3600000) / 60000);
-  var s = Math.floor((ms % 60000) / 1000);
-  var mmm = ms % 1000;
-  return String(h).padStart(2, '0') + ':' + String(m).padStart(2, '0') + ':' +
-    String(s).padStart(2, '0') + ',' + String(mmm).padStart(3, '0');
 }
 function applyEditsToSrt(blocks, edits) {
   if (!blocks || !blocks.length) return '';
@@ -2204,13 +2195,26 @@ function showPreview(talkId, videoSlug) {
   renderEditList();
   updateClearBtn();
 
-  // Load SRT — once it arrives, re-render the edit list so rows that
-  // depend on parsed blocks (original text, timecodes) actually show.
+  // Capture the entry {talkId, videoSlug} so fetch-settled callbacks
+  // from a stale entry don't mutate state for the next one if the user
+  // navigates away before the network resolves.
+  var entryTalkId = talkId;
+  var entryVideoSlug = videoSlug;
+  function stillOnSameVideo() {
+    return previewState
+      && previewState.talkId === entryTalkId
+      && previewState.videoSlug === entryVideoSlug;
+  }
+
   var srtLoaded = loadSubtitleLang(defaultLang).then(function() {
-    if (previewState && previewState.mode === 'edit') renderEditList();
+    if (stillOnSameVideo() && previewState.mode === 'edit') renderEditList();
   });
 
-  // Setup player events — wait for both player ready and SRT
+  // Cache the two hot-path DOM nodes written from timeupdate so the
+  // ~4Hz tick doesn't re-query the tree on every frame.
+  var overlayEl = document.getElementById('subtitle-overlay');
+  var timeEl = document.getElementById('time-display');
+
   if (embedUrl) {
     try {
       var player = new Vimeo.Player(iframe);
@@ -2218,6 +2222,7 @@ function showPreview(talkId, videoSlug) {
       player.ready().then(function() {
         console.log('[SPA] Vimeo player ready');
         player.on('timeupdate', function(data) {
+          if (!stillOnSameVideo()) return;
           previewState.currentTime = data.seconds;
           var ms = Math.round(data.seconds * 1000);
           var idx = findActiveSubtitleIdx(previewState.subtitles, ms);
@@ -2230,12 +2235,15 @@ function showPreview(talkId, videoSlug) {
               : previewState.subtitles[idx].text;
           }
           if (text !== previewState.lastText) {
-            document.getElementById('subtitle-overlay').textContent = text;
+            overlayEl.textContent = text;
             previewState.lastText = text;
           }
           var s = Math.floor(data.seconds);
-          document.getElementById('time-display').textContent =
-            String(Math.floor(s/3600)).padStart(2,'0') + ':' + String(Math.floor((s%3600)/60)).padStart(2,'0') + ':' + String(s%60).padStart(2,'0');
+          if (s !== previewState.lastSec) {
+            timeEl.textContent =
+              String(Math.floor(s/3600)).padStart(2,'0') + ':' + String(Math.floor((s%3600)/60)).padStart(2,'0') + ':' + String(s%60).padStart(2,'0');
+            previewState.lastSec = s;
+          }
         });
       }).catch(function(err) {
         console.warn('[SPA] Vimeo player error:', err);
@@ -2253,7 +2261,6 @@ function vimeoEmbed(url) {
   return m ? 'https://player.vimeo.com/video/' + m[1] + '?h=' + m[2] : url;
 }
 
-// --- Preview state persistence ---
 function savePreviewState() {
   if (!previewState || !previewState.talkId) return;
   var key = 'preview_' + previewState.talkId + '_' + previewState.videoSlug;
@@ -2265,27 +2272,21 @@ function savePreviewState() {
   localStorage.setItem(key, JSON.stringify(payload));
 }
 
-// --- Mode switching ---
 function applyPreviewMode() {
   var mode = previewState.mode || 'marker';
-  // Segmented control active state
   document.querySelectorAll('.preview-mode-toggle button').forEach(function(b) {
     if (b.dataset.mode === mode) b.classList.add('active');
     else b.classList.remove('active');
   });
-  // Mark/Edit button label + title
   var markBtn = document.getElementById('btn-mark');
   if (markBtn) {
     markBtn.textContent = mode === 'edit' ? t('btn.edit') : t('btn.mark');
     markBtn.title = mode === 'edit' ? t('btn.edit_title') : t('btn.mark_title');
   }
-  // Header action buttons: copy visible only in marker mode,
-  // editor visible only in edit mode.
   var copyBtn = document.getElementById('btn-copy-all');
   if (copyBtn) copyBtn.style.display = mode === 'marker' ? 'inline-block' : 'none';
   var editorBtn = document.getElementById('btn-preview-editor');
   if (editorBtn) editorBtn.style.display = mode === 'edit' ? 'inline-block' : 'none';
-  // List summary label + list visibility
   var label = document.getElementById('preview-list-label');
   if (label) label.textContent = mode === 'edit' ? t('edits.summary') : t('markers.summary');
   var markerList = document.getElementById('marker-list');
@@ -2311,13 +2312,11 @@ SPA.switchPreviewVideo = function(newSlug) {
   location.hash = '#/preview/' + previewState.talkId + '/' + newSlug;
 };
 
-// --- Dispatch for the Mark/Edit button under the player ---
 SPA.addMarkOrEdit = function() {
   if (previewState.mode === 'edit') SPA.addEdit();
   else SPA.addMarker();
 };
 
-// --- Markers ---
 SPA.addMarker = function() {
   var tSec = previewState.currentTime;
   var text = previewState.lastText || '(no subtitle)';
@@ -2419,7 +2418,6 @@ function renderMarkers() {
   });
 }
 
-// --- Edit list rendering ---
 function renderEditList() {
   var list = document.getElementById('edit-list');
   var count = document.getElementById('marker-count');
@@ -2563,9 +2561,6 @@ SPA.clearAll = function() {
     showToast(t('toast.markers_cleared'));
   }
 };
-
-// Backwards-compat alias — some tests and keybindings still call clearMarkers.
-SPA.clearMarkers = function() { SPA.clearAll(); };
 
 SPA.copyMarkers = function() {
   var lines = ['# ' + document.title, ''];

--- a/site/index.html
+++ b/site/index.html
@@ -1568,10 +1568,12 @@ function loadSubtitleLang(lang) {
 }
 
 SPA.switchSubLang = function(lang) {
+  // Persist the choice synchronously so a fast reload or fetch failure
+  // doesn't drop it. Fetch races have historically lost the save when
+  // write happened inside the .then() callback.
+  if (previewState) localStorage.setItem('sy_srt_lang_' + previewState.talkId, lang);
   loadSubtitleLang(lang).then(function() {
     document.getElementById('subtitle-overlay').textContent = '';
-    // Save per-video language choice
-    if (previewState) localStorage.setItem('sy_srt_lang_' + previewState.talkId, lang);
     // Edit list is lang-scoped — re-render when lang changes.
     if (previewState && previewState.mode === 'edit') {
       renderEditList();
@@ -1905,10 +1907,18 @@ function renderIndex(el) {
       var href = st.issue_number ? 'https://github.com/' + REPO + '/issues/' + st.issue_number : '#';
       badge = '<a href="' + href + '" target="_blank" class="review-badge ' + bc + '">' + bt + '</a>';
     }
-    var firstVideo = (tk.videos || []).find(function(v) { return v.hasSrt && v.vimeo_url; });
+    // Prefer the last-viewed video for this talk; fall back to the first
+    // valid one. Both must have an SRT and vimeo_url to be linkable.
+    var validVideos = (tk.videos || []).filter(function(v) { return v.hasSrt && v.vimeo_url; });
+    var lastSlug = localStorage.getItem('sy_last_video_' + tk.id);
+    var targetVideo = null;
+    if (lastSlug) {
+      targetVideo = validVideos.find(function(v) { return v.slug === lastSlug; }) || null;
+    }
+    if (!targetVideo) targetVideo = validVideos[0] || null;
     var videoLinks = '';
-    if (firstVideo) {
-      videoLinks = '<a href="#/preview/' + tk.id + '/' + firstVideo.slug + '" class="preview-link">' + esc(t('link.preview')) + '</a>';
+    if (targetVideo) {
+      videoLinks = '<a href="#/preview/' + tk.id + '/' + targetVideo.slug + '" class="preview-link">' + esc(t('link.preview')) + '</a>';
     }
     var reviewLink = '';
     if (tk.hasEn && tk.hasUk) {
@@ -2090,6 +2100,10 @@ function showPreview(talkId, videoSlug) {
   // Find talk info
   var talk = manifest ? manifest.talks.find(function(t) { return t.id === talkId; }) : null;
   var video = talk ? (talk.videos || []).find(function(v) { return v.slug === videoSlug; }) : null;
+
+  // Remember this as the last-viewed video for the talk so the index
+  // link points here next time.
+  if (video) localStorage.setItem('sy_last_video_' + talkId, videoSlug);
 
   document.getElementById('p-title').textContent = (talk ? talk.title : talkId) + ' — ' + (video ? video.title : videoSlug);
   document.title = (video ? video.title : videoSlug) + ' – Preview';

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -2756,6 +2756,43 @@ class TestPreviewEditMode:
         stored = page.evaluate(f"JSON.parse(localStorage.getItem('{PREVIEW_KEY}') || 'null')")
         assert stored["edits"].get("uk", {}) == {}
 
+    def test_overlay_reflects_edited_text_during_playback(self, server, page):
+        _goto_preview_video(page, server)
+        self._switch_to_edit(page)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")
+        page.wait_for_timeout(100)
+        # Overwrite the edit text.
+        page.evaluate("""
+          var el = document.activeElement;
+          el.innerText = 'Відредагований субтитр';
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+        """)
+        page.wait_for_timeout(50)
+        # Drive the player timeupdate to re-render overlay.
+        page.evaluate("window._vimeoPlayer._setTime(3)")
+        page.wait_for_timeout(200)
+        overlay = page.evaluate("document.getElementById('subtitle-overlay').textContent")
+        assert overlay == "Відредагований субтитр"
+
+    def test_overlay_falls_back_to_original_when_edit_reverted(self, server, page):
+        _goto_preview_video(page, server)
+        self._switch_to_edit(page)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")
+        page.evaluate("""
+          var el = document.activeElement;
+          el.innerText = 'Перший субтитр';
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+        """)
+        page.wait_for_timeout(50)
+        page.evaluate("window._vimeoPlayer._setTime(3)")
+        page.wait_for_timeout(200)
+        overlay = page.evaluate("document.getElementById('subtitle-overlay').textContent")
+        assert overlay == "Перший субтитр"
+
     def test_clear_all_edit_mode(self, server, page):
         _goto_preview_video(page, server)
         self._switch_to_edit(page)

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -250,14 +250,13 @@ class TestIndexView:
         preview_links = page.locator("a[href*='preview']").count()
         assert preview_links >= 1
 
-    def test_both_videos_have_preview(self, server, page):
-        """Both videos have uk.srt — both should have preview links."""
+    def test_single_preview_link_for_multi_video(self, server, page):
+        """Multi-video talks get a single consolidated preview link — users switch
+        videos from within the preview page via the video selector."""
         goto_spa(page, server)
         page.wait_for_selector(".talk-item", timeout=10000)
-        links = page.locator("a[href*='preview']").all()
-        link_texts = [el.text_content().strip() for el in links]
-        assert any("Test Video" in t for t in link_texts), f"'Test Video' not found in {link_texts}"
-        assert any("Test Video 2" in t for t in link_texts), f"'Test Video 2' not found in {link_texts}"
+        links = page.locator(".talk-item").first.locator("a.preview-link").count()
+        assert links == 1
 
     def test_talk_without_uk_no_review(self, server, page):
         """Talk without UK transcript should NOT have review link."""
@@ -476,9 +475,10 @@ class TestMarkers:
         page.evaluate("window._vimeoPlayer._setTime(2)")
         page.wait_for_timeout(200)
         page.click("#btn-mark")
-        data = page.evaluate("localStorage.getItem('markers_preview_2001-01-01_Test-Talk_Test-Video')")
-        assert data is not None
-        markers = json.loads(data)
+        markers = page.evaluate(
+            "JSON.parse(localStorage.getItem('preview_2001-01-01_Test-Talk_Test-Video') || '{}').markers || null"
+        )
+        assert markers is not None
         assert len(markers) == 1
         assert markers[0]["text"] == "Перший субтитр"
 
@@ -533,11 +533,15 @@ class TestMarkers:
         page.evaluate("window._vimeoPlayer._setTime(2)")
         page.wait_for_timeout(200)
         page.click("#btn-mark")
-        data = json.loads(page.evaluate("localStorage.getItem('markers_preview_2001-01-01_Test-Talk_Test-Video')"))
+        data = page.evaluate(
+            "JSON.parse(localStorage.getItem('preview_2001-01-01_Test-Talk_Test-Video') || '{}').markers || []"
+        )
         assert len(data) == 1
         page.once("dialog", lambda dialog: dialog.accept())
         page.click("button.danger")
-        data = json.loads(page.evaluate("localStorage.getItem('markers_preview_2001-01-01_Test-Talk_Test-Video')"))
+        data = page.evaluate(
+            "JSON.parse(localStorage.getItem('preview_2001-01-01_Test-Talk_Test-Video') || '{}').markers || []"
+        )
         assert len(data) == 0
 
     def test_marker_comment_input(self, server, page):
@@ -555,7 +559,9 @@ class TestMarkers:
         page.evaluate("window._vimeoPlayer._setTime(0.5)")
         page.wait_for_timeout(200)
         page.click("#btn-mark")
-        data = json.loads(page.evaluate("localStorage.getItem('markers_preview_2001-01-01_Test-Talk_Test-Video')"))
+        data = page.evaluate(
+            "JSON.parse(localStorage.getItem('preview_2001-01-01_Test-Talk_Test-Video') || '{}').markers || []"
+        )
         assert data[0]["text"] == "(no subtitle)"
 
     def test_comment_enter_blurs_input(self, server, page):
@@ -688,7 +694,7 @@ class TestFullscreenMode:
         self._goto_preview(server, page)
         self._enter_fs(page)
         display = page.evaluate("""
-            getComputedStyle(document.querySelector('#view-preview .markers')).display
+            getComputedStyle(document.querySelector('#view-preview .preview-list')).display
         """)
         assert display == "none"
 
@@ -2472,3 +2478,327 @@ class TestRealTranscriptRoundTrip:
         assert para_count == expected, (
             f"[{fixture}] paragraph count mismatch: SPA reports {para_count}, expected {expected}"
         )
+
+
+# ============================================================
+# Preview: marker ↔ edit mode toggle
+# ============================================================
+
+PREVIEW_KEY = "preview_2001-01-01_Test-Talk_Test-Video"
+LEGACY_KEY = "markers_preview_2001-01-01_Test-Talk_Test-Video"
+
+
+def _goto_preview_video(page, server, video_slug="Test-Video"):
+    # Always do a full navigation so route() runs against a clean previewState.
+    # page.goto with only a hash change would not reload when already on the
+    # same path in Playwright, and hashchange alone can race with manifest load.
+    page.goto(f"{server}{SPA_URL}?_r={video_slug}#/preview/2001-01-01_Test-Talk/{video_slug}")
+    page.wait_for_selector("#mock-player", state="visible", timeout=10000)
+    page.wait_for_function(
+        f"window.previewState && window.previewState.videoSlug === {video_slug!r}",
+        timeout=10000,
+    )
+    page.wait_for_timeout(300)
+
+
+class TestPreviewModeDefaults:
+    def test_default_mode_is_marker(self, server, page):
+        _goto_preview_video(page, server)
+        mode = page.evaluate(
+            "document.querySelector('.preview-mode-toggle [data-mode=\"marker\"]').classList.contains('active')"
+        )
+        assert mode is True
+
+    def test_default_new_key_shape_on_first_mutation(self, server, page):
+        _goto_preview_video(page, server)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")
+        stored = page.evaluate(f"JSON.parse(localStorage.getItem('{PREVIEW_KEY}') || 'null')")
+        assert stored is not None
+        assert stored["mode"] == "marker"
+        assert isinstance(stored["markers"], list)
+        assert isinstance(stored["edits"], dict)
+        assert len(stored["markers"]) == 1
+
+    def test_mode_persisted_across_reload(self, server, page):
+        _goto_preview_video(page, server)
+        page.click('.preview-mode-toggle [data-mode="edit"]')
+        page.wait_for_timeout(100)
+        _goto_preview_video(page, server)
+        mode = page.evaluate(
+            "document.querySelector('.preview-mode-toggle [data-mode=\"edit\"]').classList.contains('active')"
+        )
+        assert mode is True
+
+    def test_mode_independent_per_video(self, server, page):
+        _goto_preview_video(page, server, "Test-Video")
+        page.click('.preview-mode-toggle [data-mode="edit"]')
+        page.wait_for_timeout(100)
+        _goto_preview_video(page, server, "Test-Video-2")
+        debug = page.evaluate("""
+          ({
+            state_mode: (window.previewState || {}).mode,
+            btn_marker_classes: document.querySelector('.preview-mode-toggle [data-mode=\"marker\"]').className,
+            btn_edit_classes: document.querySelector('.preview-mode-toggle [data-mode=\"edit\"]').className,
+            v2_key: localStorage.getItem('preview_2001-01-01_Test-Talk_Test-Video-2'),
+            v1_key: localStorage.getItem('preview_2001-01-01_Test-Talk_Test-Video'),
+          })
+        """)
+        mode2 = page.evaluate(
+            "document.querySelector('.preview-mode-toggle [data-mode=\"marker\"]').classList.contains('active')"
+        )
+        assert mode2 is True, f"debug: {debug}"
+        _goto_preview_video(page, server, "Test-Video")
+        mode1 = page.evaluate(
+            "document.querySelector('.preview-mode-toggle [data-mode=\"edit\"]').classList.contains('active')"
+        )
+        assert mode1 is True
+
+
+class TestPreviewLegacyMigration:
+    def test_legacy_markers_migrated_to_new_key(self, server, page):
+        # Seed legacy key before navigation — use init script so it runs
+        # before any SPA code sees localStorage.
+        legacy = json.dumps([{"time": 2.0, "tc": "00:00:02", "text": "legacy one", "comment": ""}])
+        page.add_init_script(f"localStorage.setItem({LEGACY_KEY!r}, {legacy!r});")
+        _goto_preview_video(page, server)
+        new = page.evaluate(f"JSON.parse(localStorage.getItem('{PREVIEW_KEY}') || 'null')")
+        assert new is not None
+        assert new["mode"] == "marker"
+        assert len(new["markers"]) == 1
+        assert new["markers"][0]["text"] == "legacy one"
+        legacy_after = page.evaluate(f"localStorage.getItem('{LEGACY_KEY}')")
+        assert legacy_after is None
+
+    def test_legacy_ignored_when_new_key_exists(self, server, page):
+        new_payload = json.dumps({"mode": "edit", "markers": [], "edits": {"uk": {"0": "нове"}}})
+        legacy_payload = json.dumps([{"time": 1, "tc": "00:00:01", "text": "stale", "comment": ""}])
+        page.add_init_script(
+            f"localStorage.setItem({PREVIEW_KEY!r}, {new_payload!r});"
+            f"localStorage.setItem({LEGACY_KEY!r}, {legacy_payload!r});"
+        )
+        _goto_preview_video(page, server)
+        stored = page.evaluate(f"JSON.parse(localStorage.getItem('{PREVIEW_KEY}') || 'null')")
+        assert stored["mode"] == "edit"
+        legacy_after = page.evaluate(f"localStorage.getItem('{LEGACY_KEY}')")
+        assert legacy_after is None
+
+
+class TestPreviewLayoutButtons:
+    def test_action_buttons_live_in_header(self, server, page):
+        _goto_preview_video(page, server)
+        # Buttons that should be in the preview header.
+        for sel in ["#btn-preview-issue", "#btn-clear-all"]:
+            count = page.locator(f"#view-preview .header .header-actions {sel}").count()
+            assert count == 1, f"{sel} not found in preview header-actions"
+
+    def test_mark_button_stays_in_player_controls(self, server, page):
+        _goto_preview_video(page, server)
+        count = page.locator("#view-preview .player-container .controls #btn-mark").count()
+        assert count == 1
+
+    def test_segmented_control_in_header(self, server, page):
+        _goto_preview_video(page, server)
+        count = page.locator("#view-preview .header .preview-mode-toggle").count()
+        assert count == 1
+        btns = page.locator(".preview-mode-toggle button").count()
+        assert btns == 2
+
+    def test_clear_btn_hidden_when_empty(self, server, page):
+        _goto_preview_video(page, server)
+        visible = page.locator("#btn-clear-all").is_visible()
+        assert visible is False
+
+    def test_clear_btn_shown_after_adding_marker(self, server, page):
+        _goto_preview_video(page, server)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")
+        visible = page.locator("#btn-clear-all").is_visible()
+        assert visible is True
+
+    def test_copy_btn_only_visible_in_marker_mode(self, server, page):
+        _goto_preview_video(page, server)
+        assert page.locator("#btn-copy-all").is_visible() is True
+        page.click('.preview-mode-toggle [data-mode="edit"]')
+        assert page.locator("#btn-copy-all").is_visible() is False
+
+    def test_open_editor_btn_only_visible_in_edit_mode(self, server, page):
+        _goto_preview_video(page, server)
+        assert page.locator("#btn-preview-editor").is_visible() is False
+        page.click('.preview-mode-toggle [data-mode="edit"]')
+        assert page.locator("#btn-preview-editor").is_visible() is True
+
+
+class TestPreviewEditMode:
+    def _switch_to_edit(self, page):
+        page.click('.preview-mode-toggle [data-mode="edit"]')
+        page.wait_for_timeout(50)
+
+    def test_add_edit_creates_item_and_pauses(self, server, page):
+        _goto_preview_video(page, server)
+        self._switch_to_edit(page)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")  # same button, label now "Edit"
+        count = page.locator(".edit-item").count()
+        assert count == 1
+        paused = page.evaluate("window._vimeoPlayer._paused")
+        assert paused is True
+
+    def test_add_edit_initial_text_equals_original(self, server, page):
+        _goto_preview_video(page, server)
+        self._switch_to_edit(page)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")
+        text = page.locator(".edit-item .edited").first.inner_text().strip()
+        assert text == "Перший субтитр"
+
+    def test_add_edit_focuses_contenteditable(self, server, page):
+        _goto_preview_video(page, server)
+        self._switch_to_edit(page)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")
+        page.wait_for_timeout(100)
+        focused = page.evaluate("document.activeElement.classList.contains('edited')")
+        assert focused is True
+
+    def test_add_edit_existing_block_does_not_duplicate(self, server, page):
+        _goto_preview_video(page, server)
+        self._switch_to_edit(page)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")
+        page.keyboard.press("Escape")  # blur
+        page.evaluate("window._vimeoPlayer._setTime(3)")  # still inside block 0 (1000-5000)
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")
+        count = page.locator(".edit-item").count()
+        assert count == 1
+
+    def test_add_edit_no_active_subtitle_does_nothing(self, server, page):
+        _goto_preview_video(page, server)
+        self._switch_to_edit(page)
+        page.evaluate("window._vimeoPlayer._setTime(5.5)")  # gap between blocks
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")
+        count = page.locator(".edit-item").count()
+        assert count == 0
+
+    def test_edit_text_persists_to_storage(self, server, page):
+        _goto_preview_video(page, server)
+        self._switch_to_edit(page)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")
+        page.wait_for_timeout(100)
+        # Type new text into focused contenteditable.
+        page.evaluate("""
+          var el = document.activeElement;
+          el.innerText = 'Змінений текст';
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+        """)
+        page.wait_for_timeout(50)
+        stored = page.evaluate(f"JSON.parse(localStorage.getItem('{PREVIEW_KEY}') || 'null')")
+        assert stored["edits"]["uk"]["0"] == "Змінений текст"
+
+    def test_edit_equal_to_original_removes_entry(self, server, page):
+        _goto_preview_video(page, server)
+        self._switch_to_edit(page)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")
+        page.evaluate("""
+          var el = document.activeElement;
+          el.innerText = 'Інакший';
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+        """)
+        page.wait_for_timeout(50)
+        page.evaluate("""
+          var el = document.activeElement;
+          el.innerText = 'Перший субтитр';
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+        """)
+        page.wait_for_timeout(50)
+        stored = page.evaluate(f"JSON.parse(localStorage.getItem('{PREVIEW_KEY}') || 'null')")
+        uk_edits = stored["edits"].get("uk", {})
+        assert "0" not in uk_edits and 0 not in uk_edits
+
+    def test_edit_enter_resumes_video(self, server, page):
+        _goto_preview_video(page, server)
+        self._switch_to_edit(page)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")
+        page.wait_for_timeout(100)
+        assert page.evaluate("window._vimeoPlayer._paused") is True
+        # Send Enter to the focused contenteditable.
+        page.keyboard.press("Enter")
+        page.wait_for_timeout(100)
+        assert page.evaluate("window._vimeoPlayer._paused") is False
+
+    def test_delete_edit_row_removes_from_storage(self, server, page):
+        _goto_preview_video(page, server)
+        self._switch_to_edit(page)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")
+        page.evaluate("""
+          var el = document.activeElement;
+          el.innerText = 'Змінений';
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+        """)
+        page.wait_for_timeout(50)
+        page.click(".edit-item .del")
+        stored = page.evaluate(f"JSON.parse(localStorage.getItem('{PREVIEW_KEY}') || 'null')")
+        assert stored["edits"].get("uk", {}) == {}
+
+    def test_clear_all_edit_mode(self, server, page):
+        _goto_preview_video(page, server)
+        self._switch_to_edit(page)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")
+        page.evaluate("""
+          var el = document.activeElement;
+          el.innerText = 'X';
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+        """)
+        page.wait_for_timeout(50)
+        page.once("dialog", lambda dialog: dialog.accept())
+        page.click("#btn-clear-all")
+        count = page.locator(".edit-item").count()
+        assert count == 0
+        stored = page.evaluate(f"JSON.parse(localStorage.getItem('{PREVIEW_KEY}') || 'null')")
+        assert stored["edits"].get("uk", {}) == {}
+
+
+class TestIndexSingleLink:
+    def test_single_preview_link_per_talk(self, server, page):
+        goto_spa(page, server)
+        page.wait_for_selector(".talk-item", timeout=10000)
+        # Test-Talk has 2 videos but we want a single preview entry.
+        links = page.locator(".talk-item").first.locator(".preview-link").count()
+        assert links == 1, f"expected 1 preview link, got {links}"
+
+    def test_preview_link_points_to_first_video(self, server, page):
+        goto_spa(page, server)
+        page.wait_for_selector(".talk-item", timeout=10000)
+        href = page.locator(".talk-item").first.locator(".preview-link").get_attribute("href")
+        assert href == "#/preview/2001-01-01_Test-Talk/Test-Video"
+
+
+class TestPreviewVideoSwitcher:
+    def test_switcher_visible_for_multi_video(self, server, page):
+        _goto_preview_video(page, server)
+        visible = page.locator("#preview-video-select").is_visible()
+        assert visible is True
+
+    def test_switcher_changes_route(self, server, page):
+        _goto_preview_video(page, server)
+        page.select_option("#preview-video-select", "Test-Video-2")
+        page.wait_for_timeout(500)
+        assert "Test-Video-2" in page.url

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -2756,6 +2756,24 @@ class TestPreviewEditMode:
         stored = page.evaluate(f"JSON.parse(localStorage.getItem('{PREVIEW_KEY}') || 'null')")
         assert stored["edits"].get("uk", {}) == {}
 
+    def test_edit_list_rows_visible_when_navigating_from_index(self, server, page):
+        # Seed an edit for block 0 in uk, then navigate to the preview from
+        # scratch. The edit list must render a row once the SRT is fetched.
+        page.add_init_script(
+            "localStorage.setItem('preview_2001-01-01_Test-Talk_Test-Video',"
+            " JSON.stringify({mode:'edit', markers:[], edits:{uk:{'0':'Мій правлений блок'}}}))"
+        )
+        _goto_preview_video(page, server)
+        # Wait until the SRT-dependent re-render finishes.
+        page.wait_for_function(
+            "document.querySelectorAll('.edit-item').length > 0",
+            timeout=5000,
+        )
+        rows = page.locator(".edit-item").count()
+        assert rows == 1
+        text = page.locator(".edit-item .edited").first.inner_text().strip()
+        assert text == "Мій правлений блок"
+
     def test_overlay_reflects_edited_text_during_playback(self, server, page):
         _goto_preview_video(page, server)
         self._switch_to_edit(page)
@@ -2826,6 +2844,95 @@ class TestIndexSingleLink:
         page.wait_for_selector(".talk-item", timeout=10000)
         href = page.locator(".talk-item").first.locator(".preview-link").get_attribute("href")
         assert href == "#/preview/2001-01-01_Test-Talk/Test-Video"
+
+
+class TestSubtitleLangPerTalk:
+    """Subtitle language choice is persisted per-talk, not per-video."""
+
+    def test_lang_choice_saved_per_talk(self, server, page):
+        # Seed availability of both uk and en for Test-Talk via manifest — the
+        # default Test-Video only advertises uk in the fixture, so we flip via
+        # the setter directly and then assert the new per-talk key.
+        page.goto(f"{server}/index.html?_=1#/preview/2001-01-01_Test-Talk/Test-Video")
+        page.wait_for_selector("#mock-player", state="visible", timeout=10000)
+        page.wait_for_function(
+            "window.previewState && window.previewState.videoSlug === 'Test-Video'",
+            timeout=10000,
+        )
+        page.evaluate("localStorage.setItem('sy_srt_lang_2001-01-01_Test-Talk', 'uk')")
+        # Navigate to second video of the same talk — it should pick up the
+        # per-talk saved lang without needing a video-specific entry.
+        page.goto(f"{server}/index.html?_=2#/preview/2001-01-01_Test-Talk/Test-Video-2")
+        page.wait_for_selector("#mock-player", state="visible", timeout=10000)
+        page.wait_for_function(
+            "window.previewState && window.previewState.videoSlug === 'Test-Video-2'",
+            timeout=10000,
+        )
+        lang = page.evaluate("window.previewState && window.previewState.srtLang")
+        assert lang == "uk"
+
+    def test_legacy_per_video_key_ignored(self, server, page):
+        # Legacy per-video keys from before the per-talk change should not
+        # leak into the new per-talk default behavior. We seed a legacy key
+        # and expect it to be ignored (no crash, no false positive).
+        page.add_init_script("localStorage.setItem('sy_srt_lang_2001-01-01_Test-Talk_Test-Video', 'xx')")
+        page.goto(f"{server}/index.html?_=3#/preview/2001-01-01_Test-Talk/Test-Video")
+        page.wait_for_selector("#mock-player", state="visible", timeout=10000)
+        page.wait_for_function(
+            "window.previewState && window.previewState.videoSlug === 'Test-Video'",
+            timeout=10000,
+        )
+        lang = page.evaluate("window.previewState && window.previewState.srtLang")
+        # Only uk is available in the fixture — defaults to uk, legacy ignored.
+        assert lang == "uk"
+
+
+class TestIndexFilterPersistence:
+    """Active filter on the index is persisted separately for normal and
+    expert mode so each mode recalls its own last choice."""
+
+    def test_normal_mode_filter_persisted(self, server, page):
+        page.add_init_script("localStorage.setItem('sy_expert_mode', '0');")
+        goto_spa(page, server)
+        page.wait_for_selector(".stat-card", timeout=10000)
+        # Click the "in-review" stat card to change the filter (valid in normal mode).
+        page.click('.stat-card[data-filter="in-review"]')
+        page.wait_for_timeout(50)
+        saved = page.evaluate("localStorage.getItem('sy_filter_normal')")
+        assert saved == "in-review"
+        # Reload and verify — the active stat card should match on rehydration.
+        goto_spa(page, server)
+        page.wait_for_selector(".stat-card.active", timeout=10000)
+        active = page.evaluate(
+            "document.querySelector('.stat-card.active') && document.querySelector('.stat-card.active').dataset.filter"
+        )
+        assert active == "in-review"
+
+    def test_expert_mode_filter_persisted_separately(self, server, page):
+        page.add_init_script("localStorage.setItem('sy_expert_mode', '1');")
+        goto_spa(page, server)
+        page.wait_for_selector(".talk-item", timeout=10000)
+        page.click('.stat-card[data-filter="in-review"]')
+        page.wait_for_timeout(50)
+        assert page.evaluate("localStorage.getItem('sy_filter_expert')") == "in-review"
+        # Normal-mode filter key must be untouched by expert-mode clicks.
+        assert page.evaluate("localStorage.getItem('sy_filter_normal')") in (None, "needs-review")
+
+    def test_toggle_expert_switches_filter_to_saved(self, server, page):
+        page.add_init_script(
+            "localStorage.setItem('sy_expert_mode', '0');"
+            "localStorage.setItem('sy_filter_normal', 'in-review');"
+            "localStorage.setItem('sy_filter_expert', 'approved');"
+        )
+        goto_spa(page, server)
+        page.wait_for_selector(".stat-card.active", timeout=10000)
+        active = page.evaluate("document.querySelector('.stat-card.active').dataset.filter")
+        assert active == "in-review"
+        # Toggle to expert mode — filter should switch to the expert saved value.
+        page.evaluate("SPA.toggleExpert()")
+        page.wait_for_timeout(50)
+        active = page.evaluate("document.querySelector('.stat-card.active').dataset.filter")
+        assert active == "approved"
 
 
 class TestPreviewVideoSwitcher:

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -2584,6 +2584,17 @@ class TestPreviewLegacyMigration:
         legacy_after = page.evaluate(f"localStorage.getItem('{LEGACY_KEY}')")
         assert legacy_after is None
 
+    def test_corrupt_legacy_json_falls_back_to_default(self, server, page):
+        page.add_init_script(f"localStorage.setItem({LEGACY_KEY!r}, '{{not-json');")
+        _goto_preview_video(page, server)
+        stored = page.evaluate(f"JSON.parse(localStorage.getItem('{PREVIEW_KEY}') || 'null')")
+        assert stored is not None
+        assert stored["mode"] == "marker"
+        assert stored["markers"] == []
+        assert stored["edits"] == {}
+        # Legacy key is wiped regardless of parse outcome.
+        assert page.evaluate(f"localStorage.getItem({LEGACY_KEY!r})") is None
+
 
 class TestPreviewLayoutButtons:
     def test_action_buttons_live_in_header(self, server, page):
@@ -2773,6 +2784,63 @@ class TestPreviewEditMode:
         assert rows == 1
         text = page.locator(".edit-item .edited").first.inner_text().strip()
         assert text == "Мій правлений блок"
+
+    def test_create_issue_edit_mode_body_has_before_after(self, server, page):
+        _goto_preview_video(page, server)
+        self._switch_to_edit(page)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")
+        page.wait_for_timeout(100)
+        page.evaluate("""
+          var el = document.activeElement;
+          el.innerText = 'НОВА ВЕРСІЯ';
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+        """)
+        page.wait_for_timeout(50)
+        page.evaluate(
+            "window._openedUrl = null;"
+            " window.open = function(u) { window._openedUrl = u; };"
+            " navigator.clipboard.writeText = function() { return Promise.resolve(); };"
+            " window.alert = function() {};"
+        )
+        page.evaluate("SPA.createPreviewIssue()")
+        page.wait_for_timeout(200)
+        body = page.evaluate("decodeURIComponent(window._openedUrl || '')")
+        assert "Suggested edits" in body, body[:400]
+        assert "НОВА ВЕРСІЯ" in body, body[:400]
+        assert "Перший субтитр" in body, body[:400]
+
+    def test_open_preview_editor_clipboards_rebuilt_srt(self, server, page):
+        _goto_preview_video(page, server)
+        self._switch_to_edit(page)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")
+        page.wait_for_timeout(100)
+        page.evaluate("""
+          var el = document.activeElement;
+          el.innerText = 'ЗМІНА';
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+        """)
+        page.wait_for_timeout(50)
+        page.evaluate(
+            "window._clipText = '';"
+            " navigator.clipboard.writeText = function(t) {"
+            "   window._clipText = t; return Promise.resolve();"
+            " };"
+            " window.alert = function() {};"
+            " window._openedUrl = null;"
+            " window.open = function(u) { window._openedUrl = u; };"
+        )
+        page.evaluate("SPA.openPreviewEditor()")
+        page.wait_for_timeout(200)
+        clip = page.evaluate("window._clipText || ''")
+        opened = page.evaluate("window._openedUrl || ''")
+        assert "ЗМІНА" in clip, clip[:400]
+        assert "00:00:01,000 --> 00:00:05,000" in clip, clip[:400]
+        assert "Другий субтитр" in clip, clip[:400]
+        assert opened.startswith("https://github.com/") and "final/uk.srt" in opened
 
     def test_overlay_reflects_edited_text_during_playback(self, server, page):
         _goto_preview_video(page, server)

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -2935,6 +2935,27 @@ class TestIndexFilterPersistence:
         assert active == "approved"
 
 
+class TestIndexRemembersLastVideo:
+    def test_last_viewed_video_saved_on_preview(self, server, page):
+        _goto_preview_video(page, server, "Test-Video-2")
+        saved = page.evaluate("localStorage.getItem('sy_last_video_2001-01-01_Test-Talk')")
+        assert saved == "Test-Video-2"
+
+    def test_index_link_targets_last_viewed_video(self, server, page):
+        page.add_init_script("localStorage.setItem('sy_last_video_2001-01-01_Test-Talk', 'Test-Video-2')")
+        goto_spa(page, server)
+        page.wait_for_selector(".talk-item", timeout=10000)
+        href = page.locator(".talk-item").first.locator(".preview-link").get_attribute("href")
+        assert href == "#/preview/2001-01-01_Test-Talk/Test-Video-2"
+
+    def test_index_link_falls_back_to_first_video_when_last_invalid(self, server, page):
+        page.add_init_script("localStorage.setItem('sy_last_video_2001-01-01_Test-Talk', 'Nope-Does-Not-Exist')")
+        goto_spa(page, server)
+        page.wait_for_selector(".talk-item", timeout=10000)
+        href = page.locator(".talk-item").first.locator(".preview-link").get_attribute("href")
+        assert href == "#/preview/2001-01-01_Test-Talk/Test-Video"
+
+
 class TestPreviewVideoSwitcher:
     def test_switcher_visible_for_multi_video(self, server, page):
         _goto_preview_video(page, server)

--- a/tests/test_preview_state.js
+++ b/tests/test_preview_state.js
@@ -1,0 +1,227 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const {
+  defaultPreviewState,
+  loadPreviewState,
+  applyEditsToSrt,
+} = require('../tools/preview_state');
+const { findActiveSubtitleIdx } = require('../tools/preview_srt_parser');
+
+// In-memory storage double — matches just enough of localStorage
+// surface (getItem/setItem/removeItem) for loadPreviewState.
+function makeStorage(initial) {
+  const store = Object.assign({}, initial || {});
+  return {
+    data: store,
+    getItem(k) {
+      return Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null;
+    },
+    setItem(k, v) {
+      store[k] = String(v);
+    },
+    removeItem(k) {
+      delete store[k];
+    },
+  };
+}
+
+describe('defaultPreviewState', () => {
+  it('has marker mode and empty collections', () => {
+    const s = defaultPreviewState();
+    assert.strictEqual(s.mode, 'marker');
+    assert.deepStrictEqual(s.markers, []);
+    assert.deepStrictEqual(s.edits, {});
+  });
+  it('returns a fresh object each call', () => {
+    const a = defaultPreviewState();
+    const b = defaultPreviewState();
+    a.markers.push({ time: 1, tc: '00:00:01', text: 'x', comment: '' });
+    assert.strictEqual(b.markers.length, 0);
+  });
+});
+
+describe('loadPreviewState — migration and precedence', () => {
+  const talkId = '2001-01-01_Test';
+  const videoSlug = 'v1';
+  const newKey = 'preview_' + talkId + '_' + videoSlug;
+  const legacyKey = 'markers_preview_' + talkId + '_' + videoSlug;
+
+  it('returns default when neither key is present', () => {
+    const storage = makeStorage();
+    const state = loadPreviewState(talkId, videoSlug, storage);
+    assert.strictEqual(state.mode, 'marker');
+    assert.deepStrictEqual(state.markers, []);
+    assert.deepStrictEqual(state.edits, {});
+    // Default is not written back to storage until user mutates.
+    assert.strictEqual(storage.getItem(newKey), null);
+  });
+
+  it('reads the new key and leaves storage untouched', () => {
+    const payload = {
+      mode: 'edit',
+      markers: [{ time: 1, tc: '00:00:01', text: 'a', comment: '' }],
+      edits: { uk: { 3: 'нове' } },
+    };
+    const storage = makeStorage({ [newKey]: JSON.stringify(payload) });
+    const state = loadPreviewState(talkId, videoSlug, storage);
+    assert.deepStrictEqual(state, payload);
+    assert.strictEqual(storage.getItem(legacyKey), null);
+  });
+
+  it('migrates legacy markers-only key to new shape and removes legacy', () => {
+    const legacyMarkers = [
+      { time: 12.3, tc: '00:00:12', text: 'hi', comment: 'c1' },
+      { time: 45.6, tc: '00:00:45', text: 'bye', comment: '' },
+    ];
+    const storage = makeStorage({
+      [legacyKey]: JSON.stringify(legacyMarkers),
+    });
+    const state = loadPreviewState(talkId, videoSlug, storage);
+    assert.strictEqual(state.mode, 'marker');
+    assert.deepStrictEqual(state.markers, legacyMarkers);
+    assert.deepStrictEqual(state.edits, {});
+    assert.strictEqual(storage.getItem(legacyKey), null);
+    const stored = JSON.parse(storage.getItem(newKey));
+    assert.deepStrictEqual(stored.markers, legacyMarkers);
+    assert.strictEqual(stored.mode, 'marker');
+  });
+
+  it('prefers new key when both exist and drops legacy', () => {
+    const legacy = [{ time: 1, tc: '00:00:01', text: 'old', comment: '' }];
+    const payload = {
+      mode: 'edit',
+      markers: [],
+      edits: { uk: { 0: 'x' } },
+    };
+    const storage = makeStorage({
+      [legacyKey]: JSON.stringify(legacy),
+      [newKey]: JSON.stringify(payload),
+    });
+    const state = loadPreviewState(talkId, videoSlug, storage);
+    assert.deepStrictEqual(state, payload);
+    assert.strictEqual(storage.getItem(legacyKey), null);
+  });
+
+  it('falls back to default on corrupted new key', () => {
+    const storage = makeStorage({ [newKey]: '{not-json' });
+    const state = loadPreviewState(talkId, videoSlug, storage);
+    assert.strictEqual(state.mode, 'marker');
+    assert.deepStrictEqual(state.markers, []);
+  });
+
+  it('coerces missing fields from partial new payload', () => {
+    const storage = makeStorage({
+      [newKey]: JSON.stringify({ mode: 'edit' }),
+    });
+    const state = loadPreviewState(talkId, videoSlug, storage);
+    assert.strictEqual(state.mode, 'edit');
+    assert.deepStrictEqual(state.markers, []);
+    assert.deepStrictEqual(state.edits, {});
+  });
+});
+
+describe('findActiveSubtitleIdx', () => {
+  const subs = [
+    { index: 1, startMs: 1000, endMs: 5000, text: 'First' },
+    { index: 2, startMs: 6000, endMs: 10000, text: 'Second' },
+  ];
+
+  it('returns 0 at start of first block', () => {
+    assert.strictEqual(findActiveSubtitleIdx(subs, 1000), 0);
+  });
+  it('returns 0 in middle of first block', () => {
+    assert.strictEqual(findActiveSubtitleIdx(subs, 3000), 0);
+  });
+  it('returns -1 at exact end (exclusive)', () => {
+    assert.strictEqual(findActiveSubtitleIdx(subs, 5000), -1);
+  });
+  it('returns -1 in gap between blocks', () => {
+    assert.strictEqual(findActiveSubtitleIdx(subs, 5500), -1);
+  });
+  it('returns 1 inside second block', () => {
+    assert.strictEqual(findActiveSubtitleIdx(subs, 7000), 1);
+  });
+  it('returns -1 before all', () => {
+    assert.strictEqual(findActiveSubtitleIdx(subs, 0), -1);
+  });
+  it('returns -1 after all', () => {
+    assert.strictEqual(findActiveSubtitleIdx(subs, 15000), -1);
+  });
+  it('handles empty array', () => {
+    assert.strictEqual(findActiveSubtitleIdx([], 1000), -1);
+  });
+});
+
+describe('applyEditsToSrt', () => {
+  const blocks = [
+    { index: 1, startMs: 1000, endMs: 5000, text: 'First' },
+    { index: 2, startMs: 6000, endMs: 10000, text: 'Second' },
+    { index: 3, startMs: 11000, endMs: 15000, text: 'Third' },
+  ];
+
+  it('empty edits rebuild identical SRT', () => {
+    const out = applyEditsToSrt(blocks, {});
+    const expected = [
+      '1',
+      '00:00:01,000 --> 00:00:05,000',
+      'First',
+      '',
+      '2',
+      '00:00:06,000 --> 00:00:10,000',
+      'Second',
+      '',
+      '3',
+      '00:00:11,000 --> 00:00:15,000',
+      'Third',
+      '',
+    ].join('\n');
+    assert.strictEqual(out, expected);
+  });
+
+  it('replaces one block text', () => {
+    const out = applyEditsToSrt(blocks, { 1: 'Перший' });
+    assert.match(out, /\n2\n00:00:06,000 --> 00:00:10,000\nПерший\n/);
+    // Other blocks untouched.
+    assert.match(out, /\nFirst\n/);
+    assert.match(out, /\nThird\n/);
+  });
+
+  it('replaces multiple blocks', () => {
+    const out = applyEditsToSrt(blocks, { 0: 'A', 2: 'C' });
+    const lines = out.split('\n');
+    assert.strictEqual(lines[2], 'A');
+    assert.strictEqual(lines[10], 'C');
+  });
+
+  it('preserves multiline edits', () => {
+    const out = applyEditsToSrt(blocks, { 0: 'Line 1\nLine 2' });
+    assert.ok(
+      out.startsWith('1\n00:00:01,000 --> 00:00:05,000\nLine 1\nLine 2\n'),
+      'expected multiline edit at block 0, got: ' + out.slice(0, 80),
+    );
+  });
+
+  it('ignores edits with indices outside block range', () => {
+    const out = applyEditsToSrt(blocks, { 99: 'ghost' });
+    assert.doesNotMatch(out, /ghost/);
+    // Result equals empty-edits case.
+    assert.strictEqual(out, applyEditsToSrt(blocks, {}));
+  });
+
+  it('edit equal to original is effectively a noop', () => {
+    const out = applyEditsToSrt(blocks, { 0: 'First' });
+    assert.strictEqual(out, applyEditsToSrt(blocks, {}));
+  });
+
+  it('returns empty string for empty blocks', () => {
+    assert.strictEqual(applyEditsToSrt([], {}), '');
+  });
+
+  it('keeps sequential numbering starting at 1', () => {
+    const out = applyEditsToSrt(blocks, {});
+    const lines = out.split('\n');
+    assert.strictEqual(lines[0], '1');
+    assert.strictEqual(lines[4], '2');
+    assert.strictEqual(lines[8], '3');
+  });
+});

--- a/tests/test_sync_player.py
+++ b/tests/test_sync_player.py
@@ -601,6 +601,61 @@ class TestReopenPreservesPlayhead:
         assert abs(current - 8) < 0.1, f"Player currentTime must be preserved after hide/show cycle, got {current}"
 
 
+class TestButtonResetOnVideoSwitch:
+    """Switching to another video must not leave the toggle button with
+    stale 'Hide video' text from the previous video, and the button must
+    be hidden outright when the new video has no playable source."""
+
+    def test_button_text_resets_to_show_on_video_switch(self, server, page):  # noqa: F811
+        _goto_review_srt(page, server)
+        page.click("#btn-sync-player")
+        page.wait_for_selector("#mock-player", state="visible", timeout=3000)
+        # Sanity: we're in "Hide video" state.
+        text_open = page.evaluate("document.getElementById('btn-sync-player').textContent")
+        assert "Hide" in text_open or "\u0421\u0445\u043e\u0432\u0430\u0442\u0438" in text_open
+
+        # Switch to second video — we have no saved state for Test-Video-2.
+        page.evaluate("SPA.switchReviewMode('srt', 'Test-Video-2')")
+        page.wait_for_timeout(300)
+
+        text_after = page.evaluate("document.getElementById('btn-sync-player').textContent")
+        assert "Show" in text_after or "\u041f\u043e\u043a\u0430\u0437" in text_after, (
+            f"expected show-text after video switch, got: {text_after!r}"
+        )
+
+    def test_button_hidden_when_target_video_has_no_vimeo_url(self, server, page, server_fixtures=None):  # noqa: F811
+        # Swap in a meta.yaml where Test-Video-2 has an empty vimeo_url so
+        # that init() must hide the button even in SRT mode.
+        page.route(
+            "**/raw.githubusercontent.com/**/meta.yaml",
+            lambda route: route.fulfill(
+                status=200,
+                content_type="text/plain",
+                body=(
+                    "title: 'Test Talk: Subtitle Preview'\n"
+                    "date: '2001-01-01'\n"
+                    "location: Test Location\n"
+                    "videos:\n"
+                    "- slug: Test-Video\n"
+                    "  title: Test Video\n"
+                    "  vimeo_url: https://vimeo.com/12345/abc\n"
+                    "- slug: Test-Video-2\n"
+                    "  title: Test Video 2\n"
+                    "  vimeo_url: ''\n"
+                ),
+            ),
+        )
+        _goto_review_srt(page, server)
+        page.click("#btn-sync-player")
+        page.wait_for_selector("#mock-player", state="visible", timeout=3000)
+
+        page.evaluate("SPA.switchReviewMode('srt', 'Test-Video-2')")
+        page.wait_for_timeout(300)
+        assert not page.locator("#btn-sync-player").is_visible(), (
+            "button must hide when switching to a video without a playable source"
+        )
+
+
 class TestPersistAcrossNavigation:
     """State (open flag + playback position + bar height) must survive
     leaving the review view and coming back. Before the fix, destroy()

--- a/tests/test_sync_player.py
+++ b/tests/test_sync_player.py
@@ -601,6 +601,36 @@ class TestReopenPreservesPlayhead:
         assert abs(current - 8) < 0.1, f"Player currentTime must be preserved after hide/show cycle, got {current}"
 
 
+class TestPersistAcrossNavigation:
+    """State (open flag + playback position + bar height) must survive
+    leaving the review view and coming back. Before the fix, destroy()
+    called hide() which rewrote localStorage with open:false on every
+    route leave, stranding the user at a closed player on return."""
+
+    def test_open_and_playhead_survive_navigation_to_index(self, server, page):  # noqa: F811
+        _goto_review_srt(page, server)
+        page.click("#btn-sync-player")
+        page.wait_for_selector("#mock-player", state="visible", timeout=3000)
+        page.evaluate("window._vimeoPlayer._setTime(9)")
+        page.wait_for_timeout(1100)  # allow throttled persist
+        # Leave to index — this triggers route-level SyncPlayer.destroy().
+        page.evaluate("location.hash = '#/'")
+        page.wait_for_selector(".talk-item", timeout=5000)
+        # localStorage should still report open:true and a lastTime near 9s.
+        saved = page.evaluate("JSON.parse(localStorage.getItem('sy.sync_player.2001-01-01_Test-Talk.Test-Video'))")
+        assert saved is not None
+        assert saved["open"] is True, f"expected open:true after navigating away, got {saved}"
+        assert saved["lastTime"] >= 8500, f"expected lastTime near 9000ms, got {saved}"
+
+        # Come back — the bar must auto-open and the mock player must
+        # seek back to the saved position.
+        _goto_review_srt(page, server)
+        page.wait_for_selector("#sync-player-bar:not([hidden])", timeout=3000)
+        page.wait_for_selector("#mock-player", state="visible", timeout=3000)
+        current = page.evaluate("window._vimeoPlayer._currentTime")
+        assert abs(current - 9) < 0.5, f"expected playhead near 9s, got {current}"
+
+
 class TestPersistClosed:
     def test_closed_state_survives_reload(self, server, page):  # noqa: F811
         """After closing the player and reloading, the bar must remain hidden."""

--- a/tools/preview_srt_parser.js
+++ b/tools/preview_srt_parser.js
@@ -43,6 +43,20 @@ function findActiveSubtitle(subtitles, currentTimeMs) {
   return null;
 }
 
+function findActiveSubtitleIdx(subtitles, currentTimeMs) {
+  for (var i = 0; i < subtitles.length; i++) {
+    if (currentTimeMs >= subtitles[i].startMs && currentTimeMs < subtitles[i].endMs) {
+      return i;
+    }
+  }
+  return -1;
+}
+
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { timeToMs: timeToMs, parseSRT: parseSRT, findActiveSubtitle: findActiveSubtitle };
+  module.exports = {
+    timeToMs: timeToMs,
+    parseSRT: parseSRT,
+    findActiveSubtitle: findActiveSubtitle,
+    findActiveSubtitleIdx: findActiveSubtitleIdx,
+  };
 }

--- a/tools/preview_state.js
+++ b/tools/preview_state.js
@@ -1,10 +1,5 @@
-// Preview page state: marker mode / edit mode persistence,
-// legacy migration, and SRT rebuild from edits.
-//
-// Keep this file pure (no DOM, no localStorage references) and mirror
-// its logic inline in site/index.html where the SPA actually runs. The
-// Node test suite (tests/test_preview_state.js) exercises this file
-// directly.
+// Pure helpers for preview-page marker/edit state. Mirrored inline
+// into site/index.html; the browser runs the copy there.
 
 function defaultPreviewState() {
   return { mode: 'marker', markers: [], edits: {} };
@@ -18,9 +13,6 @@ function legacyKeyFor(talkId, videoSlug) {
   return 'markers_preview_' + talkId + '_' + videoSlug;
 }
 
-// Normalize an arbitrary parsed payload into the canonical preview
-// state shape. Missing fields fall back to defaults; invalid types are
-// discarded to prevent a corrupt entry from poisoning the UI.
 function coerceState(raw) {
   var out = defaultPreviewState();
   if (!raw || typeof raw !== 'object') return out;
@@ -32,10 +24,8 @@ function coerceState(raw) {
   return out;
 }
 
-// Load preview state for a video from a storage adapter that matches
-// the localStorage surface (getItem/setItem/removeItem). Migrates the
-// legacy markers_preview_* key if only the legacy key is present, and
-// always drops the legacy key once a new key is in place.
+// Legacy markers_preview_* key is migrated on first read and then
+// removed unconditionally once the new key exists.
 function loadPreviewState(talkId, videoSlug, storage) {
   var newKey = newKeyFor(talkId, videoSlug);
   var legacyKey = legacyKeyFor(talkId, videoSlug);
@@ -72,7 +62,6 @@ function loadPreviewState(talkId, videoSlug, storage) {
   return defaultPreviewState();
 }
 
-// Format an ms integer into an SRT "HH:MM:SS,mmm" timestamp.
 function msToSrtTime(ms) {
   var h = Math.floor(ms / 3600000);
   var m = Math.floor((ms % 3600000) / 60000);
@@ -89,9 +78,6 @@ function msToSrtTime(ms) {
   );
 }
 
-// Rebuild a valid SRT from parsed blocks, substituting text from
-// `edits` (keyed by 0-based block index) where present. Returns the
-// empty string for empty block input.
 function applyEditsToSrt(blocks, edits) {
   if (!blocks || !blocks.length) return '';
   var e = edits || {};

--- a/tools/preview_state.js
+++ b/tools/preview_state.js
@@ -1,0 +1,117 @@
+// Preview page state: marker mode / edit mode persistence,
+// legacy migration, and SRT rebuild from edits.
+//
+// Keep this file pure (no DOM, no localStorage references) and mirror
+// its logic inline in site/index.html where the SPA actually runs. The
+// Node test suite (tests/test_preview_state.js) exercises this file
+// directly.
+
+function defaultPreviewState() {
+  return { mode: 'marker', markers: [], edits: {} };
+}
+
+function newKeyFor(talkId, videoSlug) {
+  return 'preview_' + talkId + '_' + videoSlug;
+}
+
+function legacyKeyFor(talkId, videoSlug) {
+  return 'markers_preview_' + talkId + '_' + videoSlug;
+}
+
+// Normalize an arbitrary parsed payload into the canonical preview
+// state shape. Missing fields fall back to defaults; invalid types are
+// discarded to prevent a corrupt entry from poisoning the UI.
+function coerceState(raw) {
+  var out = defaultPreviewState();
+  if (!raw || typeof raw !== 'object') return out;
+  if (raw.mode === 'edit' || raw.mode === 'marker') out.mode = raw.mode;
+  if (Array.isArray(raw.markers)) out.markers = raw.markers;
+  if (raw.edits && typeof raw.edits === 'object' && !Array.isArray(raw.edits)) {
+    out.edits = raw.edits;
+  }
+  return out;
+}
+
+// Load preview state for a video from a storage adapter that matches
+// the localStorage surface (getItem/setItem/removeItem). Migrates the
+// legacy markers_preview_* key if only the legacy key is present, and
+// always drops the legacy key once a new key is in place.
+function loadPreviewState(talkId, videoSlug, storage) {
+  var newKey = newKeyFor(talkId, videoSlug);
+  var legacyKey = legacyKeyFor(talkId, videoSlug);
+  var rawNew = storage.getItem(newKey);
+
+  if (rawNew != null) {
+    var parsed;
+    try {
+      parsed = JSON.parse(rawNew);
+    } catch (_) {
+      parsed = null;
+    }
+    // New key is authoritative — legacy is stale garbage if still around.
+    if (storage.getItem(legacyKey) != null) storage.removeItem(legacyKey);
+    return coerceState(parsed);
+  }
+
+  var rawLegacy = storage.getItem(legacyKey);
+  if (rawLegacy != null) {
+    var legacyMarkers;
+    try {
+      legacyMarkers = JSON.parse(rawLegacy);
+    } catch (_) {
+      legacyMarkers = [];
+    }
+    if (!Array.isArray(legacyMarkers)) legacyMarkers = [];
+    var migrated = defaultPreviewState();
+    migrated.markers = legacyMarkers;
+    storage.setItem(newKey, JSON.stringify(migrated));
+    storage.removeItem(legacyKey);
+    return migrated;
+  }
+
+  return defaultPreviewState();
+}
+
+// Format an ms integer into an SRT "HH:MM:SS,mmm" timestamp.
+function msToSrtTime(ms) {
+  var h = Math.floor(ms / 3600000);
+  var m = Math.floor((ms % 3600000) / 60000);
+  var s = Math.floor((ms % 60000) / 1000);
+  var mmm = ms % 1000;
+  return (
+    String(h).padStart(2, '0') +
+    ':' +
+    String(m).padStart(2, '0') +
+    ':' +
+    String(s).padStart(2, '0') +
+    ',' +
+    String(mmm).padStart(3, '0')
+  );
+}
+
+// Rebuild a valid SRT from parsed blocks, substituting text from
+// `edits` (keyed by 0-based block index) where present. Returns the
+// empty string for empty block input.
+function applyEditsToSrt(blocks, edits) {
+  if (!blocks || !blocks.length) return '';
+  var e = edits || {};
+  var lines = [];
+  for (var i = 0; i < blocks.length; i++) {
+    var b = blocks[i];
+    var text = Object.prototype.hasOwnProperty.call(e, i) ? e[i] : b.text;
+    lines.push(String(i + 1));
+    lines.push(msToSrtTime(b.startMs) + ' --> ' + msToSrtTime(b.endMs));
+    lines.push(text);
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    defaultPreviewState: defaultPreviewState,
+    loadPreviewState: loadPreviewState,
+    applyEditsToSrt: applyEditsToSrt,
+    msToSrtTime: msToSrtTime,
+  };
+}


### PR DESCRIPTION
## Summary

Preview page gains a second mode. Existing marker flow stays as-is; a new **edit mode** lets reviewers rewrite individual SRT block text while watching the video and ship the result as an issue or via the GitHub web editor — matching how the review page works today.

Multi-video talks on the index now show a single "▶ Переглянути переклад" entry; inside the preview a header dropdown switches between videos.

## UI changes

- `.header` + `.header-actions` on preview, matching review page:
  - Segmented control `[📌 Markers | ✎ Edit]`
  - Marker mode: `Copy all`, `Create issue`, `Clear all`
  - Edit mode: `Create issue`, `Open in GitHub Editor`, `Clear all`
  - `Clear all` hidden unless the active mode has entries
- Player `.controls` keeps time/lang/fullscreen; the Mark/Edit button stays under the video and changes label per mode.
- List container renamed `.preview-list`, body swaps between `marker-list` and `edit-list`.
- New `#preview-video-select` next to `<h1>` for multi-video talks.

## State

`localStorage['preview_<talkId>_<videoSlug>']`:

\`\`\`json
{
  "mode": "marker" | "edit",
  "markers": [ { "time": 12.3, "tc": "00:00:12", "text": "…", "comment": "" } ],
  "edits": { "uk": { "0": "…" } }
}
\`\`\`

- One-shot migration of legacy `markers_preview_<…>` key on first load.
- Per-video, per-language; markers stay language-independent.

## Edit behavior

- Pressing Edit pauses the video, adds or focuses a row for the currently-active SRT block, and drops the cursor in a contenteditable initialized with the original text.
- Enter (no Shift) blurs and resumes playback; arrow keys seek when focus is outside a contenteditable.
- Resetting a row back to its original text removes it from `edits`.
- `Clear all` in edit mode clears **only** the current language's edits.
- `Open in GitHub Editor` rebuilds the SRT with edits applied, copies it to clipboard, then opens the GitHub `/edit/` URL — same mechanism as `SPA.openEditor` on the review page.

## Tests

- **Node unit tests** (`tests/test_preview_state.js`, new): 24 cases covering `defaultPreviewState`, `loadPreviewState` (new/legacy/both/corrupt/partial), `findActiveSubtitleIdx`, `applyEditsToSrt`.
- **Playwright** (`tests/test_preview_spa.py`): 20 new tests covering defaults, legacy migration, layout, video switcher, edit add/focus/persist/enter/delete/clear.
- Four existing marker tests updated to read the new key shape.
- `test_both_videos_have_preview` replaced with `test_single_preview_link_for_multi_video`.
- `#view-preview.fs-mode` now hides both `.markers` and `.preview-list`.

All 196 tests in `test_preview_spa.py` pass locally. Node suites pass.

## Test plan

- [ ] Open http://localhost:8000/ and inspect:
  - [ ] Index card shows a single "▶ Переглянути переклад" entry per talk
  - [ ] Preview header has segmented control and action buttons
  - [ ] Default mode is Markers; creating a marker shows Clear all
  - [ ] Switching to Edit swaps buttons, the list, and the under-video Mark/Edit button label
  - [ ] Edit button adds a row for the active subtitle block, pauses, focuses cursor
  - [ ] Enter in the edit row resumes playback; arrow keys seek when the row is blurred
  - [ ] Edits persist across reload; switching videos loads that video's state
  - [ ] \`Open in GitHub Editor\` copies the rebuilt SRT and opens GitHub's edit page
- [ ] \`python -m pytest tests/test_preview_spa.py -q\` green
- [ ] \`node --test tests/test_preview_state.js tests/test_preview_srt_parser.js\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)