### PR TITLE
fix(transcript): strip bracketed stage directions from loader

### DIFF
--- a/tests/test_golden_talks.py
+++ b/tests/test_golden_talks.py
@@ -67,6 +67,7 @@ KNOWN_BROKEN_VALIDATION: dict[str, str] = {
     "1982-07-11_From-Heart-To-Sahastrar-Derby/From-Heart-to-Sahasrara": "text preservation drift",
     "1983-03-30_Celebration-Of-Birthday-In-Bombay/Birthday-Puja-English-Talk": "text preservation drift",
     "1984-03-22_Birthday-Puja/Birthday-Puja-Be-Sweet": "duration > 21s",
+    "1984-03-22_Birthday-Puja/Birthday-Puja-Talk-Be-Sweet": "legacy SRT contains stripped stage directions; rebuild via pipeline",
 }
 
 KNOWN_NON_IDEMPOTENT: dict[str, str] = {
@@ -81,6 +82,7 @@ KNOWN_NON_IDEMPOTENT: dict[str, str] = {
     "1982-07-11_From-Heart-To-Sahastrar-Derby/From-Heart-to-Sahasrara": "text preservation drift",
     "1983-03-30_Celebration-Of-Birthday-In-Bombay/Birthday-Puja-English-Talk": "text preservation drift",
     "1984-03-22_Birthday-Puja/Birthday-Puja-Be-Sweet": "high CPS from merged stage-direction blocks; fixed by opus-single-pass rebuild",
+    "1984-03-22_Birthday-Puja/Birthday-Puja-Talk-Be-Sweet": "legacy SRT contains stripped stage directions; rebuild via pipeline",
 }
 
 

--- a/tests/test_text_segmentation.py
+++ b/tests/test_text_segmentation.py
@@ -172,3 +172,44 @@ def test_build_blocks_normalizes_embedded_newlines() -> None:
     assert "Промова англійською" in combined
     assert "Переклад з маратхі" in combined
     assert "Перший бхаджан" in combined
+
+
+def test_load_transcript_strips_bracketed_stage_directions(tmp_path: Path) -> None:
+    """Standalone bracket-only lines are editorial metadata, not subtitles."""
+    f = tmp_path / "transcript.txt"
+    f.write_text(
+        "Мова промови: англійська | Транскрипт\n"
+        "\n"
+        "[Промова англійською]\n"
+        "[Переклад з маратхі на англійську]\n"
+        "Перший бхаджан було заспівано.\n"
+        "[Промова англійською]\n"
+        "\n"
+        "Багато людей запитували Мене.\n",
+        encoding="utf-8",
+    )
+    paras = load_transcript(str(f))
+    # Stage-direction-only lines gone; content preserved.
+    assert paras == ["Перший бхаджан було заспівано.", "Багато людей запитували Мене."]
+
+
+def test_load_transcript_preserves_inline_brackets(tmp_path: Path) -> None:
+    """Bracketed text inside a sentence is translator clarification — keep."""
+    f = tmp_path / "transcript.txt"
+    f.write_text(
+        "Мова: англійська\n\nШрі Матаджі [в Лондоні] сказала наступне.\n",
+        encoding="utf-8",
+    )
+    paras = load_transcript(str(f))
+    assert paras == ["Шрі Матаджі [в Лондоні] сказала наступне."]
+
+
+def test_load_transcript_strips_multilingual_stage_direction_patterns(tmp_path: Path) -> None:
+    """Works for both UK and EN transcripts — same editorial convention."""
+    f = tmp_path / "transcript.txt"
+    f.write_text(
+        "Language: English\n\n[English Talk]\n[Marathi to English translation]\nFirst Bhajan was sung.\n[Music]\n",
+        encoding="utf-8",
+    )
+    paras = load_transcript(str(f))
+    assert paras == ["First Bhajan was sung."]

--- a/tools/text_segmentation.py
+++ b/tools/text_segmentation.py
@@ -47,6 +47,20 @@ def load_transcript(path: str) -> list[str]:
 
     body = "\n".join(lines[body_start:])
 
+    # Drop editorial stage-direction lines — a line that is *entirely* bracketed
+    # (e.g. "[Промова англійською]", "[Marathi to English translation]", "[Музика]")
+    # is metadata for the human reader describing what is happening in the
+    # audio; it has no counterpart in en.srt and must not appear as a subtitle.
+    # Inline bracketed content inside a sentence is left alone — translator
+    # clarifications belong in square brackets (see feedback_translation_brackets).
+    body_lines = []
+    for ln in body.split("\n"):
+        stripped = ln.strip()
+        if stripped and re.fullmatch(r"\[[^\[\]]+\]", stripped):
+            continue
+        body_lines.append(ln)
+    body = "\n".join(body_lines)
+
     if "\n\n" in body:
         paragraphs = [p.strip() for p in re.split(r"\n\n+", body) if p.strip()]
     else:


### PR DESCRIPTION
## Summary
- Drop standalone `^\[…\]$` lines from `transcript_en.txt` / `transcript_uk.txt` before paragraph splitting — they are editorial audio descriptions (e.g. `[Промова англійською]`, `[Marathi to English translation]`, `[Музика]`, `[Music]`) and have no counterpart in `en.srt`, so must not appear as subtitle text.
- Inline bracketed text inside a sentence (translator clarifications per `feedback_translation_brackets.md`) is preserved.
- Added new cases to `tests/test_text_segmentation.py`: strips stage directions, preserves inline brackets, handles both UK and EN conventions.
- Xfailed `1984-03-22_Birthday-Puja/Birthday-Puja-Talk-Be-Sweet` in `KNOWN_BROKEN_VALIDATION` + `KNOWN_NON_IDEMPOTENT` — its legacy uk.srt still contains the stripped directions; will clear after a pipeline rebuild.

## Test plan
- [x] `python -m pytest tests/test_text_segmentation.py` — 26/26 pass (3 new cases)
- [x] `python -m pytest tests/test_golden_talks.py` — 29 passed, 16 xfailed (matches new xfail entries)
- [ ] After merge: trigger `subtitle-pipeline.yml` for `1984-03-22_Birthday-Puja` to rebuild secondary SRT and drop the xfail entries in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)