### PR TITLE
Retry SyncPlayer E2E tests to absorb CI scheduling flakiness

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 pytest>=8.0
 pytest-xdist>=3.8
+pytest-rerunfailures>=14.0
 ruff>=0.8
 pre-commit>=4.0
 playwright>=1.59.0

--- a/tests/test_sync_player.py
+++ b/tests/test_sync_player.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from tests.test_preview_spa import (  # noqa: F401  — re-exported fixtures
     SPA_URL,
     browser,
@@ -18,6 +20,16 @@ from tests.test_preview_spa import (  # noqa: F401  — re-exported fixtures
     server,
     spa_path,
 )
+
+# Every test here drives the click -> mountPlayer -> (mock) Vimeo SDK fetch ->
+# new Vimeo.Player -> #mock-player chain. The button's handler is a static
+# inline onclick (never an unbound-handler race), so a failure to reach
+# #mock-player is pure scheduling latency: on a 2-core CI runner under
+# `pytest -n auto` a worker can be starved long enough that the chain misses
+# even the widened 20s budget. Widening the timeout alone did not fully fix it,
+# so retry the (idempotent, read-only) tests; a genuine logic regression still
+# fails all attempts. Scoped to this module so it cannot mask flakes elsewhere.
+pytestmark = pytest.mark.flaky(reruns=2, reruns_delay=2)
 
 # Single timeout budget for "wait for an SPA-rendered element" probes. The
 # click→mount chain that produces #mock-player is synchronous once the page has


### PR DESCRIPTION
`test_sync_player.py::TestSmartPauseGuards::test_manual_window_scroll_pauses_follow` intermittently times out waiting for `#mock-player` under `pytest -n auto` (seen on a recent unrelated PR run; passed on rerun with no code change).

## Root cause — scheduling latency, not a logic bug
The `#btn-sync-player` button uses a **static inline `onclick="SPA.onSyncBtnClick()"`** (`index.html:1444`), so there is no unbound-handler race — the click always fires. Every failure is the **post-click async chain** missing the deadline: `onSyncBtnClick → mountPlayer → fetch the (mocked) Vimeo SDK → new Vimeo.Player → #mock-player`. On a 2-core CI runner a worker can be CPU-starved long enough that this synchronous-once-loaded chain misses even the **already-widened 20s** `RENDER_WAIT_MS`. Widening the timeout further was already tried and did not fully fix it.

## Fix
- Add `pytest-rerunfailures` to `requirements-dev.txt`.
- Module-scoped `pytestmark = pytest.mark.flaky(reruns=2, reruns_delay=2)` in `tests/test_sync_player.py`.

The tests are idempotent and read-only, so a retry is safe. A **genuine regression still fails all three attempts** — only a transient scheduling blip is absorbed. Scoped to this one module so it can't mask flakes elsewhere; no change to the `pytest tests/ -n auto` command (the mark is honoured once the plugin is installed).

Verified the rerun mechanism fires (a probe that fails-then-passes reruns and passes; `rerunfailures-16.1`), the `flaky` mark is recognised (no unknown-mark warning), and the previously-flaky test + the mount tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)