### PR TITLE
Fix CodeQL alerts: CI workflow permissions + SPA XSS hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ on:
       - 'ruff.toml'
       - '.github/workflows/**'
 
+# Least-privilege default for every job (all are read-only lint/test jobs).
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/golden-talks.yml
+++ b/.github/workflows/golden-talks.yml
@@ -9,6 +9,10 @@ name: Golden talks (full corpus)
 on:
   workflow_dispatch:
 
+# Read-only full-corpus pytest job; needs no write scopes.
+permissions:
+  contents: read
+
 jobs:
   golden:
     runs-on: ubuntu-latest

--- a/site/index.html
+++ b/site/index.html
@@ -3331,7 +3331,7 @@ function renderStatusBadge(status, reviewSt) {
 function renderPipelineDAG(tk, stages, st) {
   function node(label, done, href, extraCls) {
     var cls = 'pipe-node' + (done ? ' done' : '') + (extraCls ? ' ' + extraCls : '');
-    var sh = href ? safeHref(href) : '';
+    var sh = safeHref(href);
     if (sh) return '<a href="' + sh + '" class="' + cls + '">' + esc(label) + '</a>';
     return '<span class="' + cls + '">' + esc(label) + '</span>';
   }

--- a/site/index.html
+++ b/site/index.html
@@ -3150,7 +3150,7 @@ function renderIndex(el) {
     if (st) {
       var bc = st.status === 'approved' ? 'approved' : st.status === 'in-progress' ? 'in-review' : 'needs-review';
       var bt = st.status === 'approved' ? t('badge.approved') : st.status === 'in-progress' ? t('badge.in_review') + (st.reviewer ? ' (' + esc(st.reviewer) + ')' : '') : t('badge.needs_review');
-      var href = st.issue_number ? 'https://github.com/' + REPO + '/issues/' + st.issue_number : '#';
+      var href = safeHref(st.issue_number ? 'https://github.com/' + REPO + '/issues/' + st.issue_number : '#');
       badge = '<a href="' + href + '" target="_blank" class="review-badge ' + bc + '">' + bt + '</a>';
     }
     // Which action links to show. View (preview) needs subtitles on a playable
@@ -3165,21 +3165,34 @@ function renderIndex(el) {
       var lastSlug = localStorage.getItem('sy_last_video_' + tk.id);
       var targetVideo = (lastSlug && validVideos.find(function(v) { return v.slug === lastSlug; }))
         || validVideos[0];
-      videoLinks = '<a href="#/preview/' + tk.id + '/' + targetVideo.slug + '" class="preview-link">' + esc(t('link.preview')) + '</a>';
+      videoLinks = '<a href="' + safeHref('#/preview/' + tk.id + '/' + targetVideo.slug) + '" class="preview-link">' + esc(t('link.preview')) + '</a>';
     }
     var reviewLink = '';
     if (actions.review) {
-      reviewLink = '<a href="#/review/' + tk.id + '" class="review-link">&#x270E; ' + t('link.review') + '</a>';
+      reviewLink = '<a href="' + safeHref('#/review/' + tk.id) + '" class="review-link">&#x270E; ' + t('link.review') + '</a>';
     }
-    // Assemble card (all values are escaped or from trusted i18n)
-    var dateHtml = tk.amrutaUrl
-      ? '<a href="' + tk.amrutaUrl + '" target="_blank" title="' + t('link.amruta') + '" style="color:var(--fg5);text-decoration:none;">' + dateStr + ' &#x2197;</a>'
-      : dateStr;
-    var expertHtml = ' <a href="https://github.com/' + REPO + '/actions/workflows/subtitle-pipeline.yml" target="_blank" class="expert-only expert-btn" style="display:none;" onclick="event.stopPropagation();navigator.clipboard.writeText(\'' + tk.id + '\')" title="' + t('expert.copy_and_run') + '">&#x25B6; pipeline</a>';
+    // Assemble card. amruta_url is attacker-influenceable (meta.yaml from a
+    // PR / the amruta-scraping bookmarklet) so route it through safeHref;
+    // dateStr is escaped too. The expert button's talk-id copy is bound via
+    // addEventListener below (no raw tk.id in an inline onclick string).
+    var amrutaHref = safeHref(tk.amrutaUrl);
+    var dateHtml = amrutaHref
+      ? '<a href="' + amrutaHref + '" target="_blank" title="' + esc(t('link.amruta')) + '" style="color:var(--fg5);text-decoration:none;">' + esc(dateStr) + ' &#x2197;</a>'
+      : esc(dateStr);
+    var expertHtml = ' <a href="' + safeHref('https://github.com/' + REPO + '/actions/workflows/subtitle-pipeline.yml') + '" target="_blank" class="expert-only expert-btn" style="display:none;" title="' + esc(t('expert.copy_and_run')) + '">&#x25B6; pipeline</a>';
     var statusBadge = renderStatusBadge(status, st);
     div.innerHTML = '<div class="talk-date"><span>' + dateHtml + expertHtml + '</span>' + statusBadge + '</div>'
       + '<div class="talk-title">' + esc(tk.title || tk.id) + '</div>'
       + ((videoLinks || reviewLink) ? '<div class="talk-actions">' + videoLinks + reviewLink + '</div>' : '');
+
+    // Copy the talk id on expert-button click (id comes from the closure, never
+    // injected into HTML). stopPropagation keeps the card from expanding; the
+    // anchor's default action still opens the pipeline workflow in a new tab.
+    var expBtn = div.querySelector('.expert-btn');
+    if (expBtn) expBtn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      if (navigator.clipboard && navigator.clipboard.writeText) navigator.clipboard.writeText(tk.id);
+    });
 
     // Expert mode: click card to expand inline DAG detail (one at a time)
     if (expertMode) {
@@ -3310,7 +3323,7 @@ function renderStatusBadge(status, reviewSt) {
   };
   var text = labels[status] || status;
   if (status === 'in-review' && reviewSt && reviewSt.reviewer) text += ' (' + esc(reviewSt.reviewer) + ')';
-  var href = reviewSt && reviewSt.issue_number ? 'https://github.com/' + REPO + '/issues/' + reviewSt.issue_number : '';
+  var href = safeHref(reviewSt && reviewSt.issue_number ? 'https://github.com/' + REPO + '/issues/' + reviewSt.issue_number : '');
   if (href) return '<a href="' + href + '" target="_blank" class="review-badge ' + status + '">' + text + '</a>';
   return '<span class="review-badge ' + status + '">' + text + '</span>';
 }
@@ -3318,7 +3331,8 @@ function renderStatusBadge(status, reviewSt) {
 function renderPipelineDAG(tk, stages, st) {
   function node(label, done, href, extraCls) {
     var cls = 'pipe-node' + (done ? ' done' : '') + (extraCls ? ' ' + extraCls : '');
-    if (href) return '<a href="' + href + '" class="' + cls + '">' + esc(label) + '</a>';
+    var sh = href ? safeHref(href) : '';
+    if (sh) return '<a href="' + sh + '" class="' + cls + '">' + esc(label) + '</a>';
     return '<span class="' + cls + '">' + esc(label) + '</span>';
   }
   function arrow(done) {
@@ -4747,7 +4761,11 @@ SPA.openEditor = function() {
 // ============================================================
 // Helpers
 // ============================================================
-function esc(s) { return (s||'').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
+function esc(s) { return (s||'').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;'); }
+// Allow only http(s)/hash-route/mailto hrefs (blocks javascript:, data:,
+// protocol-relative //host), then HTML-escape so a quote/tag cannot break out
+// of the href="" attribute. Returns '' for disallowed/empty URLs.
+function safeHref(u) { return /^(https?:\/\/|#|mailto:)/i.test(u || '') ? esc(u) : ''; }
 function showToast(msg) {
   var el = document.getElementById('toast');
   el.textContent = msg; el.classList.add('show');

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -23,6 +23,16 @@ videos:
   vimeo_url: https://vimeo.com/67890/def
 """
 
+# Hostile amruta_url values (the meta.yaml / scraping-bookmarklet attacker
+# vector) that try to break out of the card's href="". Two distinct vectors,
+# because esc() escapes < > independently of the quote fix:
+#   - tag injection ("><img …>) — blocked by < > escaping + safeHref wiring
+#   - attribute injection (" data-xss="…) — blocked only by the " -> &quot; fix
+_XSS_AMRUTA_TAG = 'https://www.amruta.org/x"><img src=x onerror=window.__XSS_FIRED=true>'
+_XSS_AMRUTA_ATTR = 'https://www.amruta.org/x" data-xss="pwned'
+XSS_AMRUTA_TAG_META = SAMPLE_META + "amruta_url: '" + _XSS_AMRUTA_TAG + "'\n"
+XSS_AMRUTA_ATTR_META = SAMPLE_META + "amruta_url: '" + _XSS_AMRUTA_ATTR + "'\n"
+
 SAMPLE_SRT = """1
 00:00:01,000 --> 00:00:05,000
 Перший субтитр
@@ -5333,3 +5343,57 @@ class TestExpertPipelineButton:
         page.evaluate("localStorage.setItem('sy_expert_mode','1'); expertMode=true; applyExpertMode();")
         onclick_count = page.evaluate("document.querySelectorAll('.talk-item [onclick]').length")
         assert onclick_count == 0, f"a card still uses an inline onclick handler: {onclick_count}"
+
+
+class TestIndexCardXssDefenses:
+    """A hostile amruta_url from meta.yaml (the PR / scraping-bookmarklet vector)
+    must not break out of the card's href="". esc()/safeHref() are the only
+    defense — there is no CSP — so this renders a card from a real breakout
+    payload and asserts the DOM stays clean. Complements the source-regex guards
+    in test_spa_xss.js with a behavioural, refactor-resilient check."""
+
+    def test_hostile_amruta_url_cannot_inject_a_tag(self, server, page):
+        # Override the default meta.yaml mock with a tag-injection payload.
+        page.route(
+            "**/raw.githubusercontent.com/**/meta.yaml",
+            lambda route: route.fulfill(status=200, content_type="text/plain", body=XSS_AMRUTA_TAG_META),
+        )
+        page.add_init_script("window.__XSS_FIRED = false;")
+        goto_spa(page, server)
+        page.wait_for_selector(".talk-item", timeout=10000)
+        page.wait_for_timeout(200)
+        assert page.evaluate("window.__XSS_FIRED === true") is False, (
+            "amruta_url payload broke out of href= and fired onerror"
+        )
+        assert page.evaluate("document.querySelectorAll('.talk-item img').length") == 0, (
+            "an <img> element was injected from the amruta_url payload"
+        )
+
+    def test_hostile_amruta_url_cannot_inject_an_attribute(self, server, page):
+        # Quote-only breakout: " data-xss="pwned attempts to add a NEW attribute
+        # to the anchor. Only the esc() " -> &quot; fix blocks this (< > escaping
+        # does not), so this is the test with teeth for the attribute-sanitization
+        # alerts (#11-#17).
+        page.route(
+            "**/raw.githubusercontent.com/**/meta.yaml",
+            lambda route: route.fulfill(status=200, content_type="text/plain", body=XSS_AMRUTA_ATTR_META),
+        )
+        goto_spa(page, server)
+        page.wait_for_selector(".talk-item", timeout=10000)
+        injected = page.evaluate("document.querySelectorAll('.talk-item [data-xss]').length")
+        assert injected == 0, "amruta_url broke out of href= and injected a data-xss attribute"
+
+    def test_javascript_scheme_amruta_url_is_dropped(self, server, page):
+        js_meta = SAMPLE_META + "amruta_url: 'javascript:window.__XSS_FIRED=true'\n"
+        page.route(
+            "**/raw.githubusercontent.com/**/meta.yaml",
+            lambda route: route.fulfill(status=200, content_type="text/plain", body=js_meta),
+        )
+        page.add_init_script("window.__XSS_FIRED = false;")
+        goto_spa(page, server)
+        page.wait_for_selector(".talk-item", timeout=10000)
+        bad = page.evaluate(
+            "Array.from(document.querySelectorAll('.talk-item a')).filter("
+            "a => (a.getAttribute('href') || '').toLowerCase().startsWith('javascript:')).length"
+        )
+        assert bad == 0, "a javascript: amruta_url survived into an anchor href"

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -5298,3 +5298,38 @@ class TestSrtReviewEditsPersist:
             timeout=10000,
         )
         assert page.evaluate("reviewState.edits['0']") == "TRANSCRIPT_EDIT", "transcript edit clobbered by SRT edit"
+
+
+class TestExpertPipelineButton:
+    """The expert-mode pipeline button copies the talk id to the clipboard.
+
+    The copy was reworked from an inline onclick that concatenated the raw
+    talk id into an HTML attribute (an XSS sink — CodeQL js/xss #18) to a
+    dataset-free addEventListener that reads the id from the render closure.
+    This guards that the copy behaviour survived the rework.
+    """
+
+    def test_expert_button_copies_talk_id(self, server, page):
+        goto_spa(page, server)
+        page.wait_for_selector(".talk-item", timeout=10000)
+        page.evaluate(
+            "window._clipText = '';"
+            "navigator.clipboard.writeText = function(t){ window._clipText = t; return Promise.resolve(); };"
+        )
+        page.evaluate("localStorage.setItem('sy_expert_mode','1'); expertMode=true; applyExpertMode();")
+        # Drop the href so the anchor's default new-tab navigation doesn't open
+        # a popup during the test; the copy listener fires regardless.
+        page.evaluate("document.querySelector('.talk-item .expert-btn').removeAttribute('href')")
+        page.click(".talk-item .expert-btn")
+        clip = page.evaluate("window._clipText || ''")
+        assert clip == "2001-01-01_Test-Talk", f"expert button copied wrong id: {clip!r}"
+
+    def test_talk_id_never_appears_inside_an_inline_onclick(self, server, page):
+        """Defense-in-depth: no rendered card carries an inline onclick at all,
+        so a talk id (a directory name a malicious PR could craft with quotes)
+        can never break out of an attribute into script."""
+        goto_spa(page, server)
+        page.wait_for_selector(".talk-item", timeout=10000)
+        page.evaluate("localStorage.setItem('sy_expert_mode','1'); expertMode=true; applyExpertMode();")
+        onclick_count = page.evaluate("document.querySelectorAll('.talk-item [onclick]').length")
+        assert onclick_count == 0, f"a card still uses an inline onclick handler: {onclick_count}"

--- a/tests/test_spa_xss.js
+++ b/tests/test_spa_xss.js
@@ -14,15 +14,18 @@ const fs = require('fs');
 
 const HTML = fs.readFileSync('site/index.html', 'utf8');
 
+// Match lazily to the first closing brace (esc/safeHref have no inner braces)
+// rather than to end-of-line, so a future multi-line reformat won't break
+// extraction.
 function loadEsc() {
-  const escM = HTML.match(/function esc\(s\) \{[^\n]*\}/);
-  assert.ok(escM, 'esc() one-liner not found in index.html');
+  const escM = HTML.match(/function esc\(s\) \{[\s\S]*?\}/);
+  assert.ok(escM, 'esc() not found in index.html');
   return eval('(' + escM[0] + ')');
 }
 
 function loadEscapers() {
-  const shM = HTML.match(/function safeHref\(u\) \{[^\n]*\}/);
-  assert.ok(shM, 'safeHref() one-liner not found in index.html');
+  const shM = HTML.match(/function safeHref\(u\) \{[\s\S]*?\}/);
+  assert.ok(shM, 'safeHref() not found in index.html');
   // Parenthesise so eval yields the function expression; safeHref closes over esc.
   const esc = loadEsc();
   const safeHref = eval('(' + shM[0] + ')');

--- a/tests/test_spa_xss.js
+++ b/tests/test_spa_xss.js
@@ -1,0 +1,111 @@
+// Tests for the SPA's XSS defenses in site/index.html:
+//   - esc()      — HTML escaper, must be attribute-safe (escape " and ')
+//   - safeHref()  — URL scheme allowlist + escaping for href= sinks
+//   - source guards — the talk-card / pipeline-DAG sinks must route
+//     attacker-influenceable values (amruta_url, talk id, issue_number)
+//     through esc()/safeHref() instead of raw concatenation.
+//
+// esc()/safeHref() live inline in index.html (single-source, no js/ mirror),
+// so — like extractI18N in test_spa_cache.js — we extract the real function
+// source and eval it, exercising the shipped code rather than a replica.
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+
+const HTML = fs.readFileSync('site/index.html', 'utf8');
+
+function loadEsc() {
+  const escM = HTML.match(/function esc\(s\) \{[^\n]*\}/);
+  assert.ok(escM, 'esc() one-liner not found in index.html');
+  return eval('(' + escM[0] + ')');
+}
+
+function loadEscapers() {
+  const shM = HTML.match(/function safeHref\(u\) \{[^\n]*\}/);
+  assert.ok(shM, 'safeHref() one-liner not found in index.html');
+  // Parenthesise so eval yields the function expression; safeHref closes over esc.
+  const esc = loadEsc();
+  const safeHref = eval('(' + shM[0] + ')');
+  return { esc, safeHref };
+}
+
+describe('SPA esc() — attribute-safe HTML escaping', () => {
+  it('escapes double and single quotes', () => {
+    const esc = loadEsc();
+    assert.strictEqual(esc('"'), '&quot;');
+    assert.strictEqual(esc("'"), '&#39;');
+  });
+
+  it('still escapes & < > with no double-escaping', () => {
+    const esc = loadEsc();
+    assert.strictEqual(esc('<a>&"\''), '&lt;a&gt;&amp;&quot;&#39;');
+  });
+
+  it('treats null/undefined as empty string', () => {
+    const esc = loadEsc();
+    assert.strictEqual(esc(null), '');
+    assert.strictEqual(esc(undefined), '');
+  });
+});
+
+describe('SPA safeHref() — URL scheme allowlist + escaping', () => {
+  it('passes http(s) and hash routes through unchanged', () => {
+    const { safeHref } = loadEscapers();
+    assert.strictEqual(safeHref('https://www.amruta.org/x/'), 'https://www.amruta.org/x/');
+    assert.strictEqual(safeHref('http://amruta.org'), 'http://amruta.org');
+    assert.strictEqual(safeHref('#/review/2020_x'), '#/review/2020_x');
+  });
+
+  it('blocks javascript:, data: and protocol-relative URLs', () => {
+    const { safeHref } = loadEscapers();
+    assert.strictEqual(safeHref('javascript:alert(1)'), '');
+    assert.strictEqual(safeHref('data:text/html,<script>alert(1)</script>'), '');
+    assert.strictEqual(safeHref('//evil.com'), '');
+  });
+
+  it('escapes a quote/tag breakout inside an allowed URL', () => {
+    const { safeHref } = loadEscapers();
+    assert.strictEqual(
+      safeHref('https://x/"><img src=x onerror=alert(1)>'),
+      'https://x/&quot;&gt;&lt;img src=x onerror=alert(1)&gt;'
+    );
+  });
+
+  it('returns empty for empty/garbage input', () => {
+    const { safeHref } = loadEscapers();
+    assert.strictEqual(safeHref(''), '');
+    assert.strictEqual(safeHref(null), '');
+    assert.strictEqual(safeHref('not a url'), '');
+  });
+});
+
+describe('SPA index source — XSS sinks are sanitized (regression guards)', () => {
+  it('the amruta date link routes amruta_url through safeHref', () => {
+    assert.ok(
+      !/href="'\s*\+\s*tk\.amrutaUrl/.test(HTML),
+      'raw tk.amrutaUrl is still concatenated straight into an href attribute'
+    );
+    assert.ok(
+      /safeHref\(tk\.amrutaUrl\)/.test(HTML),
+      'tk.amrutaUrl is not routed through safeHref()'
+    );
+  });
+
+  it('the expert pipeline button does not inject the talk id via inline onclick', () => {
+    assert.ok(
+      !/expert-btn[^>]*onclick=/.test(HTML),
+      'expert-btn still carries an inline onclick (raw tk.id sink)'
+    );
+    assert.ok(
+      /querySelector\('\.expert-btn'\)/.test(HTML) && /addEventListener\('click'/.test(HTML),
+      'expert-btn copy is not bound via addEventListener'
+    );
+  });
+
+  it('the pipeline-DAG node() escapes its href', () => {
+    assert.ok(
+      /safeHref\(href\)/.test(HTML),
+      'renderPipelineDAG node() does not pass its href through safeHref()'
+    );
+  });
+});


### PR DESCRIPTION
Resolves 13 of the 25 open CodeQL alerts — the two genuinely fixable groups. Triaged + adversarially verified; full triage in the session notes.

## 1. Workflow permissions (`0435a03d`) — CodeQL alerts 1–4

<!-- alert numbers, not issue refs — no auto-close keyword on purpose -->


`ci.yml` (lint, test, test-js) and `golden-talks.yml` (golden) declared no `permissions:` block, so `GITHUB_TOKEN` inherited broad default scopes. All four are read-only lint/test jobs, so a single top-level `permissions: contents: read` per file applies to every job.

## 2. SPA XSS / attribute sanitization (`36bea58f`) — CodeQL alerts 11–19

Two roots in `site/index.html`:

1. **`esc()` was not quote-safe** (escaped `& < >` but not `"`/`'`), so any value placed in a double-quoted attribute via `esc(x)` could break out → `incomplete-html-attribute-sanitization` (#11–#17). Now also escapes `"`→`&quot;` and `'`→`&#39;` (`&` replaced first, no double-escaping).
2. **Several href/onclick sinks bypassed `esc()` entirely** (the two HIGH `js/xss`, #18/#19):
   - `tk.amrutaUrl` (from `meta.yaml`, attacker-influenceable via a PR or the amruta-scraping bookmarklet) concatenated raw into `href=""`.
   - the talk id concatenated raw into an inline `onclick="…writeText('<id>')"` (a directory name a malicious PR could craft with quotes).
   - `issue_number` concatenated raw into `renderPipelineDAG` / badge hrefs.

   New `safeHref(u)`: allow only `http(s)`/hash-route/`mailto` (blocks `javascript:`, `data:`, protocol-relative `//host`), then `esc()`. Every dynamic href (amruta link, preview/review links, review badges, pipeline-DAG nodes) routes through it. The expert button's inline `onclick` is replaced with an `addEventListener` that reads the id from the render closure, so the id never enters HTML.

**Severity note:** the reachable vector is *stored-on-default-branch* (a malicious `meta.yaml` / `review-status.json` merged to `main`), **not** the anonymous `?branch=` link — that 404s the Trees API and never loads a manifest. No GitHub token is stored, so the worst case was origin-script-exec on the Pages site (localStorage theft of review marks, phishing), not token exfiltration.

`esc()`/`safeHref()`/the render functions are single-source in `index.html` (no `js/` mirror).

### Tests (TDD)
- `tests/test_spa_xss.js` — extracts and exercises the **real** `esc()`/`safeHref()` from `index.html` (the `extractI18N` pattern) + source guards for the three sinks.
- `tests/test_preview_spa.py` — expert-button copy + "no inline onclick on any card" E2E coverage (none existed before).
- Green locally: **499/499** JS (`node --test`), **313/313** E2E (`pytest tests/test_preview_spa.py`).

## Not in this PR
- **9 test-file false positives** (#5,6,7,8,9,10,23,24,25 — i18n lint helpers / pytest assertions over the repo's own source). The repo uses CodeQL **default setup**, so a checked-in `paths-ignore` is a no-op; these will be **dismissed in the Security UI** instead.
- **#20/#21/#22** (`incomplete-url-substring-sanitization` in `sw.js`/`add_talk_data.js`) — real but non-exploitable (fail-safe cache-strategy / UI-routing, never a trust decision). Optional hardening, left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
