### PR TITLE
Fix sync-review-status PR conflicts: branch off live main tip

### DIFF
--- a/.github/workflows/sync-review-status.yml
+++ b/.github/workflows/sync-review-status.yml
@@ -18,7 +18,19 @@ jobs:
       github.event_name != 'issues' ||
       contains(join(github.event.issue.labels.*.name, ','), 'review:')
     steps:
+      # Always branch off the live main tip, not the inherited SHA. When this
+      # workflow runs via `workflow_call` from subtitle-pipeline.yml, the default
+      # checkout uses the caller's `github.sha` — the pipeline's dispatch SHA,
+      # which can be ~1h stale once the long translate/build jobs finish.
+      # sync-review-status.py regenerates review-status.json by merging entries
+      # preserved from the on-disk file, so a stale base yields stale content;
+      # bot-pr.sh then opens a PR off that stale base and merges into a moved
+      # main, producing a 3-way conflict whenever another status update landed
+      # during the run. Pinning `ref: main` bases the regenerated file on the
+      # current tip and lets the PR merge cleanly.
       - uses: actions/checkout@v6
+        with:
+          ref: main
 
       - name: Auto-update labels on assign/unassign/close/reopen
         if: >


### PR DESCRIPTION
## Problem

The Subtitle Pipeline intermittently fails on the final `sync-status / sync` job at the **Commit via PR** step:

```
X Pull request #228 is not mergeable: the merge commit cannot be cleanly created.
Process completed with exit code 1.
```

Example failure: run [26625917310](https://github.com/sy-tools/sy-subtitles/actions/runs/26625917310).

## Root cause

`sync-review-status.yml` runs via `workflow_call` from `subtitle-pipeline.yml`. A reusable workflow invoked that way checks out the **caller's** `github.sha` — i.e. the SHA the pipeline was dispatched at, which is ~1h stale by the time the long translate/build jobs finish.

The job then:
1. regenerates `review-status.json` on that stale base (`sync-review-status.py` merges entries preserved from the on-disk file, so the stale base also yields slightly stale content), and
2. `bot-pr.sh` opens a PR off the stale base and merges it into a **moved** `main`.

Whenever another review-status update landed during the run (e.g. #212, #222 in the example), the 3-way merge base is the stale SHA and both sides edited the same lines → **conflict** → `gh pr merge` exits 1.

This is why it "passes on another run": when no review-status update merges to `main` during the pipeline's lifetime, the stale base still matches the tip and the merge is clean. Purely a timing race.

**Evidence:** PR #228's head-commit parent was `10b93106` (exactly the `Uses: …sync-review-status.yml@10b93106` SHA in the log), while `main` had advanced to `c89cfdae`.

## Fix

Pin the checkout to `ref: main` so the regenerated file is always based on the current tip and the PR merges cleanly. No behavioural change for the `issues` / `workflow_dispatch` triggers (those already run against `main`).

### Residual (not addressed here, optional)

The pipeline's "Create review tracking issue" step fires `issues: labeled`, triggering a second concurrent `sync-review-status` run. After this fix both runs regenerate from the same issue state and merge cleanly, but a few-second race window remains. A `concurrency:` group would close it — left out to keep this PR scoped to the demonstrated failure.

### Verification

Verified by reasoning (branch base becomes main's tip); empirically confirmed on the next pipeline run's `sync-status` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)