### PR TITLE
Fix white Vimeo letterbox in dark-theme fullscreen

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -861,11 +861,26 @@ body.preview-subs-resize-active-body * { cursor: ns-resize !important; user-sele
 }
 
 /* Iframe sits above placeholder when loaded; hidden when no real src yet. */
-.video-wrap iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; z-index: 1; background: #000; }
+.video-wrap iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; z-index: 1; background: var(--player-letterbox, #fff); }
 .video-wrap iframe:not([src]),
 .video-wrap iframe[src=""],
 .video-wrap iframe[src="about:blank"] { visibility: hidden; background: transparent; }
-.sync-player-video iframe { background: #000; }
+.sync-player-video iframe { background: var(--player-letterbox, #fff); }
+
+/* Video-player letterbox colour (the bars around the video in fullscreen).
+   The Vimeo player itself is transparent, so the iframe's own background is
+   what shows through. We paint it per theme — black in dark, white in light;
+   Vimeo effectively only supports a black or white surround.
+   `color-scheme: normal` is REQUIRED: when the iframe inherits the page's
+   `color-scheme: dark`, the Vimeo player paints its OWN opaque white
+   letterbox on top, which overrode this and turned the dark-theme fullscreen
+   surround white. Resetting the scheme keeps the player transparent. */
+.video-wrap iframe,
+.sync-player-video iframe { color-scheme: normal; }
+[data-theme="dark"] { --player-letterbox: #000; }
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) { --player-letterbox: #000; }
+}
 
 #subtitle-overlay {
   background: var(--bg2);

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -806,6 +806,58 @@ class TestFullscreenMode:
         title = page.locator("#btn-fullscreen").get_attribute("title")
         assert title is not None and len(title) > 0
 
+    def test_player_iframe_not_dark_color_scheme(self, server, page):
+        """Regression: the Vimeo player iframe must not inherit color-scheme: dark.
+
+        In dark theme the page sets `color-scheme: dark`, which a Vimeo
+        <iframe> inherits. The Vimeo player reacts to a dark scheme by
+        painting an opaque WHITE letterbox — so in fullscreen the surround
+        turns white instead of black. The player iframe must override
+        color-scheme so the player stays transparent and the letterbox shows
+        the iframe's own (theme-coloured) background instead.
+        """
+        self._goto_preview(server, page)
+        color_scheme = page.evaluate(
+            """() => {
+                document.documentElement.setAttribute('data-theme', 'dark');
+                var wrap = document.querySelector('.video-wrap');
+                var probe = document.createElement('iframe');
+                wrap.appendChild(probe);
+                var cs = getComputedStyle(probe)
+                    .getPropertyValue('color-scheme').trim();
+                probe.remove();
+                return cs;
+            }"""
+        )
+        assert color_scheme != "dark", (
+            f"player iframe inherited color-scheme '{color_scheme}' — "
+            "Vimeo paints a white letterbox in fullscreen when the scheme is dark"
+        )
+
+    def test_player_iframe_letterbox_tracks_theme(self, server, page):
+        """The player iframe's letterbox follows the theme: black in dark,
+        white in light. The Vimeo player is transparent, so the iframe's own
+        background is what shows in the fullscreen letterbox.
+        """
+        self._goto_preview(server, page)
+        colors = page.evaluate(
+            """() => {
+                var wrap = document.querySelector('.video-wrap');
+                function bgFor(theme) {
+                    document.documentElement.setAttribute('data-theme', theme);
+                    var probe = document.createElement('iframe');
+                    probe.src = 'x';  // non-empty: avoid the transparent override
+                    wrap.appendChild(probe);
+                    var bg = getComputedStyle(probe).backgroundColor;
+                    probe.remove();
+                    return bg;
+                }
+                return { dark: bgFor('dark'), light: bgFor('light') };
+            }"""
+        )
+        assert colors["dark"] == "rgb(0, 0, 0)", f"dark-theme letterbox should be black, got {colors['dark']}"
+        assert colors["light"] == "rgb(255, 255, 255)", f"light-theme letterbox should be white, got {colors['light']}"
+
 
 class TestReviewModeToggle:
     """Tests for transcript/subtitle mode toggle in review page (expert mode)."""


### PR DESCRIPTION
## Problem

In **fullscreen**, the Vimeo player's letterbox (the bars around the video) turned **white in dark theme**, where it used to be black/theme-appropriate. Embedded (non-fullscreen) playback was unaffected. The regression coincided with the org migration timeframe but the root cause predates it.

## Root cause

The warm-paper theme added `color-scheme: dark` for `[data-theme="dark"]`. The Vimeo player `<iframe>` **inherits** that scheme, and the player reacts to a dark `color-scheme` by painting its **own opaque white letterbox** on top. Before the `color-scheme` property existed, the player letterbox was transparent and showed the iframe's `#000` background (black).

Verified empirically with real Vimeo embeds: `color-scheme: dark` → opaque white letterbox; `color-scheme: light`/`normal`/`light dark` → transparent (shows the background behind).

## Fix

- Reset `color-scheme: normal` on the player iframes so the Vimeo player stays **transparent**.
- Paint the letterbox ourselves via a new `--player-letterbox` variable — **black in dark, white in light** (Vimeo effectively only supports a black/white surround).

## Tests

Adds two regression tests in `tests/test_preview_spa.py`:
- the player iframe never inherits `color-scheme: dark` (the bug-causing condition);
- the letterbox background tracks the theme (black in dark, white in light).

All 370 preview/sync-player E2E tests pass.

## Scope notes

- The same fix is applied to `.sync-player-video iframe` (review-mode player) as well as the preview iframe — same root cause.
- **Not addressed here (follow-up):** `site/index.html:1785` still sets `REPO = 'SlavaSubotskiy/sy-subtitles'` (old owner). The org migration story is incomplete while the SPA fetches data from the pre-migration owner — worth a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)