### PR TITLE
Fix add-talk meta.yaml: quote free-text scalars so colons don't break YAML

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -5108,29 +5108,21 @@ function updateAddPreview() {
     if (vTitle || vUrl) videos.push({ title: vTitle, url: vUrl, slug: slugify(vTitle || 'Video-' + (videos.length + 1)) });
   });
 
-  var yaml = "title: '" + title.replace(/'/g, "''") + "'\n";
-  yaml += "date: '" + date + "'\n";
-  if (location) yaml += "location: " + location + "\n";
-  if (url) yaml += "amruta_url: " + url + "\n";
-  yaml += "language: " + lang + "\n";
-  if (videos.length) {
-    yaml += "videos:\n";
-    videos.forEach(function(v) {
-      yaml += "- slug: " + v.slug + "\n";
-      yaml += "  title: " + v.title + "\n";
-      yaml += "  vimeo_url: " + v.url + "\n";
-    });
-  }
-
   var transcript = document.getElementById('add-transcript').value.trim();
-  if (transcript) {
-    var b64 = btoa(unescape(encodeURIComponent(transcript)));
-    yaml += "transcript_en_base64: |\n";
-    // Split base64 into 76-char lines for readability
-    for (var i = 0; i < b64.length; i += 76) {
-      yaml += "  " + b64.substring(i, i + 76) + "\n";
-    }
-  }
+  // btoa is browser-only, so the base64 is encoded here and the pure
+  // buildMetaYaml() (site/js/add_talk_data.js) does the YAML serialization —
+  // including the quoting that keeps colons in titles/location valid.
+  var transcriptBase64 = transcript ? btoa(unescape(encodeURIComponent(transcript))) : '';
+
+  var yaml = buildMetaYaml({
+    title: title,
+    date: date,
+    location: location,
+    amruta_url: url,
+    language: lang,
+    videos: videos,
+    transcriptBase64: transcriptBase64,
+  });
 
   document.getElementById('add-preview').textContent = yaml;
 }

--- a/site/js/add_talk_data.js
+++ b/site/js/add_talk_data.js
@@ -33,6 +33,50 @@ function parseAddTalkHash(hash) {
   return { state: 'form', data: data };
 }
 
+// Render a scalar as a single-quoted YAML string, escaping embedded quotes by
+// doubling them (the YAML single-quote escape). Quoting makes the value safe
+// regardless of content — a colon, leading symbol, etc. can no longer be
+// misread as YAML structure.
+function yamlStr(s) {
+  return "'" + String(s == null ? '' : s).replace(/'/g, "''") + "'";
+}
+
+// Build meta.yaml text from add-talk form fields. Every free-text scalar
+// (title, location, per-video title) is single-quoted via yamlStr so a colon
+// in user input cannot corrupt the file (regression: sy-tools/sy-subtitles#293,
+// "Guru Puja Talk: Gurus Who Belong To The Collective" → ScannerError). Slugs
+// are generated ([A-Za-z0-9-]) and URLs/date/language are constrained formats,
+// so they stay unquoted to match existing meta.yaml files.
+//
+// fields: { title, date, location?, amruta_url?, language,
+//           videos?: [{ slug, title, url }], transcriptBase64? }
+function buildMetaYaml(fields) {
+  var f = fields || {};
+  var yaml = "title: " + yamlStr(f.title) + "\n";
+  yaml += "date: '" + (f.date || '') + "'\n";
+  if (f.location) yaml += "location: " + yamlStr(f.location) + "\n";
+  if (f.amruta_url) yaml += "amruta_url: " + f.amruta_url + "\n";
+  yaml += "language: " + (f.language || '') + "\n";
+  var videos = f.videos || [];
+  if (videos.length) {
+    yaml += "videos:\n";
+    videos.forEach(function (v) {
+      yaml += "- slug: " + v.slug + "\n";
+      yaml += "  title: " + yamlStr(v.title) + "\n";
+      yaml += "  vimeo_url: " + v.url + "\n";
+    });
+  }
+  if (f.transcriptBase64) {
+    yaml += "transcript_en_base64: |\n";
+    var b64 = f.transcriptBase64;
+    // Split base64 into 76-char lines for readability.
+    for (var i = 0; i < b64.length; i += 76) {
+      yaml += "  " + b64.substring(i, i + 76) + "\n";
+    }
+  }
+  return yaml;
+}
+
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { parseAddTalkHash: parseAddTalkHash };
+  module.exports = { parseAddTalkHash: parseAddTalkHash, buildMetaYaml: buildMetaYaml };
 }

--- a/tests/test_add_talk_data.js
+++ b/tests/test_add_talk_data.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { parseAddTalkHash } = require('../site/js/add_talk_data');
+const { parseAddTalkHash, buildMetaYaml } = require('../site/js/add_talk_data');
 
 // The bookmarklet encodes its payload exactly like this, then opens the SPA
 // at `<base>#/add?data=<encoded>`. These helpers reproduce that round trip so
@@ -76,5 +76,70 @@ describe('parseAddTalkHash — literal percent in content', () => {
     const res = parseAddTalkHash(hashFor(obj));
     assert.strictEqual(res.state, 'form');
     assert.strictEqual(res.data.tx, 'Section #1 and 50% done');
+  });
+});
+
+// Regression: the add-talk form emitted free-text scalars (per-video title,
+// location) unquoted, so a colon in a video title — e.g. "Guru Puja Talk:
+// Gurus Who Belong To The Collective" — produced invalid YAML
+// ("mapping values are not allowed here") and broke the new-talk automation
+// (sy-tools/sy-subtitles#293). All free-text scalars must be single-quoted
+// and '-escaped.
+describe('buildMetaYaml — YAML-safe quoting', () => {
+  it('quotes a per-video title containing a colon', () => {
+    const yaml = buildMetaYaml({
+      title: 'Guru Puja',
+      date: '1993-07-04',
+      language: 'en',
+      videos: [{
+        slug: 'Guru-Puja-Talk',
+        title: 'Guru Puja Talk: Gurus Who Belong To The Collective',
+        url: 'https://vimeo.com/189921224/c6fb45a3f2',
+      }],
+    });
+    assert.match(yaml, /^ {2}title: 'Guru Puja Talk: Gurus Who Belong To The Collective'$/m);
+  });
+
+  it('quotes the top-level title containing a colon', () => {
+    const yaml = buildMetaYaml({ title: 'Guru Puja: Gurus', date: '1993-07-04', language: 'en' });
+    assert.match(yaml, /^title: 'Guru Puja: Gurus'$/m);
+  });
+
+  it('quotes a location containing a colon', () => {
+    const yaml = buildMetaYaml({
+      title: 'T', date: '1993-07-04', language: 'en',
+      location: 'Public Program: Royal Albert Hall',
+    });
+    assert.match(yaml, /^location: 'Public Program: Royal Albert Hall'$/m);
+  });
+
+  it('escapes single quotes by doubling them', () => {
+    const yaml = buildMetaYaml({ title: "Mother's love", date: '1993-07-04', language: 'en' });
+    assert.match(yaml, /^title: 'Mother''s love'$/m);
+  });
+
+  it('emits date/language, video block and base64 transcript', () => {
+    const yaml = buildMetaYaml({
+      title: 'T', date: '1993-07-04', language: 'en',
+      amruta_url: 'https://www.amruta.org/x/',
+      videos: [{ slug: 'A', title: 'A', url: 'https://vimeo.com/1/2' }],
+      transcriptBase64: 'YWJjZA==',
+    });
+    assert.match(yaml, /^date: '1993-07-04'$/m);
+    assert.match(yaml, /^language: en$/m);
+    assert.match(yaml, /^amruta_url: https:\/\/www\.amruta\.org\/x\/$/m);
+    assert.match(yaml, /^videos:$/m);
+    assert.match(yaml, /^- slug: A$/m);
+    assert.match(yaml, /^  vimeo_url: https:\/\/vimeo\.com\/1\/2$/m);
+    assert.match(yaml, /^transcript_en_base64: \|$/m);
+    assert.match(yaml, /^ {2}YWJjZA==$/m);
+  });
+
+  it('omits optional location/amruta_url/videos/transcript when absent', () => {
+    const yaml = buildMetaYaml({ title: 'T', date: '1993-07-04', language: 'en' });
+    assert.doesNotMatch(yaml, /^location:/m);
+    assert.doesNotMatch(yaml, /^amruta_url:/m);
+    assert.doesNotMatch(yaml, /^videos:/m);
+    assert.doesNotMatch(yaml, /^transcript_en_base64:/m);
   });
 });

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from urllib.parse import quote, unquote
 
 import pytest
+import yaml
 
 SAMPLE_META = """title: 'Test Talk: Subtitle Preview'
 date: '2001-01-01'
@@ -3788,12 +3789,57 @@ class TestAddTalkForm:
         yaml_text = page.locator("#add-preview").text_content()
         assert "title: 'My Test Talk'" in yaml_text
         assert "date: '2020-05-05'" in yaml_text
-        assert "location: Test City" in yaml_text
+        # Free-text scalars are single-quoted so a colon can't corrupt the YAML.
+        assert "location: 'Test City'" in yaml_text
         assert "amruta_url: https://www.amruta.org/" in yaml_text
         assert "language: en" in yaml_text
         assert "videos:" in yaml_text
         assert "vimeo_url: https://vimeo.com/1234/abcd" in yaml_text
         assert "transcript_en_base64: |" in yaml_text
+        # The preview must be valid YAML — this is the exact path the pipeline's
+        # yaml.safe_load takes; substring checks alone would miss a quoting bug.
+        parsed = yaml.safe_load(yaml_text)
+        assert parsed["location"] == "Test City"
+
+    def test_preview_yaml_valid_when_fields_contain_colons(self, server, page):
+        """Regression (sy-tools/sy-subtitles#293): a colon in a video title —
+        e.g. "Guru Puja Talk: Gurus Who Belong To The Collective" — was emitted
+        unquoted and produced YAML that failed yaml.safe_load ("mapping values
+        are not allowed here"), breaking the new-talk `detect` job. Drive the
+        real form with colons in the talk title, location, and a video title,
+        then assert the preview parses and every value round-trips intact."""
+        data = {
+            "t": "Guru Puja: Gurus who belong to the collective",
+            "d": "1993-07-04",
+            "u": "https://www.amruta.org/1993/07/04/guru-puja-1993/",
+            "loc": "Public Program: Cabella Ligure",
+            "v": [
+                {"id": "189922347", "h": "8eea76507c", "l": "Guru Puja"},
+                {
+                    "id": "189921224",
+                    "h": "c6fb45a3f2",
+                    "l": "Guru Puja Talk: Gurus Who Belong To The Collective",
+                },
+            ],
+            "tx": "He said 100% & it's done.",
+        }
+        encoded = quote(json.dumps(data), safe="")
+        page.goto(f"{server}{SPA_URL}#/add?data={encoded}")
+        page.wait_for_selector("#add-form", state="visible", timeout=5000)
+        page.wait_for_timeout(200)  # let updateAddPreview run
+
+        yaml_text = page.locator("#add-preview").text_content()
+        # The colon-bearing video title must be quoted in the rendered preview.
+        assert "title: 'Guru Puja Talk: Gurus Who Belong To The Collective'" in yaml_text, yaml_text
+
+        # Parsing is the real contract — this is what the pipeline runs.
+        parsed = yaml.safe_load(yaml_text)
+        assert parsed["title"] == "Guru Puja: Gurus who belong to the collective"
+        assert parsed["location"] == "Public Program: Cabella Ligure"
+        assert [v["title"] for v in parsed["videos"]] == [
+            "Guru Puja",
+            "Guru Puja Talk: Gurus Who Belong To The Collective",
+        ]
 
     def test_create_pr_button_generates_github_new_file_url(self, server, page):
         self._open_add_form(page, server)

--- a/tests/test_spa_cache.js
+++ b/tests/test_spa_cache.js
@@ -1650,28 +1650,26 @@ function slugifyTest(text) {
   return text.replace(/[^a-zA-Z0-9 -]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
 }
 
+// Thin adapter over the single-source builder in site/js/add_talk_data.js so
+// these tests exercise the real serialization (incl. YAML-safe quoting) rather
+// than a drifting copy — an earlier copy here re-emitted video titles unquoted
+// and so never caught the colon bug (sy-tools/sy-subtitles#293). btoa is
+// browser-only, so raw transcript text is base64-encoded here before handing
+// off, mirroring what index.html does.
+const { buildMetaYaml: buildMetaYamlModule } = require('../site/js/add_talk_data');
+
 function buildMetaYaml(opts) {
-  var yaml = "title: '" + (opts.title || '').replace(/'/g, "''") + "'\n";
-  yaml += "date: '" + (opts.date || '') + "'\n";
-  if (opts.location) yaml += "location: " + opts.location + "\n";
-  if (opts.url) yaml += "amruta_url: " + opts.url + "\n";
-  yaml += "language: " + (opts.language || 'en') + "\n";
-  if (opts.videos && opts.videos.length) {
-    yaml += "videos:\n";
-    opts.videos.forEach(function(v) {
-      yaml += "- slug: " + v.slug + "\n";
-      yaml += "  title: " + (v.title || '') + "\n";
-      yaml += "  vimeo_url: " + (v.url || '') + "\n";
-    });
-  }
-  if (opts.transcript) {
-    var b64 = Buffer.from(opts.transcript, 'utf8').toString('base64');
-    yaml += "transcript_en_base64: |\n";
-    for (var i = 0; i < b64.length; i += 76) {
-      yaml += "  " + b64.substring(i, i + 76) + "\n";
-    }
-  }
-  return yaml;
+  return buildMetaYamlModule({
+    title: opts.title,
+    date: opts.date,
+    location: opts.location,
+    amruta_url: opts.url,
+    language: opts.language || 'en',
+    videos: opts.videos,
+    transcriptBase64: opts.transcript
+      ? Buffer.from(opts.transcript, 'utf8').toString('base64')
+      : '',
+  });
 }
 
 function parseBookmarkletData(encodedStr) {
@@ -1703,7 +1701,7 @@ describe('Add Talk: buildMetaYaml', () => {
 
   it('includes location and amruta_url', () => {
     var yaml = buildMetaYaml({ title: 'T', date: '2001-01-01', location: 'Mumbai', url: 'https://amruta.org/test' });
-    assert.ok(yaml.includes('location: Mumbai'));
+    assert.ok(yaml.includes("location: 'Mumbai'"));
     assert.ok(yaml.includes('amruta_url: https://amruta.org/test'));
   });
 
@@ -1714,7 +1712,7 @@ describe('Add Talk: buildMetaYaml', () => {
     });
     assert.ok(yaml.includes('videos:'));
     assert.ok(yaml.includes('- slug: Video-1'));
-    assert.ok(yaml.includes("title: Video 1"));
+    assert.ok(yaml.includes("title: 'Video 1'"));
     assert.ok(yaml.includes('vimeo_url: https://vimeo.com/123/abc'));
   });
 
@@ -1989,8 +1987,13 @@ describe('Add Talk: SPA code integrity', () => {
     assert.ok(matches >= 2, 'add.title should be in uk and en');
   });
 
-  it('transcript_en_base64 field generated in yaml', () => {
-    assert.ok(html.includes('transcript_en_base64'));
+  it('meta.yaml generation is single-sourced in add_talk_data.js', () => {
+    // buildMetaYaml() lives in the module (tested in test_add_talk_data.js);
+    // index.html must delegate to it rather than re-inline the serialization.
+    var mod = fs.readFileSync('site/js/add_talk_data.js', 'utf8');
+    assert.ok(mod.includes('transcript_en_base64'), 'module emits transcript_en_base64');
+    assert.ok(mod.includes('function buildMetaYaml'), 'module defines buildMetaYaml');
+    assert.ok(html.includes('buildMetaYaml('), 'index.html calls buildMetaYaml');
   });
 });
 
@@ -2120,13 +2123,13 @@ describe('Add Talk: real amruta.org page parsing', () => {
     });
     assert.ok(yaml.includes("title: 'Sahasrara Puja: How it was decided'"));
     assert.ok(yaml.includes("date: '1988-05-08'"));
-    assert.ok(yaml.includes('location: Fregene (Italy)'));
+    assert.ok(yaml.includes("location: 'Fregene (Italy)'"));
     assert.ok(yaml.includes('amruta_url: https://www.amruta.org/'));
     assert.ok(yaml.includes('language: en'));
     assert.ok(yaml.includes('videos:'));
     assert.ok(yaml.includes('- slug: Sahasrara-Puja'));
-    assert.ok(yaml.includes("title: Sahasrara Puja\n"));
-    assert.ok(yaml.includes("title: Sahasrara Puja Talk"));
+    assert.ok(yaml.includes("title: 'Sahasrara Puja'\n"));
+    assert.ok(yaml.includes("title: 'Sahasrara Puja Talk'"));
     assert.ok(yaml.includes('vimeo_url: https://vimeo.com/88490248/e956098e13'));
     assert.ok(yaml.includes('vimeo_url: https://vimeo.com/88509806/2453ea7524'));
   });


### PR DESCRIPTION
## Problem

Creating a talk from the **Add talk** page produces invalid `meta.yaml` when any free-text field contains a colon. A video title like `Guru Puja Talk: Gurus Who Belong To The Collective` yields:

```
yaml.scanner.ScannerError: mapping values are not allowed here
  in "talks/.../meta.yaml", line 11, column 24
```

which fails the new-talk `detect` automation (e.g. sy-tools/sy-subtitles#293).

## Root cause

The SPA generated `meta.yaml` by hand-concatenating strings. The top-level `title` was single-quoted, but **per-video `title` and `location` were emitted raw**, so a `:` in those values was parsed as YAML structure.

## Fix

Extract the serialization into `buildMetaYaml()` in `site/js/add_talk_data.js` (single source — `index.html` now calls it, keeping only the browser-only `btoa`). A `yamlStr()` helper single-quotes and `'`-escapes **every** free-text scalar (title, location, per-video title). Slugs (`[A-Za-z0-9-]`), URLs, and date/language are constrained formats and stay unquoted to match existing `meta.yaml` files.

Also collapses a stale **duplicate** `buildMetaYaml` in `tests/test_spa_cache.js` — it re-emitted video titles unquoted and so never caught this bug — into a thin adapter over the real module.

## Verification

- TDD: added failing tests in `tests/test_add_talk_data.js` (colon in video title / top-level title / location, `'`-escaping), then implemented.
- 488/488 JS tests pass.
- The real browser path through `updateAddPreview` now emits `title: 'Guru Puja Talk: Gurus Who Belong To The Collective'`.
- The generated YAML round-trips through Python `yaml.safe_load` (the original failure path).
- `tools/download.py` uses `yaml.dump` and was never affected.

Note: this fixes the generator going forward. PR #293's already-committed `meta.yaml` still needs its line 11 quoted to unblock that specific PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)