### PR TITLE
test(golden): drop stale xfail for 1984-03-22 Birthday-Puja-Be-Sweet idempotency

### DIFF
--- a/tests/test_golden_talks.py
+++ b/tests/test_golden_talks.py
@@ -82,7 +82,6 @@ KNOWN_NON_IDEMPOTENT: dict[str, str] = {
     "1981-03-21_Birthday-Puja-1981-Sydney/Birthday-Puja-Talk": "text preservation drift",
     "1982-07-11_From-Heart-To-Sahastrar-Derby/From-Heart-to-Sahasrara": "text preservation drift",
     "1983-03-30_Celebration-Of-Birthday-In-Bombay/Birthday-Puja-English-Talk": "text preservation drift",
-    "1984-03-22_Birthday-Puja/Birthday-Puja-Be-Sweet": "high CPS from merged stage-direction blocks; fixed by opus-single-pass rebuild",
     "1984-03-22_Birthday-Puja/Birthday-Puja-Talk-Be-Sweet": "legacy SRT contains stripped stage directions; rebuild via pipeline",
 }
 


### PR DESCRIPTION
## Summary
The Opus single-pass rebuild predicted in the original xfail reason landed via pipeline run [24795358675](https://github.com/SlavaSubotskiy/sy-subtitles/actions/runs/24795358675) (merged as #111). `test_optimize_idempotent_on_shipped[1984-03-22_Birthday-Puja/Birthday-Puja-Be-Sweet]` now passes, so strict xfail flips it to `XPASS → FAILED`. Removing the entry.

The sibling `1984-03-22_Birthday-Puja/Birthday-Puja-Talk-Be-Sweet` stays xfail'd — its shipped SRT still diverges from the transcript for reasons unrelated to stage directions (secondary video starts mid-talk against a whole-talk transcript).

## Test plan
- [x] `pytest tests/test_golden_talks.py` — 29 passed, 16 xfailed (no XPASS-strict failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)