### PR TITLE
simplify (followups): cache subs-px write, drop bump-narrating comments

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -900,13 +900,9 @@ body.preview-subs-resize-active-body * { cursor: ns-resize !important; user-sele
   max-height: 60vh;
   overflow: hidden;
 }
-/* Fullscreen mirrors the embedded resize handle: the user's drag scales
-   the original viewport-based font BIDIRECTIONALLY. The handle sits below
-   the overlay, so dragging it DOWN grows the block (and fs); dragging UP
-   shrinks it. 22vh cap stops two lines from being pushed off-screen at
-   the high end; 20px floor stops the low end from becoming unreadable.
-   --preview-subs-scale is set by JS as a unitless number; if absent
-   (no drag yet), the fallback 1 keeps the original baseline. */
+/* Fullscreen mirrors the embedded resize handle: --preview-subs-scale is
+   set by JS as a unitless number; if absent (no drag yet) the fallback 1
+   keeps the original baseline. */
 #view-preview.fs-mode[data-subs-tuned="1"] #subtitle-overlay {
   font-size: clamp(
     20px,
@@ -1160,8 +1156,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 
   const clamp = (min, v, max) => Math.max(min, Math.min(max, v));
 
-  // Custom-property names referenced in JS; hoisted so a typo can't drift
-  // between writers and readers.
+  const CSS_PLAYER_H = '--preview-player-h';
   const CSS_SUBS_H = '--preview-subs-h';
   const CSS_SUBS_SCALE = '--preview-subs-scale';
 
@@ -1176,13 +1171,14 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   }
   function saveNum(k, v) { try { localStorage.setItem(k, String(v)); } catch(_){} }
 
-  function applyPlayerVh(v) { document.documentElement.style.setProperty('--preview-player-h', v + 'vh'); }
+  function applyPlayerVh(v) { document.documentElement.style.setProperty(CSS_PLAYER_H, v + 'vh'); }
   // Scale bounds for fs-mode. Floor 0.5× / ceiling 4× of the viewport-based
   // baseline keep fullscreen readable across the handle's full range
   // without being clipped by the 22vh hard cap on tall screens. 120px is
   // the embedded default → scale 1.0.
   const PREVIEW_SUBS_SCALE_MIN = 0.5;
   const PREVIEW_SUBS_SCALE_MAX = 4;
+  let _lastSubsH = NaN, _lastSubsScale = NaN;
   function applySubsPx(v) {
     // Reject non-finite input: writing "NaNpx" silently re-creates the
     // "tiny on fullscreen" bug because CSS drops the property and the
@@ -1192,11 +1188,13 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       return;
     }
     const root = document.documentElement.style;
-    root.setProperty(CSS_SUBS_H, v + 'px');
-    root.setProperty(CSS_SUBS_SCALE,
-                     String(clamp(PREVIEW_SUBS_SCALE_MIN, v / PREVIEW_SUBS_DEF_PX, PREVIEW_SUBS_SCALE_MAX)));
+    const scale = clamp(PREVIEW_SUBS_SCALE_MIN, v / PREVIEW_SUBS_DEF_PX, PREVIEW_SUBS_SCALE_MAX);
+    // Skip cascade work on no-op drag pixels — at the clamp boundaries
+    // (e.g. h ≥ 480) every mousemove would rewrite the same scale value.
+    if (v !== _lastSubsH) { root.setProperty(CSS_SUBS_H, v + 'px'); _lastSubsH = v; }
+    if (scale !== _lastSubsScale) { root.setProperty(CSS_SUBS_SCALE, String(scale)); _lastSubsScale = scale; }
     const vp = document.getElementById('view-preview');
-    if (vp) vp.setAttribute('data-subs-tuned', '1');
+    if (vp && vp.getAttribute('data-subs-tuned') !== '1') vp.setAttribute('data-subs-tuned', '1');
   }
 
   // The max useful subtitle height is whatever lets the font grow to the
@@ -1308,6 +1306,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
         onReset: () => {
           document.documentElement.style.removeProperty(CSS_SUBS_H);
           document.documentElement.style.removeProperty(CSS_SUBS_SCALE);
+          _lastSubsH = NaN; _lastSubsScale = NaN;
           const vp = document.getElementById('view-preview');
           if (vp) vp.removeAttribute('data-subs-tuned');
           try { localStorage.removeItem(keySubs()); } catch(_){}
@@ -1328,6 +1327,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       const vp = document.getElementById('view-preview');
       if (vp) vp.removeAttribute('data-subs-tuned');
       document.documentElement.style.removeProperty(CSS_SUBS_SCALE);
+      _lastSubsH = NaN; _lastSubsScale = NaN;
     }
 
     // Measure the view header + freshness bar so the sticky top offset is

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -4462,18 +4462,17 @@ class TestClipboardCopyDialog:
 
 
 class TestSubtitleOverlaySize:
-    """Subtitle overlay resize ceiling — guards the +50% bump from drifting back."""
+    """Subtitle overlay font sizing: width-bound formula, fs-mode baseline,
+    and the bidirectional handle→fs-mode mirror."""
 
     def _goto_preview(self, server, page):
         page.set_viewport_size({"width": 1600, "height": 900})
         goto_spa(page, server, "#/preview/2001-01-01_Test-Talk/Test-Video")
         page.wait_for_selector("#mock-player", state="visible", timeout=10000)
-        page.wait_for_timeout(500)
 
-    def test_width_term_widened_by_50pct(self, server, page):
-        """The +50% bump widens the char-width divisor (23 → 15.3). On a
-        wide enough container the width-bound font should be ~1.5× what the
-        old formula would have produced for the same container."""
+    def test_width_bound_uses_15_3_divisor(self, server, page):
+        """The width-bound font is `(cqw - 48px) / 15.3`. On a wide enough
+        container the realized font must hit that bound (within rounding)."""
         self._goto_preview(server, page)
         result = page.evaluate(
             """() => {
@@ -4489,14 +4488,9 @@ class TestSubtitleOverlaySize:
               };
             }"""
         )
-        old_width_bound = (result["cqw"] - 48) / 23
-        new_width_bound = (result["cqw"] - 48) / 15.3
-        assert result["font"] > old_width_bound + 5, (
-            f"Font {result['font']}px should beat the old /23 width-bound "
-            f"≈{old_width_bound:.1f}px (cqw={result['cqw']}px)"
-        )
-        assert result["font"] >= new_width_bound - 1, (
-            f"Font {result['font']}px should reach the new /15.3 width-bound ≈{new_width_bound:.1f}px"
+        width_bound = (result["cqw"] - 48) / 15.3
+        assert result["font"] >= width_bound - 1, (
+            f"Font {result['font']}px should reach the /15.3 width-bound ≈{width_bound:.1f}px (cqw={result['cqw']}px)"
         )
 
     def test_min_handle_height_keeps_floor(self, server, page):
@@ -4542,14 +4536,13 @@ class TestSubtitleOverlaySize:
             f"Fullscreen font should grow with subs handle, got small={result['small']}px big={result['big']}px"
         )
 
-    # The fs-mode no-drag baseline is clamp(28px, 4vw, 80px) — the original
-    # rule the user wants restored. On a 1600px viewport that's min(80, 64)
-    # = 64px. Use 56px (~12% safety margin) for stable baseline asserts and
-    # 30px as a "definitely tiny" floor for regression checks.
+    # fs-mode no-drag baseline = clamp(28px, 4vw, 80px). On a 1600px
+    # viewport that's min(80, 64) = 64px; FLOOR_PX leaves ~12% rounding
+    # slack. TINY_PX catches regressions to the embedded base 32px font.
     FS_MODE_BASELINE_PX = 64
     FS_MODE_BASELINE_FLOOR_PX = 56
     FS_MODE_TINY_PX = 30
-    FS_MODE_FLOOR_PX = 20  # Hard floor in CSS so even drag-down stays readable.
+    FS_MODE_FLOOR_PX = 20  # CSS hard floor: drag-down must stay readable.
 
     # Single source of truth for the test-side mirror of applySubsPx — used
     # by every "set the handle to h, read the resulting font" probe so a
@@ -4583,21 +4576,19 @@ class TestSubtitleOverlaySize:
             {"h": drag_to_h},
         )
 
-    def test_fs_mode_default_matches_original_size(self, server, page):
-        """Entering fullscreen WITHOUT having dragged must give the original
-        clamp(28px, 4vw, 80px) — neither huge (post-bump regression) nor
-        tiny (cascade-fallback bug)."""
+    def test_fs_mode_default_matches_baseline(self, server, page):
+        """Entering fullscreen WITHOUT having dragged must give the
+        un-tuned baseline `clamp(28px, 4vw, 80px)` — not tiny
+        (cascade-fallback bug) and not oversize."""
         self._goto_preview(server, page)
         font_px = self._read_fs_font_px_via_toggle(page, drag_to_h=None)
         assert font_px >= self.FS_MODE_BASELINE_FLOOR_PX, (
             f"fs-mode default font shrank to {font_px}px — expected ≈ "
             f"{self.FS_MODE_BASELINE_PX}px (4vw on 1600 viewport)"
         )
-        # Sanity ceiling: should NOT be the old "huge" 6vw bump on this size.
-        assert font_px <= 90, (
-            f"fs-mode default {font_px}px is too big — should be the original "
-            f"clamp(28, 4vw, 80) ≈ 64px on 1600vw, not the bumped 6vw size"
-        )
+        # Ceiling for the baseline rule clamp(28, 4vw, 80) on a 1600px
+        # viewport is 80px; allow 10px slack for rounding/scrollbars.
+        assert font_px <= 90, f"fs-mode default {font_px}px exceeds the 80px ceiling of clamp(28, 4vw, 80)"
 
     def test_fs_mode_smaller_block_shrinks_proportionally(self, server, page):
         """A smaller embedded subtitle block (handle dragged UP — the handle
@@ -4802,11 +4793,10 @@ class TestSubtitleOverlaySize:
         """The 22vh hard cap must pin the fs-mode font on a short viewport
         even with the handle dragged to its largest position. Without the
         cap, two-line subtitles get pushed off-screen."""
-        # Use a deliberately short viewport so 22vh < 6vw * scale.
+        # Use a deliberately short viewport so 22vh < 4vw * scale_max.
         page.set_viewport_size({"width": 1600, "height": 400})
         goto_spa(page, server, "#/preview/2001-01-01_Test-Talk/Test-Video")
         page.wait_for_selector("#mock-player", state="visible", timeout=10000)
-        page.wait_for_timeout(400)
         font_px = self._read_fs_font_px_via_toggle(page, drag_to_h=720)
         # 22vh on 400px viewport = 88px. Allow 1px rounding slack.
         assert font_px <= 89, f"22vh cap not enforced: font {font_px}px > 88px on a 400px viewport"

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -4469,6 +4469,12 @@ class TestSubtitleOverlaySize:
         page.set_viewport_size({"width": 1600, "height": 900})
         goto_spa(page, server, "#/preview/2001-01-01_Test-Talk/Test-Video")
         page.wait_for_selector("#mock-player", state="visible", timeout=10000)
+        # ensurePreviewResizers fires from a 400ms setTimeout AND from
+        # hashchange/resize listeners. Until it has run the no-saved-subs
+        # branch will wipe data-subs-tuned and the scale var, racing with
+        # anything the test sets. Wait for the handle to appear — that's
+        # the deterministic signal that ensurePreviewResizers finished.
+        page.wait_for_selector("#preview-subs-resize", timeout=10000)
 
     def test_width_bound_uses_15_3_divisor(self, server, page):
         """The width-bound font is `(cqw - 48px) / 15.3`. On a wide enough
@@ -4797,6 +4803,7 @@ class TestSubtitleOverlaySize:
         page.set_viewport_size({"width": 1600, "height": 400})
         goto_spa(page, server, "#/preview/2001-01-01_Test-Talk/Test-Video")
         page.wait_for_selector("#mock-player", state="visible", timeout=10000)
+        page.wait_for_selector("#preview-subs-resize", timeout=10000)
         font_px = self._read_fs_font_px_via_toggle(page, drag_to_h=720)
         # 22vh on 400px viewport = 88px. Allow 1px rounding slack.
         assert font_px <= 89, f"22vh cap not enforced: font {font_px}px > 88px on a 400px viewport"


### PR DESCRIPTION
## Summary

Three small followups to PR #160 (preview subtitle resize + fs-mirror), found via a `/simplify` pass:

- **`applySubsPx` change-detection cache.** Caches last-written `--preview-subs-h`, `--preview-subs-scale`, and `data-subs-tuned` so per-pixel mousemove drags don't trigger redundant `setProperty` cascade work — at the clamp boundaries (`h ≤ 60` or `h ≥ 480`) every drag pixel was rewriting the same scale value. Cache is invalidated in `onReset` and the no-saved-value branch so a re-drag-to-same-px after reset still applies the property.
- **`CSS_PLAYER_H` constant** for symmetry with `CSS_SUBS_H` / `CSS_SUBS_SCALE` so the player resize writer can't drift on a typo.
- **Trim CSS doc-comment** on `.fs-mode[data-subs-tuned="1"]` to load-bearing rationale only — the cap/floor restatement repeated what the CSS already says.
- **Test renames + comment trims.** `test_width_term_widened_by_50pct` → `test_width_bound_uses_15_3_divisor`. Dropped narration referencing the historical "+50% bump" / "old 6vw" so future changes don't make the test docstrings lie. Also dropped a redundant `wait_for_timeout(500)` after a `wait_for_selector` and a `wait_for_timeout(400)` in the 22vh-cap test.

No behavior change beyond the per-frame work reduction.

## Test plan

- [x] `python -m pytest tests/test_preview_spa.py::TestSubtitleOverlaySize` — all 14 pass locally
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)