### PR TITLE
fix(validate): use load_transcript for text preservation check

### DIFF
--- a/tests/test_golden_talks.py
+++ b/tests/test_golden_talks.py
@@ -76,6 +76,7 @@ KNOWN_NON_IDEMPOTENT: dict[str, str] = {
     # pass drifts differently. These overlap with KNOWN_BROKEN_VALIDATION
     # entries where the drift is in text preservation, not duration (the
     # duration-only talks now pass because the test uses skip_duration_check).
+    "1979-02-25_Puja-In-Pune-Marathi/Mahashivaratri-Puja": "legacy SRT still contains stage-direction-only blocks that validate now strips from the transcript",
     "1979-12-10_Christmas-And-Its-Relationship-To-Lord-Jesus-1979-2/The-Incarnation-Of-Christ": "text preservation drift",
     "1980-03-23_Birthday-Puja/Birthday-Puja": "text preservation drift",
     "1981-03-21_Birthday-Puja-1981-Sydney/Birthday-Puja-Talk": "text preservation drift",

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -178,6 +178,41 @@ def test_text_preservation_with_header(tmp_path):
     assert result is True
 
 
+def test_text_preservation_ignores_stage_direction_lines(tmp_path):
+    """`^\\[…\\]$` editorial lines in the transcript must not cause a mismatch.
+
+    The builder strips them via `load_transcript`; the SRT therefore never
+    contains them. Validation must apply the same rule so transcript and
+    SRT round-trip cleanly. Regression guard for the `check_text_preservation`
+    + `load_transcript` contract.
+    """
+    srt_file = tmp_path / "uk.srt"
+    transcript_file = tmp_path / "transcript.txt"
+
+    _write_srt(
+        srt_file,
+        [
+            (1, "00:00:01,000", "00:00:03,000", "Перший бхаджан заспівано."),
+            (2, "00:00:03,500", "00:00:06,000", "Багато людей запитували Мене."),
+        ],
+    )
+    _write_transcript(
+        transcript_file,
+        "Мова промови: англійська\n\n"
+        "[Промова англійською]\n"
+        "Перший бхаджан заспівано.\n"
+        "[Переклад з маратхі на англійську]\n"
+        "Багато людей запитували Мене.\n"
+        "[Музика]\n",
+    )
+
+    from tools.srt_utils import parse_srt
+
+    blocks = parse_srt(str(srt_file))
+    report = []
+    assert check_text_preservation(blocks, str(transcript_file), report) is True
+
+
 # ---------------------------------------------------------------------------
 #  CHECK 2: Overlap detection
 # ---------------------------------------------------------------------------

--- a/tools/validate_subtitles.py
+++ b/tools/validate_subtitles.py
@@ -26,6 +26,7 @@ from .srt_utils import (
     ms_to_time,
     parse_srt,
 )
+from .text_segmentation import load_transcript
 
 AnchorLabel = Literal["EN SRT", "whisper"]
 
@@ -85,9 +86,15 @@ def extract_words(text):
 
 
 def check_text_preservation(srt_blocks, transcript_path, report):
-    """Check that all transcript text appears in SRT and vice versa."""
-    with open(transcript_path, encoding="utf-8") as f:
-        transcript_text = strip_header(f.read())
+    """Check that all transcript text appears in SRT and vice versa.
+
+    Reads the transcript via `load_transcript` so that editorial metadata
+    (header lines and `^\\[…\\]$` stage-direction lines like
+    `[Промова англійською]`) is stripped consistently with the builder's
+    view. Without this, the SRT — which never contains those lines — would
+    always mismatch the raw transcript.
+    """
+    transcript_text = " ".join(load_transcript(transcript_path))
 
     srt_text = " ".join(b["text"] for b in srt_blocks)
 


### PR DESCRIPTION
## Summary
Hotfix for a regression introduced by PR #107. The builder now strips `^\[…\]$` stage-direction lines from transcripts via `tools.text_segmentation.load_transcript`, but `tools.validate_subtitles.check_text_preservation` still read the transcript raw — so every freshly-built SRT (which correctly doesn't contain those lines) fails text preservation against the raw transcript (which still does).

Pipeline run [24791600355](https://github.com/SlavaSubotskiy/sy-subtitles/actions/runs/24791600355) for `1983-03-30_Celebration-Of-Birthday-In-Bombay` failed exactly there.

### Fix
`check_text_preservation` now reads the transcript through `load_transcript`, which already handles both header stripping and stage-direction filtering. Single source of truth for what counts as subtitle content.

### Xfail side-effect
Legacy `uk.srt` files built before PR #107 still contain stage-direction-only subtitle blocks. Those now diverge against a stripped transcript. Only one previously-passing test trips on this: `test_optimize_idempotent_on_shipped[1979-02-25_Puja-In-Pune-Marathi/Mahashivaratri-Puja]`. Added it to `KNOWN_NON_IDEMPOTENT` with reason — will clear after a fresh pipeline rebuild.

### Follow-up (non-blocking)
`tools/sync_srt_to_transcript.py` and `tools/download.py` also read transcripts raw, but neither does a text equality comparison — both are correct as-is. No further hotfixes needed.

## Test plan
- [x] `pytest tests/test_validate.py` — 50 passed, including the new regression test
- [x] `pytest tests/test_text_segmentation.py tests/test_golden_talks.py` — 104 passed, 17 xfailed (matches the new xfail entry)
- [x] Downloaded `subtitles__1983-03-30_...` artifact from the failing run and re-validated locally with the fix → all checks PASS
- [ ] After merge: re-trigger `subtitle-pipeline.yml` for `1983-03-30_Celebration-Of-Birthday-In-Bombay`; expect green

🤖 Generated with [Claude Code](https://claude.com/claude-code)