### PR TITLE
Resolve remaining CodeQL URL host-check alerts + drop stale test reimplementations

### DIFF
--- a/site/js/add_talk_data.js
+++ b/site/js/add_talk_data.js
@@ -26,11 +26,23 @@ function parseAddTalkHash(hash) {
     return { state: 'parse_error', data: null };
   }
 
-  if (!data.u || data.u.indexOf('amruta.org') === -1) {
+  if (!isAmrutaUrl(data.u)) {
     return { state: 'wrong_site', data: null };
   }
 
   return { state: 'form', data: data };
+}
+
+// True only when the url's HOST is amruta.org (or a subdomain like www.).
+// A substring test (indexOf('amruta.org')) wrongly accepted look-alikes such
+// as http://evil.com/#amruta.org and amruta.org.attacker.com.
+function isAmrutaUrl(u) {
+  try {
+    var h = new URL(u).hostname;
+    return h === 'amruta.org' || h.endsWith('.amruta.org');
+  } catch (e) {
+    return false;
+  }
 }
 
 // Render a scalar as a single-quoted YAML string, escaping embedded quotes by
@@ -78,5 +90,5 @@ function buildMetaYaml(fields) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { parseAddTalkHash: parseAddTalkHash, buildMetaYaml: buildMetaYaml };
+  module.exports = { parseAddTalkHash: parseAddTalkHash, isAmrutaUrl: isAmrutaUrl, buildMetaYaml: buildMetaYaml };
 }

--- a/site/sw.js
+++ b/site/sw.js
@@ -39,9 +39,9 @@ function isApiOrRaw(url) {
   // must not be treated as a GitHub API/raw request.
   try {
     var h = new URL(url).hostname;
-    return h === 'api.github.com'
-      || h === 'raw.githubusercontent.com'
-      || h.endsWith('.raw.githubusercontent.com');
+    // Both hosts are used bare by the app; no subdomain form exists in GitHub's
+    // infrastructure, so exact match (symmetric for both) is correct here.
+    return h === 'api.github.com' || h === 'raw.githubusercontent.com';
   } catch (e) {
     return false;
   }

--- a/site/sw.js
+++ b/site/sw.js
@@ -35,7 +35,16 @@ function isImmutable(url) {
 }
 
 function isApiOrRaw(url) {
-  return url.includes('api.github.com') || url.includes('raw.githubusercontent.com');
+  // Match on the actual host, not a substring: "https://evil.com/?x=api.github.com"
+  // must not be treated as a GitHub API/raw request.
+  try {
+    var h = new URL(url).hostname;
+    return h === 'api.github.com'
+      || h === 'raw.githubusercontent.com'
+      || h.endsWith('.raw.githubusercontent.com');
+  } catch (e) {
+    return false;
+  }
 }
 
 function isNavigation(url) {

--- a/tests/test_add_talk_data.js
+++ b/tests/test_add_talk_data.js
@@ -53,6 +53,28 @@ describe('parseAddTalkHash — routing states', () => {
   });
 });
 
+// A payload's url must be an actual amruta.org host, not merely contain the
+// string "amruta.org" somewhere — otherwise http://evil.com/#amruta.org or
+// amruta.org.attacker.com would pass (CodeQL js/incomplete-url-substring).
+describe('parseAddTalkHash — amruta host validation (not substring)', () => {
+  const stateFor = (u) => parseAddTalkHash(hashFor({ ...validTalk, u })).state;
+  it('accepts the bare amruta.org host', () => {
+    assert.strictEqual(stateFor('https://amruta.org/1978/10/02/x/'), 'form');
+  });
+  it('accepts the www.amruta.org host', () => {
+    assert.strictEqual(stateFor('https://www.amruta.org/1978/10/02/x/'), 'form');
+  });
+  it('rejects a host that only contains amruta.org in the path or fragment', () => {
+    assert.strictEqual(stateFor('http://attacker.com/#amruta.org'), 'wrong_site');
+  });
+  it('rejects a look-alike host suffixed with amruta.org', () => {
+    assert.strictEqual(stateFor('https://amruta.org.evil.com/x'), 'wrong_site');
+  });
+  it('rejects an unparseable url', () => {
+    assert.strictEqual(stateFor('not a url'), 'wrong_site');
+  });
+});
+
 // Regression: a literal '%' in the title or transcript (e.g. "100%") used to
 // trip a redundant decodeURIComponent on already-decoded text, throwing
 // "URI malformed" and surfacing the misleading "Wrong site" error.

--- a/tests/test_spa_cache.js
+++ b/tests/test_spa_cache.js
@@ -1252,6 +1252,11 @@ function swIsImmutable(url) {
 function loadSwFn(name) {
   var fs = require('fs');
   var src = fs.readFileSync('site/sw.js', 'utf8');
+  // Grab the function body up to the first closing brace at column 0. This
+  // assumes top-level sw.js functions close on their own line and any inner
+  // braces stay indented (true today). It fails loud if violated — no match
+  // throws here, a truncated match throws on eval — never a wrong-but-passing
+  // function. Same extract-the-real-source approach as extractI18N below.
   var m = src.match(new RegExp('function ' + name + '\\([\\s\\S]*?\\n\\}'));
   assert.ok(m, name + '() not found in site/sw.js');
   return eval('(' + m[0] + ')');

--- a/tests/test_spa_cache.js
+++ b/tests/test_spa_cache.js
@@ -1246,9 +1246,17 @@ function swIsImmutable(url) {
   var patterns = ['cdn.jsdelivr.net', 'player.vimeo.com/api', '/icon.png'];
   return patterns.some(function(p) { return url.includes(p); });
 }
-function swIsApiOrRaw(url) {
-  return url.includes('api.github.com') || url.includes('raw.githubusercontent.com');
+// Exercise the REAL isApiOrRaw from site/sw.js (extracted + eval'd, like
+// extractI18N) instead of a hand-copied reimplementation that can silently
+// drift from production.
+function loadSwFn(name) {
+  var fs = require('fs');
+  var src = fs.readFileSync('site/sw.js', 'utf8');
+  var m = src.match(new RegExp('function ' + name + '\\([\\s\\S]*?\\n\\}'));
+  assert.ok(m, name + '() not found in site/sw.js');
+  return eval('(' + m[0] + ')');
 }
+var swIsApiOrRaw = loadSwFn('isApiOrRaw');
 function swIsNavigation(url) {
   return url.endsWith('/') || url.endsWith('/index.html') || url.includes('sy-subtitles/#');
 }
@@ -1274,6 +1282,10 @@ describe('SW: isApiOrRaw', () => {
   it('GitHub API', () => assert.strictEqual(swIsApiOrRaw('https://api.github.com/repos/foo'), true));
   it('raw.githubusercontent', () => assert.strictEqual(swIsApiOrRaw('https://raw.githubusercontent.com/foo/file.srt'), true));
   it('index.html is not API', () => assert.strictEqual(swIsApiOrRaw('https://site.github.io/sy-subtitles/'), false));
+  // Host must match, not merely appear as a substring of the URL.
+  it('attacker host with api.github.com in the query is not API', () => assert.strictEqual(swIsApiOrRaw('https://attacker.com/?x=api.github.com'), false));
+  it('attacker host with raw host in the fragment is not raw', () => assert.strictEqual(swIsApiOrRaw('https://attacker.com/#raw.githubusercontent.com'), false));
+  it('look-alike suffix host is not API', () => assert.strictEqual(swIsApiOrRaw('https://api.github.com.evil.com/x'), false));
 });
 
 describe('SW: isNavigation', () => {
@@ -1919,43 +1931,12 @@ describe('Preview: cleanup on navigation', () => {
   });
 });
 
-describe('Add Talk: three states logic', () => {
-  function getAddState(hash) {
-    if (!hash || !hash.includes('?data=')) return 'setup';
-    var qm = hash.indexOf('?');
-    var params = new URLSearchParams(hash.slice(qm));
-    var dataStr = params.get('data');
-    if (!dataStr) return 'setup';
-    try {
-      var data = JSON.parse(decodeURIComponent(dataStr));
-      if (!data.u) return 'error';
-      if (!data.u.includes('amruta.org')) return 'wrong-site';
-      return 'form';
-    } catch(e) { return 'error'; }
-  }
-
-  it('no data param → setup (bookmarklet instruction)', () => {
-    assert.strictEqual(getAddState('/add'), 'setup');
-  });
-  it('empty hash → setup', () => {
-    assert.strictEqual(getAddState(''), 'setup');
-  });
-  it('valid amruta data → form', () => {
-    var enc = encodeBookmarkletData({ t: 'Test', u: 'https://www.amruta.org/test', v: [] });
-    assert.strictEqual(getAddState('/add?data=' + enc), 'form');
-  });
-  it('non-amruta URL → wrong-site', () => {
-    var enc = encodeBookmarkletData({ t: 'Test', u: 'https://example.com/page', v: [] });
-    assert.strictEqual(getAddState('/add?data=' + enc), 'wrong-site');
-  });
-  it('invalid data → error', () => {
-    assert.strictEqual(getAddState('/add?data=%ZZinvalid'), 'error');
-  });
-  it('data without url field → error', () => {
-    var enc = encodeBookmarkletData({ t: 'Test' });
-    assert.strictEqual(getAddState('/add?data=' + enc), 'error');
-  });
-});
+// Add-talk routing states (setup / form / wrong_site / parse_error) are tested
+// against the REAL parseAddTalkHash in tests/test_add_talk_data.js. The former
+// getAddState reimplementation here had drifted from production (it returned
+// 'error' for a missing url where production returns 'wrong_site', and still
+// did a double decodeURIComponent that production removed), so it was dropped
+// in favour of exercising the shipped function directly.
 
 describe('Add Talk: SPA code integrity', () => {
   var fs = require('fs');


### PR DESCRIPTION
Follow-up to #442. Resolves the remaining **URL host-check** CodeQL alerts at the source, and removes two stale test reimplementations that tripped the same rule.

CodeQL `incomplete-url-substring-sanitization` fires where a host is checked with `url.includes('host')` / `indexOf('host')` — which also matches `https://evil.com/?x=raw.githubusercontent.com` or `amruta.org.attacker.com`.

## Production (defense-in-depth)
Neither was a *reachable* vulnerability — `sw.js` only picks a cache strategy (a spurious match falls to `networkFirst`, the default), and `add_talk_data.js` only routes the add-talk UI (`data.u` is never fetched; it lands in a human-reviewed PR). Both now match on the actual host:

- **`site/sw.js` `isApiOrRaw`** (#21/#22): `new URL(url).hostname` **exact match** for both `api.github.com` and `raw.githubusercontent.com`. Both hosts are used bare by the app and GitHub has no `*.raw.githubusercontent.com` host (media/objects use `*.githubusercontent.com`), so a dot-suffix wildcard would be dead, untested, and asymmetric — exact-match is symmetric and fully covered. `isImmutable` is intentionally left untouched — it's not flagged and its patterns include a path (`/icon.png`), so it isn't a pure host check.
- **`site/js/add_talk_data.js` `parseAddTalkHash`** (#20): new `isAmrutaUrl(u)` helper (`hostname === 'amruta.org' || endsWith('.amruta.org')`), exported for reuse/testing.

## Tests — remove the flagged constructs at the source
- **`tests/test_spa_cache.js`**: the SW harness reimplemented `isApiOrRaw` with the same substring idiom (#23/#24). Replaced with the **real** `isApiOrRaw` extracted from `site/sw.js` (the `extractI18N` pattern), plus host-vs-substring cases. The `getAddState` block (#25) was a **stale duplicate** of `parseAddTalkHash` — it returned `'error'` for a missing url where production returns `'wrong_site'`, and still double-decoded the payload — so it's dropped; `tests/test_add_talk_data.js` already exercises the shipped function.
- **`tests/test_add_talk_data.js`**: added amruta host-validation cases (accept bare/`www` host; reject path/fragment-only and look-alike-suffix hosts) — written **failing first**, then fixed.

Resolves CodeQL alerts **#20, #21, #22, #23, #24, #25**.

Green locally: **491/491** JS (`node --test`), **313/313** E2E (`pytest tests/test_preview_spa.py`).

## Deliberately not here
The other test-file alerts — **#5/#6** (pytest assertions) and **#7–#10** (i18n lint regexes) — are CodeQL **misclassifying test infrastructure** that parses the repo's own committed source (not runtime sanitizers, no untrusted input). They stay **dismissed as "used in tests."** Rewriting that test code purely to dodge the heuristic is unverifiable locally (no CodeQL in CI's default setup to confirm a clear) and arguably less honest than the dismissal; happy to attempt it if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
