### PR TITLE
Re-architect add-talk bookmarklet as a thin loader (logic in js/bookmarklet.js)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -5012,9 +5012,16 @@ document.addEventListener('click', function(e) {
 // ============================================================
 (function() {
   var spaBase = location.origin + location.pathname.replace(/\/[^/]*$/, '/');
-  var bmCode = "(function(){var t=document.querySelector('h1.entry-title,h1,.entry-title');t=t?t.textContent.trim():document.title;var u=location.origin+location.pathname;var d=u.match(/(\\d{4})\\/(\\d{2})\\/(\\d{2})/);d=d?d[1]+'-'+d[2]+'-'+d[3]:'';var loc='';var h4=document.querySelector('.entry-content h4');if(h4){var ln=[];h4.childNodes.forEach(function(n){if(n.nodeType===3){var s=n.textContent.trim();if(s)ln.push(s);}});for(var i=0;i<ln.length;i++){if(ln[i].indexOf('Talk Language:')===0&&i>0){loc=ln[i-1];break;}}}var v=[];document.querySelectorAll('.embedded-video-wrapper').forEach(function(w){var f=w.querySelector('iframe[src*=\"vimeo\"]');if(!f)return;var m=f.src.match(/player\\.vimeo\\.com\\/video\\/(\\d+)\\?h=(\\w+)/);var lb='';var mi=w.querySelector('.video-meta-info');if(mi){var mt=mi.textContent.trim().replace(/^\\d{4}-\\d{2}-\\d{2}\\s+/,'');var ps=mt.split(',');if(ps.length)lb=ps[0].trim();}if(!lb){var prev=w.previousElementSibling;if(prev&&/^H[2-4]$/.test(prev.tagName))lb=prev.textContent.trim();}v.push({id:m?m[1]:'',h:m?m[2]:'',l:lb});});if(!v.length){document.querySelectorAll('iframe[src*=\"vimeo\"]').forEach(function(f){var m=f.src.match(/player\\.vimeo\\.com\\/video\\/(\\d+)\\?h=(\\w+)/);if(m)v.push({id:m[1],h:m[2],l:''});});}var c=document.querySelector('.entry-content,.post-content,article');var tx='';if(c){var pp=c.querySelectorAll('p');for(var i=0;i<pp.length;i++){var pc=pp[i].cloneNode(true);pc.querySelectorAll('br').forEach(function(b){b.replaceWith(' ');});var pt=pc.textContent.replace(/\\s+/g,' ').trim();if(pt.length>20&&pt.indexOf('Talk Language:')<0)tx+=(tx?'\\n':'')+pt;}}var j=encodeURIComponent(JSON.stringify({t:t,d:d,u:u,loc:loc,v:v,tx:tx}));window.open('" + spaBase + "#/add?data='+j);})();";
+  // The saved bookmark is a thin LOADER that injects the current scraper
+  // (js/bookmarklet.js) from the deployed site at click time. Keeping the
+  // scraping logic in that file (not baked into the saved bookmark) means a
+  // fix + redeploy reaches every user without re-dragging the bookmarklet.
+  // The ?t cache-buster fetches the freshest version past CDN/service-worker.
+  var loader = "(function(){var s=document.createElement('script');"
+    + "s.src='" + spaBase + "js/bookmarklet.js?t='+Date.now();"
+    + "document.body.appendChild(s);})();";
   var el = document.getElementById('bookmarklet-link');
-  if (el) el.href = 'javascript:' + bmCode;
+  if (el) el.href = 'javascript:' + loader;
 })();
 
 // parseAddTalkHash() is provided by js/add_talk_data.js (loaded in <head>),

--- a/site/js/bookmarklet.js
+++ b/site/js/bookmarklet.js
@@ -1,0 +1,114 @@
+// Add-talk bookmarklet — page scraper for amruta.org talk pages.
+//
+// The saved bookmark in the user's bookmarks bar is a thin LOADER that injects
+// this file from the deployed site (see updateBookmarklet in site/index.html).
+// Because the logic lives here and not in the saved bookmark, fixing the
+// scraping and redeploying updates every user's bookmarklet — no re-drag.
+//
+// This script is injected into the amruta.org page, so it must be
+// SELF-CONTAINED: no other site modules are available in that page. It is also
+// required by the Node test suite (tests reach extractAmrutaTalk via the
+// browser global it exports) — single source, no inline mirror.
+(function () {
+  // Scrape a talk page's DOM into the bookmarklet payload {t,d,u,loc,v,tx}.
+  function extractAmrutaTalk(doc) {
+    var titleEl = doc.querySelector("h1.entry-title,h1,.entry-title");
+    var t = titleEl ? titleEl.textContent.trim() : doc.title;
+
+    var u = doc.location ? doc.location.origin + doc.location.pathname : "";
+    var dm = u.match(/(\d{4})\/(\d{2})\/(\d{2})/);
+    var d = dm ? dm[1] + "-" + dm[2] + "-" + dm[3] : "";
+
+    // Location: the text-node line right before "Talk Language:" inside the
+    // .entry-content h4 (its date/title/location/language fields are separated
+    // by <br>, i.e. distinct text nodes).
+    var loc = "";
+    var h4 = doc.querySelector(".entry-content h4");
+    if (h4) {
+      var ln = [];
+      h4.childNodes.forEach(function (n) {
+        if (n.nodeType === 3) {
+          var s = n.textContent.trim();
+          if (s) ln.push(s);
+        }
+      });
+      for (var i = 0; i < ln.length; i++) {
+        if (ln[i].indexOf("Talk Language:") === 0 && i > 0) {
+          loc = ln[i - 1];
+          break;
+        }
+      }
+    }
+
+    // Videos: vimeo id+hash and a label (from .video-meta-info, else the
+    // preceding heading).
+    var v = [];
+    doc.querySelectorAll(".embedded-video-wrapper").forEach(function (w) {
+      var f = w.querySelector('iframe[src*="vimeo"]');
+      if (!f) return;
+      var m = f.src.match(/player\.vimeo\.com\/video\/(\d+)\?h=(\w+)/);
+      var lb = "";
+      var mi = w.querySelector(".video-meta-info");
+      if (mi) {
+        var mt = mi.textContent.trim().replace(/^\d{4}-\d{2}-\d{2}\s+/, "");
+        var ps = mt.split(",");
+        if (ps.length) lb = ps[0].trim();
+      }
+      if (!lb) {
+        var prev = w.previousElementSibling;
+        if (prev && /^H[2-4]$/.test(prev.tagName)) lb = prev.textContent.trim();
+      }
+      v.push({ id: m ? m[1] : "", h: m ? m[2] : "", l: lb });
+    });
+    if (!v.length) {
+      doc.querySelectorAll('iframe[src*="vimeo"]').forEach(function (f) {
+        var m = f.src.match(/player\.vimeo\.com\/video\/(\d+)\?h=(\w+)/);
+        if (m) v.push({ id: m[1], h: m[2], l: "" });
+      });
+    }
+
+    // Transcript: one line per <p>. Replace <br> with a space first
+    // (textContent drops <br>, merging "end.Start"), collapse all whitespace
+    // (incl. hard-wrap newlines and NBSP), and skip a header-like <p> that
+    // duplicates the metadata, so the pipeline synthesizes a clean header.
+    var c = doc.querySelector(".entry-content,.post-content,article");
+    var tx = "";
+    if (c) {
+      var pp = c.querySelectorAll("p");
+      for (var k = 0; k < pp.length; k++) {
+        var pc = pp[k].cloneNode(true);
+        pc.querySelectorAll("br").forEach(function (b) {
+          b.replaceWith(" ");
+        });
+        var pt = pc.textContent.replace(/\s+/g, " ").trim();
+        if (pt.length > 20 && pt.indexOf("Talk Language:") < 0) {
+          tx += (tx ? "\n" : "") + pt;
+        }
+      }
+    }
+
+    return { t: t, d: d, u: u, loc: loc, v: v, tx: tx };
+  }
+
+  // Expose for tests / debugging.
+  if (typeof window !== "undefined") {
+    window.extractAmrutaTalk = extractAmrutaTalk;
+  }
+
+  // When injected as a real <script> by the loader bookmarklet, scrape the
+  // page and open the SPA's add view. The SPA base is derived from THIS
+  // script's own URL (it is served from the same site as the SPA), so the
+  // loader never hardcodes it. (Skipped when the file is merely eval'd in a
+  // test — document.currentScript is null then.)
+  if (typeof document !== "undefined" && document.currentScript) {
+    var src = document.currentScript.src || "";
+    var base = src.replace(/js\/bookmarklet\.js.*$/, "");
+    var data = extractAmrutaTalk(document);
+    var url = base + "index.html#/add?data=" + encodeURIComponent(JSON.stringify(data));
+    window.open(url);
+  }
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = { extractAmrutaTalk: extractAmrutaTalk };
+  }
+})();

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -3913,54 +3913,63 @@ class TestAddTalkForm:
 class TestBookmarkletExtraction:
     """E2E for the add-talk bookmarklet's page scraping.
 
-    The bookmarklet is the inline `bmCode` string in site/index.html; users
-    drag it to their bookmarks bar and click it on an amruta.org talk page,
-    where it reads the DOM and opens the SPA with the extracted payload. That
-    extraction had no test (the existing 'real amruta parsing' suite asserts
+    The scraping logic lives in site/js/bookmarklet.js. The saved bookmark is a
+    thin loader that injects that file from the deployed site; on an amruta.org
+    talk page it reads the DOM and opens the SPA with the extracted payload.
+    The extraction had no test before (the 'real amruta parsing' suite asserts
     pre-parsed JSON, not the live code), so a selector that silently stopped
     matching a page shape would ship unnoticed — exactly what surfaced on the
     Christmas Puja 1998 talk (empty location / video titles / transcript).
 
-    These tests read the exact shipped `bmCode` from source and run it against
-    a saved fixture of that page, so they exercise the real bookmarklet end to
-    end and lock in the structures its selectors depend on."""
+    These tests load the exact shipped bookmarklet.js and run its
+    extractAmrutaTalk against a saved fixture, locking in the DOM structures
+    its selectors depend on."""
 
     FIXTURE = Path(__file__).parent / "fixtures" / "amruta_christmas_puja_1998.html"
-
-    def _bmcode_rhs(self):
-        """The right-hand side of `var bmCode = "..." + spaBase + "...";` —
-        a JS expression we can eval in the page to reconstruct the bookmarklet."""
-        html = (Path(__file__).parent.parent / "site" / "index.html").read_text()
-        m = re.search(r'var bmCode = (".*");\s*$', html, re.M)
-        assert m, "could not locate `var bmCode = ...` in site/index.html"
-        return m.group(1)
+    BOOKMARKLET_JS = Path(__file__).parent.parent / "site" / "js" / "bookmarklet.js"
 
     def _run_bookmarklet(self, page):
-        """Execute the shipped bookmarklet against the loaded page, capturing
-        the payload it would hand to the SPA via window.open.
+        """Load the shipped scraper (site/js/bookmarklet.js) into the page and
+        return extractAmrutaTalk(document) — the exact payload the loader
+        bookmarklet would hand to the SPA.
 
-        eval() is intentional here: the bookmarklet *is* a string of JS our SPA
-        ships, and the test's whole purpose is to run that exact code. It is our
-        own source (read from site/index.html) executed in a throwaway test
-        page — no untrusted input."""
-        captured = page.evaluate(
-            """(rhs) => {
-                var spaBase = 'http://spa.test/';
-                var bmCode;
-                eval('bmCode = ' + rhs + ';');
-                var opened = null;
-                var orig = window.open;
-                window.open = function (u) { opened = u; return null; };
-                try { eval(bmCode); } finally { window.open = orig; }
-                return opened;
-            }""",
-            self._bmcode_rhs(),
+        eval() is intentional: it loads our own shipped source into a throwaway
+        test page (no untrusted input). The file's auto-open branch is inert
+        here — document.currentScript is null under eval — so we call
+        extractAmrutaTalk directly and assert its payload."""
+        js = self.BOOKMARKLET_JS.read_text()
+        return page.evaluate(
+            "(src) => { eval(src); return window.extractAmrutaTalk(document); }",
+            js,
         )
-        assert captured and "#/add?data=" in captured, f"no payload opened: {captured}"
-        return json.loads(unquote(captured.split("#/add?data=", 1)[1]))
 
     def test_fixture_exists(self):
         assert self.FIXTURE.exists(), f"missing fixture: {self.FIXTURE}"
+        assert self.BOOKMARKLET_JS.exists(), f"missing scraper: {self.BOOKMARKLET_JS}"
+
+    def test_loader_path_injects_scraper_and_opens_spa(self, browser, server):
+        """Full production path: inject bookmarklet.js as a real <script> (as
+        the loader bookmarklet does) and confirm it scrapes the page and opens
+        the SPA add view. Exercises the auto-open branch + SPA-base derivation
+        from document.currentScript.src — which the direct extractAmrutaTalk
+        call cannot cover."""
+        ctx = browser.new_context()
+        try:
+            pg = ctx.new_page()
+            pg.goto(f"{server}/index.html")  # same-origin host for the injected <script>
+            pg.set_content(
+                '<div class="entry-content"><p>A paragraph with plenty of words so it is kept by the scraper.</p></div>'
+            )
+            pg.evaluate("() => { window.__opened = null; window.open = (u) => { window.__opened = u; }; }")
+            pg.add_script_tag(url=f"{server}/js/bookmarklet.js")
+            opened = pg.evaluate("() => window.__opened")
+        finally:
+            ctx.close()
+
+        assert opened, "bookmarklet.js did not call window.open when injected"
+        assert "/index.html#/add?data=" in opened, opened
+        data = json.loads(unquote(opened.split("#/add?data=", 1)[1]))
+        assert data["tx"] == "A paragraph with plenty of words so it is kept by the scraper."
 
     def test_extracts_nonempty_fields_from_real_page(self, browser):
         ctx = browser.new_context()

--- a/tests/test_spa_cache.js
+++ b/tests/test_spa_cache.js
@@ -1818,10 +1818,11 @@ describe('Add Talk: GitHub new file URL', () => {
 });
 
 describe('Add Talk: bookmarklet extracts location', () => {
+  // The scraper now lives in site/js/bookmarklet.js (the saved bookmark is a
+  // thin loader that injects it); behaviour is covered end-to-end by the
+  // Python E2E (TestBookmarkletExtraction). These are cheap source guards.
   var fs = require('fs');
-  var html = fs.readFileSync('site/index.html', 'utf8');
-  var bmMatch = html.match(/var bmCode = "(.*?)";/s);
-  var bmCode = bmMatch ? bmMatch[1] : '';
+  var bmCode = fs.readFileSync('site/js/bookmarklet.js', 'utf8');
 
   it('bookmarklet code includes location extraction', () => {
     assert.ok(bmCode.includes('loc') || bmCode.includes('location') || bmCode.includes('h4'),
@@ -1829,17 +1830,15 @@ describe('Add Talk: bookmarklet extracts location', () => {
   });
 
   it('bookmarklet data JSON includes location field', () => {
-    // The bookmarklet JSON should have a location field (l or loc)
-    assert.ok(bmCode.includes('"l"') || bmCode.includes('"loc"') || bmCode.includes(',l:') || bmCode.includes(',loc:'),
-      'bookmarklet JSON should include location field');
+    // The payload object must carry a location field (loc).
+    assert.ok(bmCode.includes('loc:') || bmCode.includes('loc :'),
+      'bookmarklet payload should include loc field');
   });
 });
 
 describe('Add Talk: bookmarklet extracts video titles', () => {
   var fs = require('fs');
-  var html = fs.readFileSync('site/index.html', 'utf8');
-  var bmMatch = html.match(/var bmCode = "(.*?)";/s);
-  var bmCode = bmMatch ? bmMatch[1] : '';
+  var bmCode = fs.readFileSync('site/js/bookmarklet.js', 'utf8');
 
   it('bookmarklet extracts video labels from video-meta-info div', () => {
     assert.ok(
@@ -1980,6 +1979,16 @@ describe('Add Talk: SPA code integrity', () => {
 
   it('bookmarklet link exists', () => {
     assert.ok(html.includes('id="bookmarklet-link"'));
+  });
+
+  it('bookmarklet is a loader that injects js/bookmarklet.js', () => {
+    // The saved bookmark must be the thin loader (so scraper fixes deploy
+    // without re-dragging), not inline scraping logic. This is the one string
+    // every user's re-dragged bookmark bakes in, and neither E2E path covers
+    // the index.html builder, so guard it here.
+    assert.ok(html.includes('js/bookmarklet.js'), 'loader must inject js/bookmarklet.js');
+    assert.ok(html.includes("'javascript:' + loader"), 'bookmarklet-link href must be the javascript: loader');
+    assert.ok(!html.includes('var bmCode'), 'inline bmCode scraper must be gone (moved to js/bookmarklet.js)');
   });
 
   it('add.title i18n key in both languages', () => {


### PR DESCRIPTION
## Why

The add-talk bookmarklet baked all scraping logic inline (`bmCode` in `index.html`). A saved bookmark is a **snapshot**, so every scraping fix (colons → #299, soft-wraps/NBSP → #366, `<br>`/header → #434) required users to **re-drag** it. This kept biting across sessions.

## What

The saved bookmark becomes a thin **loader** that injects the *current* scraper from the deployed site:

```js
javascript:(function(){var s=document.createElement('script');
s.src='<spaBase>/js/bookmarklet.js?t='+Date.now();document.body.appendChild(s);})()
```

- **New `site/js/bookmarklet.js`** — all scraping (`extractAmrutaTalk` → `{t,d,u,loc,v,tx}`, with the existing `<br>`→space + skip-header-`<p>` + whitespace-collapse fixes). Self-contained (no other modules load in the amruta page); on inject it derives the SPA base from `document.currentScript.src` and opens the add view, so the loader never hardcodes the URL.
- **`index.html`** builds the loader href from `spaBase`; `?t=<ts>` busts CDN/service-worker cache. Inline `bmCode` removed.

**Result:** a scraping fix + redeploy reaches everyone with **no re-drag**, and the scraper is finally a **testable single-source module**.

**Feasibility verified:** amruta.org has no CSP — injecting an external `github.io` `<script>` into a live talk page loads and executes (tested via Playwright).

## Tests (TDD)

- `test_preview_spa` — E2E migrated to load `bookmarklet.js` and assert `extractAmrutaTalk` (Christmas fixture + hard-wrap + `<br>`/header cases), **plus a full loader-path test**: inject as a real `<script>` → `currentScript`-derived base → `window.open`.
- `test_spa_cache` — bookmarklet source guards repointed to `bookmarklet.js`, **plus a guard** that `index.html` builds the `js/bookmarklet.js` loader and contains no inline `bmCode`.
- 311 preview + 414 JS tests pass.

## Rollout / caveats

- **Existing inline bookmarks keep working** (they're self-contained) — users re-drag **once** to start receiving future fixes. Safe, gradual rollout; nothing breaks.
- The live `github.io` fetch only works **after merge + Pages deploy** (the scraper must exist at the deployed path); the loader-path test runs against the local server.
- `site/js/*.js` is already in the shell-version glob, so no manual version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)