### PR TITLE
Bump anthropics/claude-code-action v1 → v1.0.133

### DIFF
--- a/.github/workflows/subtitle-pipeline.yml
+++ b/.github/workflows/subtitle-pipeline.yml
@@ -235,7 +235,7 @@ jobs:
 
       - name: Translate to Ukrainian
         if: inputs.translate != false && inputs.dry_run != true
-        uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251  # v1.0.133
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_bun_executable: ${{ steps.tools.outputs.bun }}
@@ -342,7 +342,7 @@ jobs:
 
       - name: Review translation (2+1)
         if: inputs.review != false && inputs.dry_run != true
-        uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251  # v1.0.133
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_bun_executable: ${{ steps.tools.outputs.bun }}
@@ -648,7 +648,7 @@ jobs:
 
       - name: Build timecodes (Opus 4.8)
         if: inputs.dry_run != true
-        uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251  # v1.0.133
         env:
           CLAUDE_CODE_MAX_OUTPUT_TOKENS: "128000"
         with:


### PR DESCRIPTION
Updates the pinned `anthropics/claude-code-action` SHA in `subtitle-pipeline.yml` (translate, review, build steps).

- `fefa07e9` (Claude Code 2.1.126) → `787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251` (tag **v1.0.133**, Claude Code 2.1.150 / Agent SDK 0.3.150).
- 35 commits ahead of the old pin, 0 behind; `v1` currently resolves to this same commit.

Kept SHA-pinned (comment updated to the exact tag). Separate from the SPA/bookmarklet work in #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)