### PR TITLE
Fix review SRT-mode edits lost on reload and mode switch

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -4301,6 +4301,7 @@ SPA.switchReviewMode = function(mode, videoSlug) {
   if (mode === 'transcript') {
     reviewState.mode = 'transcript';
     reviewState.videoSlug = '';
+    loadReviewEditsForMode();
     localStorage.setItem('sy_review_mode_' + talkId, JSON.stringify({ mode: 'transcript' }));
     updateColHeaders();
     // Reload transcripts
@@ -4373,8 +4374,7 @@ SPA.switchReviewMode = function(mode, videoSlug) {
     reviewState.leftParas = aligned.map(function(r) { return r.en ? r.en.text : ''; });
     reviewState.rightParas = aligned.map(function(r) { return r.uk ? r.uk.text : ''; });
     reviewState.alignedRows = aligned;
-    reviewState.edits = {};
-    reviewState.marks = {};
+    loadReviewEditsForMode();
 
     renderReview();
     statusEl.style.display = 'none';
@@ -4600,8 +4600,34 @@ function onReviewEdit(idx, el) {
   saveReview();
 }
 
+// SRT edits are keyed by aligned-row index, which depends on the video and the
+// chosen source/final languages — so they need their own storage key, separate
+// from transcript edits (keyed by paragraph index). Sharing one key let SRT and
+// transcript edits clobber each other and made SRT edits vanish on reload / mode
+// switch (switchReviewMode reset reviewState.edits to {} after each load).
+function reviewStorageKey() {
+  if (reviewState.mode === 'srt') {
+    return 'review_srt_' + reviewState.talkId + '_' + reviewState.videoSlug
+      + '_' + reviewState.srtLeftLang + '_' + reviewState.srtRightLang;
+  }
+  return 'review_' + reviewState.talkId;
+}
+
+// Restore saved marks/edits for the current mode (and, for SRT, the current
+// video + language pair) instead of discarding them.
+function loadReviewEditsForMode() {
+  try {
+    var s = JSON.parse(localStorage.getItem(reviewStorageKey()) || '{}');
+    reviewState.marks = s.marks || {};
+    reviewState.edits = s.edits || {};
+  } catch (e) {
+    reviewState.marks = {};
+    reviewState.edits = {};
+  }
+}
+
 function saveReview() {
-  localStorage.setItem('review_' + reviewState.talkId, JSON.stringify({ marks: reviewState.marks, edits: reviewState.edits }));
+  localStorage.setItem(reviewStorageKey(), JSON.stringify({ marks: reviewState.marks, edits: reviewState.edits }));
   updateRevertBtn();
 }
 
@@ -4847,8 +4873,7 @@ SPA.switchSrtLang = function(side, lang) {
     reviewState.leftParas = aligned.map(function(r) { return r.en ? r.en.text : ''; });
     reviewState.rightParas = aligned.map(function(r) { return r.uk ? r.uk.text : ''; });
     reviewState.alignedRows = aligned;
-    reviewState.edits = {};
-    reviewState.marks = {};
+    loadReviewEditsForMode();
     renderReview();
     updateColHeaders();
     statusEl.style.display = 'none';

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -4964,3 +4964,139 @@ class TestRepoAutoDetect:
             }"""
         )
         assert threw, "deriveRepo must throw (loud error) when the repo cannot be resolved"
+
+
+class TestLocalEditsSurviveReload:
+    """Regression: local review/preview edits must persist across a tab reload
+    (close-reopen). localStorage is per-origin and the SPA keys edits by talk;
+    a reload must restore them.
+    """
+
+    def test_review_edits_survive_reload(self, server, page):
+        goto_spa(page, server)
+        page.evaluate("localStorage.setItem('sy_expert_mode','1'); expertMode=true; applyExpertMode();")
+        page.evaluate("location.hash = '#/review/2001-01-01_Test-Talk'")
+        page.wait_for_function("document.querySelectorAll('.cell.uk').length > 0", timeout=10000)
+        page.evaluate("reviewState.edits[0] = 'PERSIST_ME'; reviewState.marks[1] = 'note'; saveReview()")
+        raw = page.evaluate("localStorage.getItem('review_2001-01-01_Test-Talk')")
+        assert raw and "PERSIST_ME" in raw, f"edit not written to localStorage: {raw!r}"
+        page.reload()
+        page.wait_for_function("document.querySelectorAll('.cell.uk').length > 0", timeout=10000)
+        state = page.evaluate("({edits: reviewState.edits, marks: reviewState.marks})")
+        assert state["edits"].get("0") == "PERSIST_ME", f"review edit lost after reload: {state}"
+        assert state["marks"].get("1") == "note", f"review mark lost after reload: {state}"
+
+    def test_preview_edits_markers_and_mode_survive_reload(self, server, page):
+        """All preview-view local changes survive a reload: text edits, markers
+        (with their comment), and the marker/edit mode."""
+        goto_spa(page, server, "#/preview/2001-01-01_Test-Talk/Test-Video")
+        page.wait_for_selector("#mock-player", state="visible", timeout=10000)
+        page.evaluate(
+            "previewState.mode = 'edit';"
+            "previewState.edits[0] = 'PREVIEW_EDIT';"
+            "previewState.markers.push({time: 12, tc: '00:00:12', text: 'blk', comment: 'note'});"
+            "savePreviewState()"
+        )
+        raw = page.evaluate("localStorage.getItem('preview_2001-01-01_Test-Talk_Test-Video')")
+        assert raw and "PREVIEW_EDIT" in raw and "00:00:12" in raw, f"preview state not written: {raw!r}"
+        page.reload()
+        page.wait_for_selector("#mock-player", state="visible", timeout=10000)
+        state = page.evaluate("({edits: previewState.edits, markers: previewState.markers, mode: previewState.mode})")
+        assert state["edits"].get("0") == "PREVIEW_EDIT", f"preview edit lost after reload: {state}"
+        assert len(state["markers"]) == 1 and state["markers"][0]["comment"] == "note", (
+            f"preview marker lost after reload: {state}"
+        )
+        assert state["mode"] == "edit", f"preview mode lost after reload: {state}"
+
+
+class TestSrtReviewEditsPersist:
+    """Regression: edits made in SRT (subtitles) review mode must persist
+    across a reload AND across switching between transcript and SRT modes.
+
+    Transcript-mode edits already persisted; SRT-mode edits were wiped because
+    switchReviewMode / switchSrtLang reset reviewState.edits to {} after load,
+    and SRT shared the transcript storage key.
+    """
+
+    def _goto_review(self, server, page):
+        goto_spa(page, server)
+        page.evaluate("localStorage.setItem('sy_expert_mode','1'); expertMode=true; applyExpertMode();")
+        page.evaluate("location.hash = '#/review/2001-01-01_Test-Talk'")
+        page.wait_for_function("document.querySelectorAll('.cell.uk').length > 0", timeout=10000)
+
+    def _enter_srt(self, page):
+        page.evaluate("SPA.switchReviewMode('srt', 'Test-Video')")
+        page.wait_for_function(
+            "typeof reviewState !== 'undefined' && reviewState.mode === 'srt'"
+            " && document.querySelectorAll('.cell.uk').length > 0",
+            timeout=10000,
+        )
+
+    def test_srt_edits_survive_reload(self, server, page):
+        self._goto_review(server, page)
+        self._enter_srt(page)
+        page.evaluate("reviewState.edits[0] = 'SRT_PERSIST'; reviewState.marks[1] = 'm'; saveReview()")
+        page.reload()
+        page.wait_for_function(
+            "typeof reviewState !== 'undefined' && reviewState.mode === 'srt'"
+            " && document.querySelectorAll('.cell.uk').length > 0",
+            timeout=10000,
+        )
+        state = page.evaluate("({edits: reviewState.edits, marks: reviewState.marks})")
+        assert state["edits"].get("0") == "SRT_PERSIST", f"SRT edit lost after reload: {state}"
+        assert state["marks"].get("1") == "m", f"SRT mark lost after reload: {state}"
+
+    def test_srt_edits_and_marks_survive_mode_switch(self, server, page):
+        """A full transcript→SRT→transcript→SRT round-trip keeps each mode's
+        own edits AND marks intact."""
+        self._goto_review(server, page)
+        page.evaluate("reviewState.edits[0] = 'TRANSCRIPT_EDIT'; reviewState.marks[2] = 'T_MARK'; saveReview()")
+        self._enter_srt(page)
+        page.evaluate("reviewState.edits[0] = 'SRT_EDIT'; reviewState.marks[1] = 'SRT_MARK'; saveReview()")
+        # SRT → transcript: transcript edits/marks must come back
+        page.evaluate("SPA.switchReviewMode('transcript')")
+        page.wait_for_function(
+            "reviewState.mode === 'transcript' && document.querySelectorAll('.cell.uk').length > 0",
+            timeout=10000,
+        )
+        tr = page.evaluate("({edits: reviewState.edits, marks: reviewState.marks})")
+        assert tr["edits"].get("0") == "TRANSCRIPT_EDIT", f"transcript edit lost on switch: {tr}"
+        assert tr["marks"].get("2") == "T_MARK", f"transcript mark lost on switch: {tr}"
+        # transcript → SRT: SRT edits/marks must come back
+        self._enter_srt(page)
+        sr = page.evaluate("({edits: reviewState.edits, marks: reviewState.marks})")
+        assert sr["edits"].get("0") == "SRT_EDIT", f"SRT edit lost after round-trip: {sr}"
+        assert sr["marks"].get("1") == "SRT_MARK", f"SRT mark lost after round-trip: {sr}"
+
+    def test_srt_edits_stored_under_separate_video_lang_key(self, server, page):
+        """SRT edits live under their own video+language key, not the transcript
+        key — which is what keeps them isolated across language switches too."""
+        self._goto_review(server, page)
+        page.evaluate("reviewState.edits[0] = 'TRANSCRIPT_EDIT'; saveReview()")
+        self._enter_srt(page)
+        page.evaluate("reviewState.edits[0] = 'SRT_EDIT'; saveReview()")
+        keys = page.evaluate(
+            """() => {
+                var transcript = localStorage.getItem('review_2001-01-01_Test-Talk') || '';
+                var srtKey = Object.keys(localStorage).find(
+                    k => k.indexOf('review_srt_2001-01-01_Test-Talk') === 0);
+                return { transcript, srtKey, srtVal: srtKey ? localStorage.getItem(srtKey) : null };
+            }"""
+        )
+        assert "TRANSCRIPT_EDIT" in keys["transcript"], f"transcript key missing its edit: {keys}"
+        assert "SRT_EDIT" not in keys["transcript"], f"SRT edit leaked into transcript key: {keys}"
+        assert keys["srtKey"] and "SRT_EDIT" in (keys["srtVal"] or ""), (
+            f"SRT edit not stored under a video+lang-specific key: {keys}"
+        )
+
+    def test_transcript_and_srt_edits_are_independent(self, server, page):
+        self._goto_review(server, page)
+        page.evaluate("reviewState.edits[0] = 'TRANSCRIPT_EDIT'; saveReview()")
+        self._enter_srt(page)
+        page.evaluate("reviewState.edits[0] = 'SRT_EDIT'; saveReview()")
+        page.evaluate("SPA.switchReviewMode('transcript')")
+        page.wait_for_function(
+            "reviewState.mode === 'transcript' && document.querySelectorAll('.cell.uk').length > 0",
+            timeout=10000,
+        )
+        assert page.evaluate("reviewState.edits['0']") == "TRANSCRIPT_EDIT", "transcript edit clobbered by SRT edit"


### PR DESCRIPTION
## Problem

In the review view, local **edits/marks made in SRT (subtitles) mode were lost** — on page reload, on switching between transcript and SRT modes, and on switching SRT languages. Transcript-mode edits persisted, which is why it looked intermittent.

## Root cause

Two issues:
1. **Shared storage key.** Both modes wrote to `review_<talk>`, but SRT edits are keyed by aligned-row index and transcript edits by paragraph index — different index spaces — so they clobbered each other.
2. **Reset on load.** `switchReviewMode` (SRT path) and `switchSrtLang` did `reviewState.edits = {}; reviewState.marks = {}` right after loading data. On reload the resume path loaded edits from storage and then immediately called `switchReviewMode('srt')`, which wiped them. The transcript path never reset, so transcript edits survived.

## Fix

- SRT mode gets its own key: `review_srt_<talk>_<video>_<left>_<right>` (the lang pair matters because alignment/row indices depend on it). Transcript keeps `review_<talk>`.
- On every entry / mode switch / language switch, **load** the saved marks+edits for the active mode instead of resetting to `{}`.

Scoped to the review persistence functions (`reviewStorageKey`, `loadReviewEditsForMode`, `saveReview`, and the three `switch*` paths).

## Tests (written RED before the fix)

Reopen-tab (reload) coverage for **every** local-change variant, plus mode-switch and isolation:
- Preview: text edits, markers (with comment), and marker/edit mode survive reload.
- Review transcript: edits + marks survive reload.
- Review SRT: edits + marks survive reload.
- transcript↔SRT round-trip keeps each mode's own edits **and** marks.
- transcript and SRT edits stay independent (no clobbering).
- SRT edits stored under a separate video+lang key.

(Previously only the sync-player open/close state had reload tests.) Full `test_preview_spa.py` suite green (305).

Verified by hand on the live site in Firefox and Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)