### PR TITLE
Harden vimeoEmbed: no raw URL passthrough into preview iframe.src

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -3539,7 +3539,10 @@ function vimeoEmbed(url) {
   if (m) return 'https://player.vimeo.com/video/' + m[1] + '?h=' + m[2];
   m = url.match(/vimeo\.com\/(\d+)(?![\/\w])/);
   if (m) return 'https://player.vimeo.com/video/' + m[1];
-  return url;
+  // Not a recognized Vimeo URL — return '' rather than the raw input, which
+  // would otherwise reach iframe.src in the preview route (a javascript:/data:/
+  // protocol-relative vimeo_url from meta.yaml would load/run in the iframe).
+  return '';
 }
 
 function savePreviewState() {

--- a/tests/test_spa_xss.js
+++ b/tests/test_spa_xss.js
@@ -112,3 +112,38 @@ describe('SPA index source — XSS sinks are sanitized (regression guards)', () 
     );
   });
 });
+
+describe('SPA vimeoEmbed() — only ever yields a player.vimeo.com embed URL', () => {
+  // vimeoEmbed() feeds iframe.src in the preview route; a non-Vimeo vimeo_url
+  // from meta.yaml must not pass through raw (javascript:/data://evil would
+  // load/run in the iframe). Extract + eval the real function (extractI18N
+  // pattern); first closing brace at column 0, no inner braces.
+  function loadVimeoEmbed() {
+    const m = HTML.match(/function vimeoEmbed\(url\) \{[\s\S]*?\n\}/);
+    assert.ok(m, 'vimeoEmbed() not found in index.html');
+    return eval('(' + m[0] + ')');
+  }
+
+  it('maps a private vimeo.com/ID/HASH url to an embed url', () => {
+    assert.strictEqual(loadVimeoEmbed()('https://vimeo.com/12345/abcdef'),
+      'https://player.vimeo.com/video/12345?h=abcdef');
+  });
+  it('maps a public vimeo.com/ID url to an embed url', () => {
+    assert.strictEqual(loadVimeoEmbed()('https://vimeo.com/12345'),
+      'https://player.vimeo.com/video/12345');
+  });
+  it('returns empty for a javascript: url (no raw passthrough into iframe.src)', () => {
+    assert.strictEqual(loadVimeoEmbed()('javascript:alert(1)'), '');
+  });
+  it('returns empty for data: and protocol-relative urls', () => {
+    const f = loadVimeoEmbed();
+    assert.strictEqual(f('data:text/html,<script>alert(1)</script>'), '');
+    assert.strictEqual(f('//evil.com'), '');
+  });
+  it('returns empty for an arbitrary non-vimeo http url', () => {
+    assert.strictEqual(loadVimeoEmbed()('https://evil.com/x'), '');
+  });
+  it('returns empty for empty input', () => {
+    assert.strictEqual(loadVimeoEmbed()(''), '');
+  });
+});


### PR DESCRIPTION
Follow-up from the #442 review (filed there as a fast follow-up, not blocking that PR). Closes the one remaining XSS sink of the same class.

## The bug
`vimeoEmbed(url)` (`site/index.html`) returns its input **unchanged** when it matches neither Vimeo pattern:
```js
function vimeoEmbed(url) {
  var m = url.match(/vimeo\.com\/(\d+)\/([a-f0-9]+)/);
  if (m) return 'https://player.vimeo.com/video/' + m[1] + '?h=' + m[2];
  m = url.match(/vimeo\.com\/(\d+)(?![\/\w])/);
  if (m) return 'https://player.vimeo.com/video/' + m[1];
  return url;            // <-- raw passthrough
}
```
The preview route feeds that straight into `iframe.src` with only a truthiness guard:
```js
var embedUrl = video ? vimeoEmbed(video.vimeo_url) : '';
...
if (embedUrl) iframe.src = embedUrl + '&texttrack=false';
```
`video.vimeo_url` comes from `meta.yaml` — the same PR / scraping-bookmarklet vector the #442 `href` fixes defend. A `vimeo_url` of `javascript:…`, `data:text/html,…`, or `//evil.com` **loads/runs in the player iframe on render** — no click, no CSP. Pre-existing (commit `22923702`), not in the #442 diff.

The sibling sink already gets this right: `SyncPlayer.mountPlayer` (`~2349`) gates on `/player\.vimeo\.com\/video\/\d+/` before assigning `iframe.src`; only the preview route lacked the equivalent.

## The fix
`vimeoEmbed`'s contract is "produce a `player.vimeo.com` embed URL." For anything it doesn't recognize it now returns `''` instead of the raw input. Both callers already handle `''`:
- preview route: `if (embedUrl)` skips setting `iframe.src`;
- `SyncPlayer`: its regex gate bails.

Valid Vimeo URLs are unchanged. `vimeoEmbed` is single-source in `index.html` (no `js/` mirror).

## Tests (TDD)
`tests/test_spa_xss.js` extracts and exercises the **real** `vimeoEmbed` (the `extractI18N` pattern): valid `vimeo.com/ID[/HASH]` → embed URL (unchanged); `javascript:` / `data:` / `//evil.com` / arbitrary non-Vimeo http → `''`. Confirmed **RED first** (those returned the raw input), GREEN after the fix.

Green locally: **505/505** JS (`node --test`); preview/player E2E unaffected (valid Vimeo URLs are unchanged; the player iframe is mocked in E2E, so the unit test on the pure function is the meaningful guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
