### PR TITLE
Add E2E coverage for the service worker (sw.js)

### DIFF
--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -1,0 +1,96 @@
+"""E2E coverage for the service worker (site/sw.js).
+
+The SPA skips SW registration on localhost (index.html guards on hostname),
+so the Playwright suite never exercised the worker. These tests register
+sw.js directly and drive the real install / activate / fetch-handler chain in
+Chromium, covering the caching strategy (cache-first for immutable assets,
+network-first for navigation — the branch where isApiOrRaw/isNavigation live)
+and the activate-time purge of stale version caches.
+
+Reuses the server/page fixtures from test_preview_spa.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.test_preview_spa import (  # noqa: F401  — re-exported fixtures
+    browser,
+    mock_player_js,
+    page,
+    server,
+    spa_path,
+)
+
+# SW install/activate/claim and the fetch chain are timing-sensitive under
+# `pytest -n auto` on a 2-core CI runner. The assertions are deterministic;
+# only the scheduling is not — so retry rather than widen the timeout forever.
+pytestmark = pytest.mark.flaky(reruns=2, reruns_delay=2)
+
+CACHE = "sy-subtitles-c3"  # CACHE_NAME in sw.js (CACHE_VERSION = 3)
+SW_WAIT_MS = 15000
+
+
+def _register_sw(page, server):  # noqa: F811
+    """Register sw.js and wait until it controls the page (clients.claim())."""
+    page.goto(f"{server}/index.html")
+    page.evaluate("() => navigator.serviceWorker.register('sw.js')")
+    page.wait_for_function("() => !!navigator.serviceWorker.controller", timeout=SW_WAIT_MS)
+
+
+class TestServiceWorker:
+    def test_registers_activates_and_controls_page(self, server, page):  # noqa: F811
+        _register_sw(page, server)
+        script_url = page.evaluate("() => navigator.serviceWorker.controller.scriptURL")
+        assert script_url.endswith("/sw.js"), script_url
+
+    def test_immutable_asset_populates_versioned_cache(self, server, page):  # noqa: F811
+        _register_sw(page, server)
+        page.evaluate("() => fetch('icon.png')")
+        page.wait_for_function(
+            "async () => { const c = await caches.open('sy-subtitles-c3');"
+            " return !!(await c.match(location.origin + '/icon.png')); }",
+            timeout=10000,
+        )
+        assert CACHE in page.evaluate("() => caches.keys()")
+
+    def test_immutable_asset_is_served_cache_first(self, server, page):  # noqa: F811
+        _register_sw(page, server)
+        # Seed a sentinel under the icon.png key; cache-first must return it
+        # without going to the network.
+        page.evaluate(
+            "async () => { const c = await caches.open('sy-subtitles-c3');"
+            " await c.put(location.origin + '/icon.png',"
+            " new Response('SENTINEL', {headers: {'content-type': 'text/plain'}})); }"
+        )
+        body = page.evaluate("async () => (await (await fetch('icon.png')).text())")
+        assert body == "SENTINEL", f"icon.png was not served cache-first: {body[:80]!r}"
+
+    def test_navigation_is_network_first_over_stale_cache(self, server, page):  # noqa: F811
+        _register_sw(page, server)
+        # Seed a stale sentinel for index.html; network-first must prefer the
+        # live response when the network is reachable.
+        page.evaluate(
+            "async () => { const c = await caches.open('sy-subtitles-c3');"
+            " await c.put(location.origin + '/index.html',"
+            " new Response('STALE', {headers: {'content-type': 'text/html'}})); }"
+        )
+        body = page.evaluate("async () => (await (await fetch('index.html')).text())")
+        assert "STALE" not in body, "index.html was served from stale cache (should be network-first)"
+        assert "<" in body, f"expected the real index.html, got: {body[:80]!r}"
+
+    def test_activate_purges_stale_version_caches(self, server, page):  # noqa: F811
+        page.goto(f"{server}/index.html")
+        # Seed an OLD version cache before the worker activates.
+        page.evaluate(
+            "async () => { const c = await caches.open('sy-subtitles-c2');"
+            " await c.put(location.origin + '/old', new Response('x')); }"
+        )
+        page.evaluate("() => navigator.serviceWorker.register('sw.js')")
+        page.wait_for_function("() => !!navigator.serviceWorker.controller", timeout=SW_WAIT_MS)
+        # The activate handler deletes every cache whose name != CACHE_NAME.
+        page.wait_for_function(
+            "async () => !(await caches.keys()).includes('sy-subtitles-c2')",
+            timeout=10000,
+        )
+        assert "sy-subtitles-c2" not in page.evaluate("() => caches.keys()")


### PR DESCRIPTION
`sw.js` had **zero browser coverage**: the SPA skips SW registration on localhost (`index.html:5302`), so the Playwright suite never ran the worker — only the pure host-matching helpers were node-unit-tested. These tests register `sw.js` directly and drive the real **install / activate / fetch** chain in Chromium.

## What's covered
- **registers, activates, controls the page** (`clients.claim()`);
- **immutable asset → cache-first**: `icon.png` populates the versioned cache `sy-subtitles-c3`, and a seeded sentinel is returned **without hitting the network**;
- **navigation → network-first**: `index.html` returns the live response over a stale cached one (this is the branch where `isApiOrRaw`/`isNavigation` route requests);
- **activate purges stale version caches**: a seeded `sy-subtitles-c2` is deleted.

## Tests have teeth (verified)
Each strategy/activate assertion was confirmed to **fail when its behaviour is broken** — `isImmutable → false` (cache-first test reds), navigation branch → `cacheFirst` (network-first test reds), activate keeps all caches (purge test reds). The flaky retries did **not** mask those breaks (failed all 3 attempts).

## On `isApiOrRaw` specifically
It is **not** asserted in isolation: for the app's real traffic it never changes the chosen strategy — `api.github.com`/`raw.githubusercontent.com` are network-first whether it matches or not (the else-branch default is also network-first). So a browser test can't distinguish it working from broken; its host-matching contract stays covered by the node unit tests in `test_spa_cache.js`. Here it simply runs as part of the real fetch handler.

Reuses the `test_preview_spa` fixtures; module-scoped `pytest.mark.flaky(reruns=2)` for SW timing under `-n auto` (added in #445). Green locally: 5 passed (`-n0` and `-n auto`), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)