### PR TITLE
Add soft passphrase gate for preview/review

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -39,6 +39,31 @@ jobs:
           sed -i "s/var APP_DEPLOY_SHA = '';/var APP_DEPLOY_SHA = '${SHELL_SHA}';/" site/index.html
           echo "Deploy: date=$DEPLOY_DATE shell=$SHELL_SHA"
 
+      - name: Inject passphrase-gate hash
+        env:
+          GATE_PASSPHRASE: ${{ secrets.GATE_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GATE_PASSPHRASE:-}" ]; then
+            echo "::error::GATE_PASSPHRASE secret is empty/unset — refusing to ship an open gate"
+            exit 1
+          fi
+          # GATE_SALT / GATE_ITERATIONS are the single source of truth in the JS module.
+          SALT=$(grep -oE "GATE_SALT = '[0-9a-f]+'" site/js/passphrase_gate.js | grep -oE "[0-9a-f]{8,}")
+          ITERS=$(grep -oE "GATE_ITERATIONS = [0-9]+" site/js/passphrase_gate.js | grep -oE "[0-9]+")
+          if [ -z "$SALT" ] || [ -z "$ITERS" ]; then
+            echo "::error::could not read GATE_SALT/GATE_ITERATIONS from site/js/passphrase_gate.js"
+            exit 1
+          fi
+          HASH=$(python3 -m tools.passphrase_gate hash --salt "$SALT" --iterations "$ITERS" "$GATE_PASSPHRASE")
+          sed -i "s/var APP_GATE_HASH = '';/var APP_GATE_HASH = '${HASH}';/" site/index.html
+          # Assert the injection landed — never silently ship an empty (disabled) gate.
+          grep -q "var APP_GATE_HASH = '${HASH}';" site/index.html || {
+            echo "::error::gate hash injection failed (placeholder not found?)"
+            exit 1
+          }
+          echo "Gate hash injected (length=${#HASH})"
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,10 @@ python -m tools.vimeo_codec encode "https://vimeo.com/<id>/<hash>"   # -> video_
 python -m tools.vimeo_codec decode "r1..."                          # -> vimeo url
 python -m tools.mask_video_refs [--check] [PATHS...]                 # migrate meta.yaml vimeo_url -> video_ref
 
+# Passphrase-gate hash (used by deploy-pages.yml to inject APP_GATE_HASH from the
+# GATE_PASSPHRASE secret). Twin of site/js/passphrase_gate.js.
+python -m tools.passphrase_gate hash --salt <hex> --iterations <n> "<phrase>"
+
 # Build subtitles (deterministic orchestrator; LLM writes timecodes.txt between prepare and assemble)
 python -m tools.build_map prepare        --talk-dir PATH --video-slug SLUG
 python -m tools.build_map prepare-timing --talk-dir PATH --video-slug SLUG [--timing-source whisper|en-srt]

--- a/docs/superpowers/plans/2026-06-01-passphrase-gate.md
+++ b/docs/superpowers/plans/2026-06-01-passphrase-gate.md
@@ -1,0 +1,954 @@
+# Passphrase Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prompt for a passphrase the first time a user opens a talk's preview or review in the SPA; a correct passphrase (verified against a slow PBKDF2 hash) unlocks both views per-browser until the site passphrase is rotated.
+
+**Architecture:** A pure dual-mode JS module (`site/js/passphrase_gate.js`, Node-tested twin of `tools/passphrase_gate.py`) does PBKDF2 hashing + unlock-state checks. `site/index.html` adds a passphrase modal, a click-interceptor on the index, and a `route()` deep-link guard. The literal passphrase lives only in the `GATE_PASSPHRASE` GitHub secret; the deploy workflow computes the hash and `sed`-injects it into `var APP_GATE_HASH`. Unlock is stored as the hash in `localStorage` and compared each access (rotation re-prompts). Empty hash ⇒ gate disabled (fail-open).
+
+**Tech Stack:** Vanilla ES5-style JS (browser + `node --test`), Python stdlib (`hashlib`), Playwright (pytest), GitHub Actions.
+
+**Threat model (keep honest):** This is a SOFT gate. The transcripts/SRT/`video_ref`s stay public on GitHub, and the hash ships in the deployed JS — anyone reading it or hitting GitHub raw can bypass. The gate stops casual browsing and keeps the *literal* passphrase out of the repo. Do not describe it as encryption.
+
+**Fixed constants (used throughout — keep identical in JS, fixture, and any test):**
+- `GATE_SALT = 'a3f1c92e6b4d80571e2c9f3a6d8b0e47'` (16-byte hex, public)
+- `GATE_ITERATIONS = 200000`
+- Storage key: `sy_gate`
+- Reference hashes (PBKDF2-HMAC-SHA256, 32-byte hex, computed with the salt+iters above):
+  - `test-passphrase` → `289fa9ee16cb75d517736c68cd7d9a646fde31efead2e17b59c3219bd1548f5f`
+  - `correct-horse-battery` → `f3267b29331e95b8d025040f16559d2744232110081a3cf1fe8a38592bebd3c7`
+- **Never** put the real passphrase or its hash in any committed file. The passphrase exists only in the `GATE_PASSPHRASE` secret; the hash is injected at deploy time. (For local manual testing, derive the hash from the secret value yourself and inject it via `window.__SY_GATE_HASH` in devtools — do not write it to a tracked file.)
+
+---
+
+### Task 1: Python hash module + CLI
+
+**Files:**
+- Create: `tools/passphrase_gate.py`
+- Test: `tests/test_passphrase_gate.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_passphrase_gate.py`:
+
+```python
+"""Tests for the passphrase-gate hash (tools/passphrase_gate.py).
+
+Twin of site/js/passphrase_gate.js. SOFT gate, not encryption: the hash ships
+publicly and the gated content is public on GitHub regardless. These tests pin
+the PBKDF2 output and the cross-language vectors shared with the JS twin.
+"""
+
+import json
+from pathlib import Path
+
+from tools.passphrase_gate import derive_hash, main
+
+SALT = "a3f1c92e6b4d80571e2c9f3a6d8b0e47"
+ITERS = 200000
+VECTORS_PATH = Path(__file__).parent / "fixtures" / "passphrase_gate_vectors.json"
+
+
+def test_derive_hash_matches_known_reference():
+    assert (
+        derive_hash("test-passphrase", SALT, ITERS)
+        == "289fa9ee16cb75d517736c68cd7d9a646fde31efead2e17b59c3219bd1548f5f"
+    )
+
+
+def test_derive_hash_is_64_hex_chars():
+    h = derive_hash("anything", SALT, ITERS)
+    assert len(h) == 64
+    assert all(c in "0123456789abcdef" for c in h)
+
+
+def test_cli_hash_prints_only_the_hash(capsys):
+    main(["hash", "--salt", SALT, "--iterations", str(ITERS), "test-passphrase"])
+    out = capsys.readouterr().out.strip()
+    assert out == "289fa9ee16cb75d517736c68cd7d9a646fde31efead2e17b59c3219bd1548f5f"
+    # The phrase must never leak to stdout.
+    assert "test-passphrase" not in out
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_passphrase_gate.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'tools.passphrase_gate'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `tools/passphrase_gate.py`:
+
+```python
+"""Passphrase-gate hash — Python twin of site/js/passphrase_gate.js.
+
+Used by .github/workflows/deploy-pages.yml to turn the GATE_PASSPHRASE secret
+into the PBKDF2 hash injected into the SPA (var APP_GATE_HASH). The literal
+passphrase is NEVER printed or committed; only the hash is emitted.
+
+This is a SOFT gate, NOT encryption: the hash ships publicly in the deployed
+site and the content behind the gate is public on GitHub regardless. The JS
+twin (site/js/passphrase_gate.js) must produce identical output, enforced by
+the shared vectors in tests/fixtures/passphrase_gate_vectors.json.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def derive_hash(phrase: str, salt_hex: str, iterations: int) -> str:
+    """PBKDF2-HMAC-SHA256(phrase, salt) -> 32-byte digest as lowercase hex."""
+    dk = hashlib.pbkdf2_hmac(
+        "sha256", phrase.encode("utf-8"), bytes.fromhex(salt_hex), iterations, dklen=32
+    )
+    return dk.hex()
+
+
+def main(argv: list[str] | None = None) -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Compute the passphrase-gate hash.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    h = sub.add_parser("hash", help="phrase -> PBKDF2 hex hash")
+    h.add_argument("phrase")
+    h.add_argument("--salt", required=True, help="salt as hex")
+    h.add_argument("--iterations", type=int, required=True)
+    args = parser.parse_args(argv)
+
+    if args.cmd == "hash":
+        print(derive_hash(args.phrase, args.salt, args.iterations))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_passphrase_gate.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/passphrase_gate.py tests/test_passphrase_gate.py
+git commit -m "Add passphrase-gate PBKDF2 hash module + CLI (Python twin)"
+```
+
+---
+
+### Task 2: Shared cross-language vectors fixture
+
+**Files:**
+- Create: `tests/fixtures/passphrase_gate_vectors.json`
+- Modify: `tests/test_passphrase_gate.py` (add cross-language vector test)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_passphrase_gate.py`:
+
+```python
+def test_cross_language_vectors_match():
+    """Frozen vectors shared byte-for-byte with tests/test_passphrase_gate.js.
+
+    This is the contract that keeps the Python and JS hashes identical. Phrases
+    are synthetic — NEVER the real passphrase.
+    """
+    data = json.loads(VECTORS_PATH.read_text(encoding="utf-8"))
+    assert data["salt"] == SALT
+    assert data["iterations"] == ITERS
+    assert data["vectors"], "vectors file must not be empty"
+    for vec in data["vectors"]:
+        assert derive_hash(vec["phrase"], data["salt"], data["iterations"]) == vec["hash"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_passphrase_gate.py::test_cross_language_vectors_match -v`
+Expected: FAIL — `FileNotFoundError` (fixture missing)
+
+- [ ] **Step 3: Create the fixture**
+
+Create `tests/fixtures/passphrase_gate_vectors.json`:
+
+```json
+{
+  "salt": "a3f1c92e6b4d80571e2c9f3a6d8b0e47",
+  "iterations": 200000,
+  "vectors": [
+    {
+      "phrase": "test-passphrase",
+      "hash": "289fa9ee16cb75d517736c68cd7d9a646fde31efead2e17b59c3219bd1548f5f"
+    },
+    {
+      "phrase": "correct-horse-battery",
+      "hash": "f3267b29331e95b8d025040f16559d2744232110081a3cf1fe8a38592bebd3c7"
+    }
+  ]
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_passphrase_gate.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/fixtures/passphrase_gate_vectors.json tests/test_passphrase_gate.py
+git commit -m "Add shared passphrase-gate hash vectors (Python side)"
+```
+
+---
+
+### Task 3: JS hash module (dual-mode twin)
+
+**Files:**
+- Create: `site/js/passphrase_gate.js`
+- Create: `tests/test_passphrase_gate.js`
+- Modify: `tests/test_passphrase_gate.py` (add JS-constants drift guard)
+
+- [ ] **Step 1: Write the failing Node test**
+
+Create `tests/test_passphrase_gate.js`:
+
+```javascript
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const Gate = require('../site/js/passphrase_gate');
+
+const data = JSON.parse(
+  fs.readFileSync(path.join(__dirname, 'fixtures', 'passphrase_gate_vectors.json'), 'utf-8')
+);
+
+function memStorage(initial) {
+  const m = Object.assign({}, initial || {});
+  return {
+    getItem(k) { return k in m ? m[k] : null; },
+    setItem(k, v) { m[k] = String(v); },
+  };
+}
+
+describe('passphrase_gate — constants match the shared fixture', () => {
+  it('GATE_SALT and GATE_ITERATIONS equal the fixture', () => {
+    assert.strictEqual(Gate.GATE_SALT, data.salt);
+    assert.strictEqual(Gate.GATE_ITERATIONS, data.iterations);
+  });
+});
+
+describe('passphrase_gate — derivePassphraseHash (cross-language)', () => {
+  data.vectors.forEach((vec) => {
+    it('reproduces the frozen hash for ' + vec.phrase, async () => {
+      assert.strictEqual(await Gate.derivePassphraseHash(vec.phrase), vec.hash);
+    });
+  });
+});
+
+describe('passphrase_gate — verifyPassphrase', () => {
+  const expected = data.vectors[0].hash;
+  it('true for the correct phrase', async () => {
+    assert.strictEqual(await Gate.verifyPassphrase(data.vectors[0].phrase, expected), true);
+  });
+  it('false for a wrong phrase', async () => {
+    assert.strictEqual(await Gate.verifyPassphrase('nope', expected), false);
+  });
+  it('false when the expected hash is empty (gate disabled)', async () => {
+    assert.strictEqual(await Gate.verifyPassphrase(data.vectors[0].phrase, ''), false);
+  });
+});
+
+describe('passphrase_gate — isGateEnabled', () => {
+  it('false for empty, true for a hash', () => {
+    assert.strictEqual(Gate.isGateEnabled(''), false);
+    assert.strictEqual(Gate.isGateEnabled(data.vectors[0].hash), true);
+  });
+});
+
+describe('passphrase_gate — unlock state (stores + compares the hash)', () => {
+  const expected = data.vectors[0].hash;
+  it('false when storage is empty', () => {
+    assert.strictEqual(Gate.isUnlocked(expected, memStorage()), false);
+  });
+  it('false when the stored hash differs (rotation re-prompts)', () => {
+    const s = memStorage({ sy_gate: 'old-rotated-away-hash' });
+    assert.strictEqual(Gate.isUnlocked(expected, s), false);
+  });
+  it('true when the stored hash equals the expected hash', () => {
+    const s = memStorage({ sy_gate: expected });
+    assert.strictEqual(Gate.isUnlocked(expected, s), true);
+  });
+  it('recordUnlock writes the expected hash under sy_gate', () => {
+    const s = memStorage();
+    Gate.recordUnlock(expected, s);
+    assert.strictEqual(s.getItem('sy_gate'), expected);
+    assert.strictEqual(Gate.isUnlocked(expected, s), true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/test_passphrase_gate.js`
+Expected: FAIL — `Cannot find module '../site/js/passphrase_gate'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `site/js/passphrase_gate.js`:
+
+```javascript
+// Passphrase gate — Python twin: tools/passphrase_gate.py.
+//
+// SOFT gate, NOT encryption: this file ships in the public SPA and the gated
+// content is public on GitHub regardless. PBKDF2 only raises the cost of
+// brute-forcing the phrase from the (public) hash; it does not protect content.
+//
+// Single source: loaded by the browser via <script src="js/passphrase_gate.js">
+// in site/index.html AND required by tests/test_passphrase_gate.js. The hashing
+// stays byte-identical to the .py twin (shared vectors in
+// tests/fixtures/passphrase_gate_vectors.json).
+//
+// GATE_SALT / GATE_ITERATIONS are the single source of truth for the KDF params
+// (deploy-pages.yml greps them out to compute the injected hash).
+
+(function () {
+  var GATE_SALT = 'a3f1c92e6b4d80571e2c9f3a6d8b0e47'; // 16-byte hex (public)
+  var GATE_ITERATIONS = 200000;
+  var STORAGE_KEY = 'sy_gate';
+
+  function hexToBytes(hex) {
+    var out = new Uint8Array(hex.length / 2);
+    for (var i = 0; i < out.length; i++) out[i] = parseInt(hex.substr(i * 2, 2), 16);
+    return out;
+  }
+  function bytesToHex(buf) {
+    var b = new Uint8Array(buf), s = '';
+    for (var i = 0; i < b.length; i++) s += (b[i] < 16 ? '0' : '') + b[i].toString(16);
+    return s;
+  }
+
+  function derivePassphraseHash(phrase) {
+    // Node (tests): synchronous PBKDF2, wrapped so the API matches the browser's
+    // async Web Crypto path. Both are RFC 2898 PBKDF2-HMAC-SHA256 -> identical.
+    if (typeof module !== 'undefined' && module.exports) {
+      var nodeCrypto = require('crypto');
+      var hex = nodeCrypto
+        .pbkdf2Sync(Buffer.from(phrase, 'utf-8'), Buffer.from(GATE_SALT, 'hex'), GATE_ITERATIONS, 32, 'sha256')
+        .toString('hex');
+      return Promise.resolve(hex);
+    }
+    var enc = new TextEncoder();
+    return crypto.subtle
+      .importKey('raw', enc.encode(phrase), { name: 'PBKDF2' }, false, ['deriveBits'])
+      .then(function (key) {
+        return crypto.subtle.deriveBits(
+          { name: 'PBKDF2', salt: hexToBytes(GATE_SALT), iterations: GATE_ITERATIONS, hash: 'SHA-256' },
+          key,
+          256
+        );
+      })
+      .then(function (bits) { return bytesToHex(bits); });
+  }
+
+  function verifyPassphrase(phrase, expectedHash) {
+    if (!expectedHash) return Promise.resolve(false);
+    return derivePassphraseHash(phrase).then(function (h) { return h === expectedHash; });
+  }
+
+  function isGateEnabled(expectedHash) { return !!expectedHash; }
+
+  function isUnlocked(expectedHash, storage) {
+    if (!expectedHash) return false;
+    try { return storage.getItem(STORAGE_KEY) === expectedHash; } catch (e) { return false; }
+  }
+
+  function recordUnlock(expectedHash, storage) {
+    try { storage.setItem(STORAGE_KEY, expectedHash); } catch (e) {}
+  }
+
+  var api = {
+    GATE_SALT: GATE_SALT,
+    GATE_ITERATIONS: GATE_ITERATIONS,
+    STORAGE_KEY: STORAGE_KEY,
+    derivePassphraseHash: derivePassphraseHash,
+    verifyPassphrase: verifyPassphrase,
+    isGateEnabled: isGateEnabled,
+    isUnlocked: isUnlocked,
+    recordUnlock: recordUnlock,
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api; // Node (tests)
+  } else {
+    this.PassphraseGate = api; // Browser: single namespace global
+  }
+}).call(typeof globalThis !== 'undefined' ? globalThis : this);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test tests/test_passphrase_gate.js`
+Expected: PASS (all suites)
+
+- [ ] **Step 5: Add the JS-constants drift guard (Python)**
+
+Append to `tests/test_passphrase_gate.py`:
+
+```python
+def test_js_module_constants_match_vectors():
+    """The JS twin's GATE_SALT/GATE_ITERATIONS must match the fixture, so the
+    deploy workflow (which greps them out of the JS) computes the right hash."""
+    js = (Path(__file__).parent.parent / "site" / "js" / "passphrase_gate.js").read_text()
+    data = json.loads(VECTORS_PATH.read_text(encoding="utf-8"))
+    assert f"GATE_SALT = '{data['salt']}'" in js
+    assert f"GATE_ITERATIONS = {data['iterations']}" in js
+```
+
+- [ ] **Step 6: Run both test suites**
+
+Run: `python -m pytest tests/test_passphrase_gate.py -v && node --test tests/test_passphrase_gate.js`
+Expected: PASS (Python 5 tests; Node all suites)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add site/js/passphrase_gate.js tests/test_passphrase_gate.js tests/test_passphrase_gate.py
+git commit -m "Add passphrase-gate JS hash module (dual-mode twin) + cross-language tests"
+```
+
+---
+
+### Task 4: Wire the gate seam into index.html (static bits)
+
+**Files:**
+- Modify: `site/index.html` (script include ~line 23; `APP_GATE_HASH` + `GATE_COPY` ~line 1772; modal CSS ~lines 1013–1083)
+- Modify: `tests/test_passphrase_gate.py` (placeholder guard)
+
+- [ ] **Step 1: Write the failing placeholder-guard test**
+
+Append to `tests/test_passphrase_gate.py`:
+
+```python
+def test_index_html_has_gate_hash_placeholder():
+    """The deploy workflow seds this exact line; if it ever changes, the deploy
+    silently ships an empty (disabled) gate. Pin the sed target."""
+    idx = (Path(__file__).parent.parent / "site" / "index.html").read_text()
+    assert "var APP_GATE_HASH = '';" in idx
+    assert "js/passphrase_gate.js" in idx
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_passphrase_gate.py::test_index_html_has_gate_hash_placeholder -v`
+Expected: FAIL — assertion error (placeholder/script not present yet)
+
+- [ ] **Step 3: Add the `<script>` include**
+
+In `site/index.html`, after line 23 (`<script src="js/talk_actions.js"></script>`), add:
+
+```html
+<script src="js/passphrase_gate.js"></script>
+```
+
+- [ ] **Step 4: Add the injected-hash placeholder + prompt copy**
+
+In `site/index.html`, find (around line 1771):
+
+```javascript
+var APP_DEPLOY_SHA = ''; // app-shell version (index.html + js/*.js) at deploy
+var APP_DEPLOY_DATE = ''; // deploy date YYYY-MM-DD
+```
+
+Add immediately after the `APP_DEPLOY_DATE` line:
+
+```javascript
+var APP_GATE_HASH = ''; // passphrase-gate PBKDF2 hash, injected at deploy from the GATE_PASSPHRASE secret (empty => gate disabled / fail-open)
+var GATE_COPY = 'Введіть пароль для доступу'; // passphrase prompt heading
+```
+
+- [ ] **Step 5: Add modal input CSS**
+
+In `site/index.html`, read the modal style block (~lines 1013–1083) and add these two rules immediately after the `.sy-modal-actions { ... }` rule:
+
+```css
+    .sy-modal-input { width: 100%; box-sizing: border-box; padding: 8px 10px; margin-top: 6px; font-size: 15px; border: 1px solid var(--border, #cccccc); border-radius: 6px; background: var(--bg, #ffffff); color: var(--fg, #111111); }
+    .sy-modal-error { color: #c0392b; font-size: 13px; margin-top: 6px; }
+```
+
+- [ ] **Step 6: Run the guard test + full JS/PY suites**
+
+Run: `python -m pytest tests/test_passphrase_gate.py -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add site/index.html tests/test_passphrase_gate.py
+git commit -m "Wire passphrase-gate seam into the SPA shell (script, placeholder, copy, CSS)"
+```
+
+---
+
+### Task 5: Passphrase modal + index click-interception (E2E-driven)
+
+**Files:**
+- Modify: `tests/test_preview_spa.py` (gate fixtures + flow tests)
+- Modify: `site/index.html` (modal + `gateExpectedHash`/`ensureUnlocked` + click listener; add after `SPA.toast` ~line 2771)
+
+- [ ] **Step 1: Write the failing E2E tests**
+
+Append to `tests/test_preview_spa.py`:
+
+```python
+GATE_TEST_PHRASE = "test-passphrase"
+GATE_TEST_HASH = "289fa9ee16cb75d517736c68cd7d9a646fde31efead2e17b59c3219bd1548f5f"
+
+
+def _enable_gate(pg):
+    """Inject the expected hash so the gate is active (set BEFORE goto)."""
+    pg.add_init_script(f"window.__SY_GATE_HASH = '{GATE_TEST_HASH}';")
+
+
+class TestPassphraseGate:
+    def test_clicking_preview_link_prompts_on_index(self, server, page):
+        _enable_gate(page)
+        goto_spa(page, server)
+        page.wait_for_selector("a.preview-link", timeout=10000)
+        page.click("a.preview-link")
+        page.wait_for_selector("#sy-gate-input", timeout=2000)
+        # Still on the index; preview NOT rendered.
+        assert "active" in page.locator("#view-index").get_attribute("class")
+        assert "active" not in page.locator("#view-preview").get_attribute("class")
+
+    def test_wrong_passphrase_shows_error_no_nav(self, server, page):
+        _enable_gate(page)
+        goto_spa(page, server)
+        page.wait_for_selector("a.preview-link", timeout=10000)
+        page.click("a.preview-link")
+        page.fill("#sy-gate-input", "wrong-phrase")
+        page.click(".sy-modal-btn.primary")
+        page.wait_for_selector(".sy-modal-error", state="visible", timeout=2000)
+        assert "active" not in page.locator("#view-preview").get_attribute("class")
+        assert page.locator("#sy-gate-input").count() == 1  # modal still open
+
+    def test_correct_passphrase_navigates_to_preview(self, server, page):
+        _enable_gate(page)
+        goto_spa(page, server)
+        page.wait_for_selector("a.preview-link", timeout=10000)
+        page.click("a.preview-link")
+        page.fill("#sy-gate-input", GATE_TEST_PHRASE)
+        page.press("#sy-gate-input", "Enter")
+        # 6000ms: PBKDF2(200k) verify + preview render can be slow on CI.
+        page.wait_for_selector("#view-preview.active", timeout=6000)
+        assert page.locator(".sy-modal").count() == 0
+
+    def test_cancel_stays_on_index(self, server, page):
+        _enable_gate(page)
+        goto_spa(page, server)
+        page.wait_for_selector("a.preview-link", timeout=10000)
+        page.click("a.preview-link")
+        page.wait_for_selector("#sy-gate-input", timeout=2000)
+        page.click(".sy-modal-btn:not(.primary)")
+        page.wait_for_selector(".sy-modal", state="detached", timeout=2000)
+        assert "active" in page.locator("#view-index").get_attribute("class")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_preview_spa.py::TestPassphraseGate -v`
+Expected: FAIL — `#sy-gate-input` never appears (modal/wiring not implemented). If Playwright is not installed the class is skipped; install with `pip install playwright && playwright install chromium`.
+
+- [ ] **Step 3: Implement the modal + helpers + click interceptor**
+
+In `site/index.html`, immediately after the `SPA.toast = function(msg) { ... };` block (ends ~line 2771), add:
+
+```javascript
+// ----- Passphrase gate (soft, client-side) -----
+// Expected hash: test/dev override first, then the deploy-injected value.
+// Empty => gate disabled (fail-open). See site/js/passphrase_gate.js.
+function gateExpectedHash() {
+  if (typeof window !== 'undefined' && typeof window.__SY_GATE_HASH === 'string') {
+    return window.__SY_GATE_HASH;
+  }
+  return APP_GATE_HASH || '';
+}
+
+// Resolves true if access is allowed (gate disabled, already unlocked, or a
+// correct passphrase was just entered); false if the user cancelled.
+function ensureUnlocked() {
+  var expected = gateExpectedHash();
+  if (!PassphraseGate.isGateEnabled(expected)) return Promise.resolve(true);
+  if (PassphraseGate.isUnlocked(expected, localStorage)) return Promise.resolve(true);
+  return SPA.passphrasePrompt(expected);
+}
+
+SPA.passphrasePrompt = function(expectedHash) {
+  return new Promise(function(resolve) {
+    var prev = document.activeElement;
+    var backdrop = document.createElement('div');
+    backdrop.className = 'sy-modal-backdrop';
+    var modal = document.createElement('div');
+    modal.className = 'sy-modal';
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+
+    var h = document.createElement('h3');
+    h.className = 'sy-modal-title';
+    h.textContent = GATE_COPY;
+    modal.appendChild(h);
+
+    var input = document.createElement('input');
+    input.type = 'password';
+    input.id = 'sy-gate-input';
+    input.className = 'sy-modal-input';
+    input.setAttribute('autocomplete', 'current-password');
+    modal.appendChild(input);
+
+    var err = document.createElement('div');
+    err.className = 'sy-modal-error';
+    err.style.display = 'none';
+    err.textContent = 'Невірний пароль';
+    modal.appendChild(err);
+
+    var actions = document.createElement('div');
+    actions.className = 'sy-modal-actions';
+    var cancelBtn = document.createElement('button');
+    cancelBtn.className = 'sy-modal-btn';
+    cancelBtn.type = 'button';
+    cancelBtn.textContent = 'Скасувати';
+    var okBtn = document.createElement('button');
+    okBtn.className = 'sy-modal-btn primary';
+    okBtn.type = 'button';
+    okBtn.textContent = 'Увійти';
+    actions.appendChild(cancelBtn);
+    actions.appendChild(okBtn);
+    modal.appendChild(actions);
+    backdrop.appendChild(modal);
+    document.body.appendChild(backdrop);
+
+    var done = false;
+    function close(val) {
+      if (done) return; done = true;
+      backdrop.style.animation = 'sy-fade-in .12s reverse';
+      setTimeout(function() { if (backdrop.parentNode) backdrop.parentNode.removeChild(backdrop); }, 120);
+      document.removeEventListener('keydown', onKey, true);
+      if (prev && prev.focus) try { prev.focus(); } catch(_){}
+      resolve(val);
+    }
+    function submit() {
+      PassphraseGate.verifyPassphrase(input.value, expectedHash).then(function(ok) {
+        if (ok) {
+          PassphraseGate.recordUnlock(expectedHash, localStorage);
+          close(true);
+        } else {
+          err.style.display = '';
+          input.value = '';
+          input.focus();
+        }
+      });
+    }
+    function onKey(e) {
+      if (e.key === 'Escape') { e.preventDefault(); close(false); }
+      if (e.key === 'Enter')  { e.preventDefault(); submit(); }
+    }
+    backdrop.addEventListener('click', function(e) { if (e.target === backdrop) close(false); });
+    cancelBtn.addEventListener('click', function() { close(false); });
+    okBtn.addEventListener('click', submit);
+    document.addEventListener('keydown', onKey, true);
+    setTimeout(function() { input.focus(); }, 20);
+  });
+};
+
+// Intercept clicks on gated links from the index so the prompt appears BEFORE
+// navigation. Correct phrase -> navigate; cancel -> stay put (no navigation).
+document.addEventListener('click', function(e) {
+  var a = e.target && e.target.closest ? e.target.closest('a') : null;
+  if (!a) return;
+  var href = a.getAttribute('href') || '';
+  if (!/^#\/(preview|review)\//.test(href)) return;
+  var expected = gateExpectedHash();
+  if (!PassphraseGate.isGateEnabled(expected)) return;          // gate off -> normal nav
+  if (PassphraseGate.isUnlocked(expected, localStorage)) return; // already unlocked
+  e.preventDefault();
+  ensureUnlocked().then(function(ok) { if (ok) location.hash = href; });
+});
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_preview_spa.py::TestPassphraseGate -v`
+Expected: PASS (4 tests)
+
+> If `test_correct_passphrase_navigates_to_preview` fails at the verify step
+> (modal never closes / no navigation), confirm `crypto.subtle` is available in
+> the test page. It IS on `http://127.0.0.1` (a secure context in Chromium), so
+> a failure here points to a wiring bug, not a missing API.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add site/index.html tests/test_preview_spa.py
+git commit -m "Add passphrase modal + index click-gate (prompt before navigation)"
+```
+
+---
+
+### Task 6: Deep-link guard + persisted unlock + fail-open (E2E-driven)
+
+**Files:**
+- Modify: `tests/test_preview_spa.py` (3 more gate tests)
+- Modify: `site/index.html` (`route()` guard; ~line 2831)
+
+- [ ] **Step 1: Write the failing E2E tests**
+
+Append to `class TestPassphraseGate` in `tests/test_preview_spa.py`:
+
+```python
+    def test_deep_link_to_review_while_locked_redirects_and_prompts(self, server, page):
+        _enable_gate(page)
+        goto_spa(page, server, "#/review/2001-01-01_Test-Talk")
+        page.wait_for_selector("#sy-gate-input", timeout=4000)
+        # Redirected to the index; review NOT rendered.
+        assert "active" in page.locator("#view-index").get_attribute("class")
+        assert "active" not in page.locator("#view-review").get_attribute("class")
+        # Correct phrase -> proceeds to the originally-requested review.
+        page.fill("#sy-gate-input", GATE_TEST_PHRASE)
+        page.press("#sy-gate-input", "Enter")
+        page.wait_for_selector("#view-review.active", timeout=6000)
+
+    def test_already_unlocked_browser_skips_prompt(self, server, page):
+        _enable_gate(page)
+        page.add_init_script(f"localStorage.setItem('sy_gate', '{GATE_TEST_HASH}');")
+        goto_spa(page, server, "#/preview/2001-01-01_Test-Talk/Test-Video")
+        page.wait_for_selector("#view-preview.active", timeout=6000)
+        assert page.locator("#sy-gate-input").count() == 0
+
+    def test_gate_disabled_opens_without_prompt(self, server, page):
+        # No _enable_gate(): APP_GATE_HASH is empty -> fail-open.
+        goto_spa(page, server, "#/preview/2001-01-01_Test-Talk/Test-Video")
+        page.wait_for_selector("#view-preview.active", timeout=6000)
+        assert page.locator("#sy-gate-input").count() == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_preview_spa.py::TestPassphraseGate -k "deep_link or already_unlocked or disabled" -v`
+Expected: `test_deep_link...` FAILS (review renders, no prompt). `test_already_unlocked...` and `test_gate_disabled...` may already PASS (the click-gate path doesn't touch direct navigation, and unlocked/empty already short-circuit) — that's fine; the deep-link test is the one driving the guard.
+
+- [ ] **Step 3: Implement the `route()` deep-link guard**
+
+In `site/index.html`, find the start of `route()` (line 2831):
+
+```javascript
+function route() {
+  var hash = location.hash.slice(1) || '/';
+
+  // Pause video when leaving preview
+```
+
+Insert the guard between the `hash` line and the `// Pause video` comment:
+
+```javascript
+function route() {
+  var hash = location.hash.slice(1) || '/';
+
+  // Soft passphrase gate: a gated route reached while locked (e.g. a pasted
+  // deep link) redirects to the index and prompts there; only a correct
+  // passphrase proceeds to the original target.
+  if (hash.startsWith('/preview/') || hash.startsWith('/review/')) {
+    var gateHash = gateExpectedHash();
+    if (PassphraseGate.isGateEnabled(gateHash) && !PassphraseGate.isUnlocked(gateHash, localStorage)) {
+      var target = hash;
+      if (previewState && previewState.player) { try { previewState.player.pause(); } catch(e) {} }
+      document.querySelectorAll('.view').forEach(function(v) { v.classList.remove('active'); });
+      history.replaceState(null, '', location.pathname + location.search);
+      showIndex();
+      ensureUnlocked().then(function(ok) { if (ok) location.hash = target; });
+      return;
+    }
+  }
+
+  // Pause video when leaving preview
+```
+
+(`location.hash = target` where `target` is e.g. `/preview/...` — the setter adds the leading `#`, re-firing `route()`, now unlocked, which renders the view.)
+
+- [ ] **Step 4: Run the full gate E2E class**
+
+Run: `python -m pytest tests/test_preview_spa.py::TestPassphraseGate -v`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Run the WHOLE preview SPA suite (no regressions)**
+
+Run: `python -m pytest tests/test_preview_spa.py -v`
+Expected: PASS (all existing + 7 new). The existing preview/review tests still pass because they never set `__SY_GATE_HASH`, so the gate is disabled (fail-open).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add site/index.html tests/test_preview_spa.py
+git commit -m "Guard deep links to preview/review with the passphrase gate"
+```
+
+---
+
+### Task 7: Deploy-time hash injection
+
+**Files:**
+- Modify: `.github/workflows/deploy-pages.yml` (new step after "Stamp build info")
+
+- [ ] **Step 1: Add the injection step**
+
+In `.github/workflows/deploy-pages.yml`, after the `Stamp build info` step and before `Upload artifact`, add:
+
+```yaml
+      - name: Inject passphrase-gate hash
+        env:
+          GATE_PASSPHRASE: ${{ secrets.GATE_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GATE_PASSPHRASE:-}" ]; then
+            echo "::error::GATE_PASSPHRASE secret is empty/unset — refusing to ship an open gate"
+            exit 1
+          fi
+          # GATE_SALT / GATE_ITERATIONS are the single source of truth in the JS module.
+          SALT=$(grep -oE "GATE_SALT = '[0-9a-f]+'" site/js/passphrase_gate.js | grep -oE "[0-9a-f]{8,}")
+          ITERS=$(grep -oE "GATE_ITERATIONS = [0-9]+" site/js/passphrase_gate.js | grep -oE "[0-9]+")
+          if [ -z "$SALT" ] || [ -z "$ITERS" ]; then
+            echo "::error::could not read GATE_SALT/GATE_ITERATIONS from site/js/passphrase_gate.js"
+            exit 1
+          fi
+          HASH=$(python3 -m tools.passphrase_gate hash --salt "$SALT" --iterations "$ITERS" "$GATE_PASSPHRASE")
+          sed -i "s/var APP_GATE_HASH = '';/var APP_GATE_HASH = '${HASH}';/" site/index.html
+          # Assert the injection landed — never silently ship an empty (disabled) gate.
+          grep -q "var APP_GATE_HASH = '${HASH}';" site/index.html || {
+            echo "::error::gate hash injection failed (placeholder not found?)"
+            exit 1
+          }
+          echo "Gate hash injected (length=${#HASH})"
+```
+
+(Notes: `python3` + stdlib only — no pip install needed; the secret is passed via env and never echoed; only the hash length is logged.)
+
+- [ ] **Step 2: Lint the workflow YAML locally**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/deploy-pages.yml')); print('yaml ok')"`
+Expected: `yaml ok`
+
+- [ ] **Step 3: Dry-run the extraction + hash locally (proves the step's logic)**
+
+Run:
+```bash
+SALT=$(grep -oE "GATE_SALT = '[0-9a-f]+'" site/js/passphrase_gate.js | grep -oE "[0-9a-f]{8,}")
+ITERS=$(grep -oE "GATE_ITERATIONS = [0-9]+" site/js/passphrase_gate.js | grep -oE "[0-9]+")
+echo "salt=$SALT iters=$ITERS"
+python3 -m tools.passphrase_gate hash --salt "$SALT" --iterations "$ITERS" test-passphrase
+```
+Expected: `salt=a3f1c92e6b4d80571e2c9f3a6d8b0e47 iters=200000` then `289fa9ee16cb75d517736c68cd7d9a646fde31efead2e17b59c3219bd1548f5f`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/deploy-pages.yml
+git commit -m "Inject passphrase-gate hash from GATE_PASSPHRASE secret at deploy"
+```
+
+---
+
+### Task 8: Docs, full test sweep, PR
+
+**Files:**
+- Modify: `CLAUDE.md` (tool list)
+
+- [ ] **Step 1: Add the tool to CLAUDE.md**
+
+In `CLAUDE.md`, in the `## Tools` code block, add (near the `vimeo_codec` entry):
+
+```bash
+# Passphrase-gate hash (used by deploy-pages.yml to inject APP_GATE_HASH from the
+# GATE_PASSPHRASE secret). Twin of site/js/passphrase_gate.js.
+python -m tools.passphrase_gate hash --salt <hex> --iterations <n> "<phrase>"
+```
+
+- [ ] **Step 2: Run the entire test suite**
+
+Run:
+```bash
+python -m pytest tests/ -q
+node --test tests/test_*.js
+```
+Expected: all green (Python incl. the new gate tests + Playwright; JS incl. the new gate module tests).
+
+- [ ] **Step 3: Verify no secret leaked into source (scan the WHOLE tree)**
+
+The real invariant: source must never contain a populated `APP_GATE_HASH` — the
+hash is only ever injected into the deploy artifact, never committed. (Do not
+grep for the literal passphrase here; writing it into the check would itself be
+the leak. Scan everything — no path exclusions.)
+
+Run: `git grep -nE "APP_GATE_HASH = '[0-9a-fA-F]{16,}'"`
+Expected: NO matches (committed `index.html` keeps `var APP_GATE_HASH = '';`).
+
+Also confirm the secret value never reached any commit on this branch. Run the
+following, substituting the real passphrase you set in the `GATE_PASSPHRASE`
+secret for `<passphrase>` (do not write it into any tracked file):
+Run: `git log -p origin/main..HEAD | grep -i "<passphrase>"`
+Expected: NO output.
+
+- [ ] **Step 4: Commit + push + open PR**
+
+```bash
+gh auth status   # confirm active account is SlavaSubotskiy
+git add CLAUDE.md
+git commit -m "Document the passphrase-gate hash tool"
+git push -u origin feat/passphrase-gate
+gh pr create --base main --title "Add soft passphrase gate for preview/review" \
+  --body "$(cat <<'EOF'
+Soft client-side passphrase gate. On first navigation to a talk's preview or
+review the SPA prompts for a passphrase; a correct phrase (verified against a
+slow PBKDF2 hash) unlocks both views per-browser until the passphrase is rotated.
+
+- Hash-checked, not encryption: content stays public on GitHub; the hash ships
+  publicly. The gate stops casual browsing and keeps the literal passphrase out
+  of the repo (it lives only in the GATE_PASSPHRASE secret; the hash is injected
+  at deploy time into APP_GATE_HASH).
+- Unlock stored as the hash in localStorage and compared each access — rotating
+  the passphrase re-prompts everyone.
+- Index stays open; preview + review are gated (click-intercept on the index +
+  route() deep-link guard). Empty hash => fail-open; deploy asserts non-empty.
+
+Spec: docs/superpowers/specs/2026-06-01-passphrase-gate-design.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: After the PR deploys to Pages, smoke-test live**
+
+Open the deployed site, click a preview link, confirm the prompt appears, enter the real passphrase (the value in the `GATE_PASSPHRASE` secret), confirm it unlocks and is remembered on reload. (Local manual check: serve `site/` and set `window.__SY_GATE_HASH` via devtools to the hash you derive from the secret value with `python -m tools.passphrase_gate hash --salt <salt> --iterations <iters> "<passphrase>"`, plus `?repo=sy-tools/sy-subtitles` for the repo override.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Hash-checked gate (PBKDF2) → Tasks 1, 3. ✓
+- Passphrase in secret, hash injected at deploy → Task 7. ✓
+- Once-per-browser, rotation re-prompts (store + compare hash) → Task 3 (`isUnlocked`/`recordUnlock`), Task 6 (persisted test). ✓
+- Coverage preview+review, index open → Task 5 (click-intercept on `.preview-link`/`.review-link`), Task 6 (route guard); index never gated. ✓
+- Prompt on index, correct→navigate, cancel→stay → Task 5. ✓
+- Deep-link guard → Task 6. ✓
+- Fail-open + deploy non-empty assertion → Task 6 test, Task 7 step. ✓
+- PBKDF2 cross-language identical → Tasks 1–3 shared vectors. ✓
+- Dev/test seam `window.__SY_GATE_HASH` → Task 5 `_enable_gate`. ✓
+- Placeholder copy `"Введіть пароль для доступу"` → Task 4 `GATE_COPY`. ✓
+- Twin tests + fixtures (synthetic phrases) → Tasks 1–3. ✓
+- CLAUDE.md tool entry → Task 8. ✓
+
+**Placeholder scan:** No `TBD`/`TODO`; every code/step shows full content and exact commands. ✓
+
+**Type/name consistency:** `PassphraseGate` namespace with `GATE_SALT`, `GATE_ITERATIONS`, `STORAGE_KEY`, `derivePassphraseHash`, `verifyPassphrase`, `isGateEnabled`, `isUnlocked`, `recordUnlock` used identically in module (Task 3), index wiring (Tasks 5–6), and tests. `gateExpectedHash`/`ensureUnlocked`/`SPA.passphrasePrompt` defined in Task 5 and consumed by the Task 6 guard. Storage key `sy_gate` consistent across JS, tests, and the persisted-unlock test. ✓

--- a/docs/superpowers/specs/2026-06-01-passphrase-gate-design.md
+++ b/docs/superpowers/specs/2026-06-01-passphrase-gate-design.md
@@ -1,0 +1,220 @@
+# Passphrase Gate for Preview & Review — Design
+
+- **Date:** 2026-06-01
+- **Status:** Approved (design); ready for implementation plan
+- **Branch:** `feat/passphrase-gate`
+
+## Goal
+
+When a user first opens a talk's **preview** or **review** view in the SPA,
+prompt for a passphrase. Only a correct passphrase lets them through. The
+unlock is remembered per browser so they are not asked again — until the site
+passphrase is rotated.
+
+## Threat model (honest framing)
+
+This is a **soft gate**, not real access control. The transcripts, SRT, and
+`video_ref`s behind preview/review are fetched from the **public** GitHub repo,
+so anyone can read that content straight from GitHub raw regardless of the SPA.
+The gate logic and the expected hash also ship publicly in the deployed site.
+
+What the gate *does* buy:
+
+- Stops casual / accidental browsing of in-progress review work.
+- Lets one shared passphrase be handed to collaborators.
+- The **literal passphrase never appears in the repo or git history** — it lives
+  only in a GitHub Actions secret; only a slow PBKDF2 **hash** ships, injected at
+  deploy time.
+
+What it does **not** buy: protection against anyone who reads the deployed JS,
+sets `localStorage` by hand, or fetches the raw content from GitHub. Same stance
+as the `video_ref` obfuscation (PR #448).
+
+## Decisions (locked)
+
+| Question | Decision |
+| --- | --- |
+| Protection level | Hash-checked gate (no literal phrase in source) |
+| Re-prompt | Once per browser; rotating the passphrase re-prompts everyone |
+| Coverage | Preview **and** review; the index (talk list) stays open |
+| Wrong / cancel | Prompt fires **on the index** when a gated link is clicked; correct → navigate; cancel/Esc → stay on index (no navigation). Wrong → inline error + retry. |
+| Hash | PBKDF2-HMAC-SHA256, slow (deliberate brute-force cost) |
+| Stored unlock | Store the **hash** (not a boolean) and compare it to the current expected hash on every gated access |
+| Hash provenance | Passphrase in GitHub secret `GATE_PASSPHRASE`; hash computed + injected at deploy time |
+| Passphrase value | Stored only in the `GATE_PASSPHRASE` secret; never committed |
+| Prompt copy | Placeholder `"Введіть пароль для доступу"` (single editable string) |
+
+## Architecture
+
+### Components
+
+1. **`site/js/passphrase_gate.js`** — dual-mode shared module (browser global +
+   Node `require`), the project's established twin pattern (cf.
+   `site/js/vimeo_codec.js`). Pure, DOM-free logic:
+   - `GATE_SALT` (hex) and `GATE_ITERATIONS` (int) — committed constants and the
+     **single source of truth** for the KDF parameters.
+   - `derivePassphraseHash(phrase)` → `Promise<hex>` (Web Crypto PBKDF2 in the
+     browser; `node:crypto` `pbkdf2` in Node — both RFC 2898, byte-identical).
+   - `verifyPassphrase(phrase, expectedHash)` → `Promise<bool>`.
+   - `isGateEnabled(expectedHash)` → `bool` (false when the hash is empty).
+   - `isUnlocked(expectedHash, storage)` → `bool` (stored hash === expectedHash).
+   - `recordUnlock(expectedHash, storage)` → writes the hash to `sy_gate`.
+
+2. **`tools/passphrase_gate.py`** — Python twin + CLI used **by the deploy
+   workflow** to turn the secret into a hash:
+   `python -m tools.passphrase_gate hash --salt <hex> --iterations <n> "<phrase>"`
+   → prints the hex hash to stdout (and nothing else; the phrase is never
+   echoed). Still usable locally to mint a dev/test hash.
+
+3. **`tests/fixtures/passphrase_gate_vectors.json`** — shared `(phrase, salt,
+   iterations) → hash` vectors using **synthetic** phrases (never the real passphrase).
+   Asserted from both the Node and Python tests so the two implementations stay
+   byte-identical.
+
+4. **`site/index.html`** changes:
+   - `<script src="js/passphrase_gate.js">` in `<head>` (loaded before the inline
+     script, like `vimeo_codec.js`).
+   - `var APP_GATE_HASH = '';` placeholder near `APP_DEPLOY_SHA`
+     (`index.html:1771`), filled at deploy via `sed`.
+   - `var GATE_COPY = 'Введіть пароль для доступу';` (single editable string).
+   - Expected hash resolution at verify time:
+     `window.__SY_GATE_HASH ?? APP_GATE_HASH ?? ''` (window override for
+     tests/dev; injected value in production; empty ⇒ gate disabled).
+   - A passphrase modal reusing the existing `.sy-modal` infrastructure
+     (`SPA.confirm` machinery at `index.html:2683`): backdrop, focus trap,
+     Esc/Enter, animations — extended with a `<input type="password">` and an
+     inline error line.
+   - `ensureUnlocked()` → `Promise<bool>`: resolves `true` immediately if already
+     unlocked or the gate is disabled; otherwise opens the modal, verifies on
+     submit (correct → `recordUnlock` + resolve `true`; wrong → inline error,
+     stay open; cancel/Esc → resolve `false`).
+
+### Control flow
+
+**Primary — click on a gated link from the index.** A delegated click listener
+on the index intercepts anchors targeting `#/preview/…` or `#/review/…`. If the
+gate is enabled and not unlocked: `preventDefault()`, call `ensureUnlocked()`
+(modal appears while still on the index). On `true`, set `location.hash` to the
+intended target. On `false`, do nothing — we stayed on the index.
+
+**Defensive — deep link / pasted URL.** At the top of the `/preview/` and
+`/review/` branches of `route()` (`index.html:2841`, `2849`), before the gated
+view is made active: if the gate is enabled and not unlocked, render the **index**
+view instead, capture the requested target, and call `ensureUnlocked()`. On
+`true`, navigate to the captured target (which re-enters `route()`, now
+unlocked, and renders normally). On `false`, stay on the index. This closes the
+"just type the hash" bypass. No flash of gated content, no hashchange loop (once
+unlocked the guard passes).
+
+### Hashing & rotation
+
+- PBKDF2-HMAC-SHA256, 32-byte output, hex-encoded. `GATE_ITERATIONS` chosen for a
+  meaningful brute-force cost (target ~0.2–0.5 s in-browser; tunable). `GATE_SALT`
+  is a fixed committed 16-byte hex value (public — its only job here is to force a
+  fresh brute force per target, which the iteration count dominates anyway).
+- The salt is **fixed across deploys** so the injected hash is deterministic and
+  stable — otherwise every deploy would change the hash and re-prompt everyone.
+- Rotation = change the `GATE_PASSPHRASE` secret and redeploy → new hash injected
+  → every stored `sy_gate` value mismatches → everyone re-prompted. This is the
+  kill switch. **Note:** changing the secret alone does *not* trigger
+  `deploy-pages.yml` (it runs on push to `site/**` or `workflow_dispatch`), so
+  rotation means manually re-running the deploy workflow.
+
+### Storage semantics
+
+- Key `sy_gate` (joins the existing `sy_`-prefixed convention) holds the **hash
+  string**, not a boolean.
+- On every gated access: read `sy_gate`; allow iff it equals the current expected
+  hash. `localStorage` (not cookies): the site is static/serverless so cookies add
+  nothing, and the "secure" cookie variants need a server. No client store is
+  tamper-proof here (the expected hash is public), so this is about
+  convenience/consistency, not security.
+
+### Deploy integration (`deploy-pages.yml`)
+
+Extend the existing "Stamp build info" step (which already `sed`s `APP_DEPLOY_SHA`
+and `APP_DEPLOY_DATE` into `index.html`):
+
+1. Derive `GATE_SALT` and `GATE_ITERATIONS` from the committed
+   `site/js/passphrase_gate.js` (single source of truth; simple extraction).
+2. `HASH=$(python -m tools.passphrase_gate hash --salt "$SALT" --iterations "$ITERS" "$GATE_PASSPHRASE")`
+   with `GATE_PASSPHRASE` from `secrets.GATE_PASSPHRASE` (env, never echoed).
+3. `sed -i "s/var APP_GATE_HASH = '';/var APP_GATE_HASH = '${HASH}';/" site/index.html`.
+4. **Assert** `APP_GATE_HASH` is non-empty afterward; **fail the deploy loudly**
+   if the secret was missing/renamed (so we never silently ship an open gate).
+
+This does not affect the auto-reload mechanism: `compute_shell_version.sh` hashes
+**committed git blob SHAs at HEAD**, independent of deploy-time working-tree edits
+(its own comment says so). Adding a new `site/js/*.js` file is auto-covered by the
+existing `site/js/*.js` glob in both `compute_shell_version.sh` and
+`computeShellVersion()`.
+
+### Fail-open
+
+Empty expected hash (local dev, tests without an override, or a missing secret in
+a misconfigured deploy) ⇒ `isGateEnabled` is false ⇒ no prompt, content opens.
+The deploy-time non-empty assertion is what prevents a *production* deploy from
+silently shipping an open gate.
+
+### Dev / test seam
+
+The Playwright server already injects `window.__SY_REPO` into the served HTML; add
+`window.__SY_GATE_HASH` the same way so tests exercise a known hash (computed from
+a synthetic test phrase + the committed salt/iters). Local manual dev runs
+fail-open (no gate) unless the override is set.
+
+## Testing (TDD, red→green→refactor)
+
+**Node — `tests/test_passphrase_gate.js`:**
+- `derivePassphraseHash` matches the shared vector for a known `(phrase, salt, iters)`.
+- `verifyPassphrase`: true for the correct phrase, false for a wrong one.
+- `isUnlocked`: false when storage empty; false when stored ≠ expected (rotation);
+  true when stored === expected.
+- `recordUnlock` writes the expected hash to `sy_gate`.
+- `isGateEnabled`: false for empty hash, true otherwise.
+
+**Python — `tests/test_passphrase_gate.py`:**
+- `hash` CLI output equals the shared vector for the same `(phrase, salt, iters)`.
+- Cross-language: the vectors file is the same one the Node test asserts against.
+- The CLI prints only the hash (no phrase leakage).
+
+**Playwright — additions to `tests/test_preview_spa.py`** (inject
+`window.__SY_GATE_HASH` for a known test phrase):
+- Locked → clicking a preview link on the index shows the modal; index stays
+  active (preview not rendered).
+- Wrong phrase → inline error, no navigation.
+- Correct phrase → navigates to preview; modal gone.
+- After unlock → second click / reload does not prompt (persisted).
+- Cancel/Esc → modal closes, stays on index.
+- Deep link to `#/review/…` while locked → redirected to index + modal; correct →
+  proceeds to review.
+- Gate disabled (no override, empty `APP_GATE_HASH`) → preview/review open with no
+  prompt (fail-open).
+
+**Guard test:** assert `site/index.html` still contains the literal
+`var APP_GATE_HASH = '';` placeholder so the deploy `sed` target cannot silently
+disappear.
+
+## Files
+
+**New:** `site/js/passphrase_gate.js`, `tools/passphrase_gate.py`,
+`tests/test_passphrase_gate.js`, `tests/test_passphrase_gate.py`,
+`tests/fixtures/passphrase_gate_vectors.json`.
+
+**Modified:** `site/index.html` (script include, `APP_GATE_HASH` placeholder,
+`GATE_COPY`, modal, `ensureUnlocked`, index click interception, `route()` guard),
+`.github/workflows/deploy-pages.yml` (compute + inject + assert),
+`tests/test_preview_spa.py` (override + gate-flow tests), `CLAUDE.md` (tool list
+entry for `python -m tools.passphrase_gate`).
+
+## Non-goals
+
+- Real access control / content confidentiality (content is public on GitHub).
+- Encrypting content at rest.
+- Per-talk passphrases, multiple users, or rate limiting.
+- Git-history rewrite of past plaintext (separate, deferred task).
+
+## Open items
+
+- Exact prompt copy — placeholder `"Введіть пароль для доступу"` for now; the user
+  will supply final wording before/at implementation.

--- a/site/index.html
+++ b/site/index.html
@@ -1293,7 +1293,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       const h = makeDragHandle({
         id: 'preview-player-resize',
         className: 'preview-player-resize',
-        title: 'Потягніть, щоб змінити висоту плеєра',
+        title: t('preview.resize_player'),
         onMove: {
           getStart: () => {
             const cs = getComputedStyle(document.documentElement).getPropertyValue('--preview-player-h').trim();
@@ -1316,7 +1316,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       const h = makeDragHandle({
         id: 'preview-subs-resize',
         className: 'preview-subs-resize',
-        title: 'Потягніть, щоб змінити висоту субтитрів',
+        title: t('preview.resize_subs'),
         onMove: {
           getStart: () => {
             // Prefer the live overlay height so first drag picks up the
@@ -1804,6 +1804,8 @@ var I18N = {
     'gate.title': '\u0412\u0432\u0435\u0434\u0456\u0442\u044C \u043F\u0430\u0440\u043E\u043B\u044C \u0434\u043B\u044F \u0434\u043E\u0441\u0442\u0443\u043F\u0443',
     'gate.error': '\u041D\u0435\u0432\u0456\u0440\u043D\u0438\u0439 \u043F\u0430\u0440\u043E\u043B\u044C',
     'gate.submit': '\u0423\u0432\u0456\u0439\u0442\u0438',
+    'preview.resize_player': '\u041F\u043E\u0442\u044F\u0433\u043D\u0456\u0442\u044C, \u0449\u043E\u0431 \u0437\u043C\u0456\u043D\u0438\u0442\u0438 \u0432\u0438\u0441\u043E\u0442\u0443 \u043F\u043B\u0435\u0454\u0440\u0430',
+    'preview.resize_subs': '\u041F\u043E\u0442\u044F\u0433\u043D\u0456\u0442\u044C, \u0449\u043E\u0431 \u0437\u043C\u0456\u043D\u0438\u0442\u0438 \u0432\u0438\u0441\u043E\u0442\u0443 \u0441\u0443\u0431\u0442\u0438\u0442\u0440\u0456\u0432',
     'search.placeholder': '\u041F\u043E\u0448\u0443\u043A \u043F\u0440\u043E\u043C\u043E\u0432...',
     'index.loading': '\u0417\u0430\u0432\u0430\u043D\u0442\u0430\u0436\u0435\u043D\u043D\u044F...',
     'nav.back': '\u2190 \u0413\u043E\u043B\u043E\u0432\u043D\u0430',
@@ -1921,6 +1923,8 @@ var I18N = {
     'gate.title': 'Enter the password to continue',
     'gate.error': 'Wrong password',
     'gate.submit': 'Enter',
+    'preview.resize_player': 'Drag to resize the player',
+    'preview.resize_subs': 'Drag to resize the subtitles',
     'search.placeholder': 'Search talks...',
     'index.loading': 'Loading...',
     'nav.back': '\u2190 Home',

--- a/site/index.html
+++ b/site/index.html
@@ -2952,6 +2952,22 @@ function ensureManifest() {
 function route() {
   var hash = location.hash.slice(1) || '/';
 
+  // Soft passphrase gate: a gated route reached while locked (e.g. a pasted
+  // deep link) redirects to the index and prompts there; only a correct
+  // passphrase proceeds to the original target.
+  if (hash.startsWith('/preview/') || hash.startsWith('/review/')) {
+    var gateHash = gateExpectedHash();
+    if (PassphraseGate.isGateEnabled(gateHash) && !PassphraseGate.isUnlocked(gateHash, localStorage)) {
+      var target = hash;
+      if (previewState && previewState.player) { try { previewState.player.pause(); } catch(e) {} }
+      document.querySelectorAll('.view').forEach(function(v) { v.classList.remove('active'); });
+      history.replaceState(null, '', location.pathname + location.search);
+      showIndex();
+      ensureUnlocked().then(function(ok) { if (ok) location.hash = target; });
+      return;
+    }
+  }
+
   // Pause video when leaving preview
   if (previewState && previewState.player) {
     try { previewState.player.pause(); } catch(e) {}

--- a/site/index.html
+++ b/site/index.html
@@ -1774,7 +1774,6 @@ var PAGES_BASE = location.pathname.replace(/\/[^/]*$/, '');
 var APP_DEPLOY_SHA = ''; // app-shell version (index.html + js/*.js) at deploy
 var APP_DEPLOY_DATE = ''; // deploy date YYYY-MM-DD
 var APP_GATE_HASH = ''; // passphrase-gate PBKDF2 hash, injected at deploy from the GATE_PASSPHRASE secret (empty => gate disabled / fail-open)
-var GATE_COPY = 'Введіть пароль для доступу'; // passphrase prompt heading
 
 // ============================================================
 // Cache — schema versioned, auto-migrates on format change
@@ -1801,6 +1800,9 @@ var CACHE_KEY = 'sy_tree_cache__' + BRANCH;
 // ============================================================
 var I18N = {
   uk: {
+    'gate.title': '\u0412\u0432\u0435\u0434\u0456\u0442\u044C \u043F\u0430\u0440\u043E\u043B\u044C \u0434\u043B\u044F \u0434\u043E\u0441\u0442\u0443\u043F\u0443',
+    'gate.error': '\u041D\u0435\u0432\u0456\u0440\u043D\u0438\u0439 \u043F\u0430\u0440\u043E\u043B\u044C',
+    'gate.submit': '\u0423\u0432\u0456\u0439\u0442\u0438',
     'search.placeholder': '\u041F\u043E\u0448\u0443\u043A \u043F\u0440\u043E\u043C\u043E\u0432...',
     'index.loading': '\u0417\u0430\u0432\u0430\u043D\u0442\u0430\u0436\u0435\u043D\u043D\u044F...',
     'nav.back': '\u2190 \u0413\u043E\u043B\u043E\u0432\u043D\u0430',
@@ -1915,6 +1917,9 @@ var I18N = {
     'title.lang': '\u041C\u043E\u0432\u0430 \u0456\u043D\u0442\u0435\u0440\u0444\u0435\u0439\u0441\u0443'
   },
   en: {
+    'gate.title': 'Enter the password to continue',
+    'gate.error': 'Wrong password',
+    'gate.submit': 'Enter',
     'search.placeholder': 'Search talks...',
     'index.loading': 'Loading...',
     'nav.back': '\u2190 Home',
@@ -2806,7 +2811,7 @@ SPA.passphrasePrompt = function(expectedHash) {
 
     var h = document.createElement('h3');
     h.className = 'sy-modal-title';
-    h.textContent = GATE_COPY;
+    h.textContent = t('gate.title');
     modal.appendChild(h);
 
     var input = document.createElement('input');
@@ -2819,7 +2824,7 @@ SPA.passphrasePrompt = function(expectedHash) {
     var err = document.createElement('div');
     err.className = 'sy-modal-error';
     err.style.display = 'none';
-    err.textContent = 'Невірний пароль';
+    err.textContent = t('gate.error');
     modal.appendChild(err);
 
     var actions = document.createElement('div');
@@ -2827,11 +2832,11 @@ SPA.passphrasePrompt = function(expectedHash) {
     var cancelBtn = document.createElement('button');
     cancelBtn.className = 'sy-modal-btn';
     cancelBtn.type = 'button';
-    cancelBtn.textContent = 'Скасувати';
+    cancelBtn.textContent = t('modal.cancel');
     var okBtn = document.createElement('button');
     okBtn.className = 'sy-modal-btn primary';
     okBtn.type = 'button';
-    okBtn.textContent = 'Увійти';
+    okBtn.textContent = t('gate.submit');
     actions.appendChild(cancelBtn);
     actions.appendChild(okBtn);
     modal.appendChild(actions);

--- a/site/index.html
+++ b/site/index.html
@@ -2839,6 +2839,7 @@ SPA.passphrasePrompt = function(expectedHash) {
     document.body.appendChild(backdrop);
 
     var done = false;
+    var submitting = false;
     function close(val) {
       if (done) return; done = true;
       backdrop.style.animation = 'sy-fade-in .12s reverse';
@@ -2848,7 +2849,11 @@ SPA.passphrasePrompt = function(expectedHash) {
       resolve(val);
     }
     function submit() {
+      if (submitting || done) return; // ignore re-entry while a verify is in flight
+      submitting = true;
       PassphraseGate.verifyPassphrase(input.value, expectedHash).then(function(ok) {
+        submitting = false;
+        if (done) return; // cancelled mid-verify -> don't unlock or mutate the modal
         if (ok) {
           PassphraseGate.recordUnlock(expectedHash, localStorage);
           close(true);

--- a/site/index.html
+++ b/site/index.html
@@ -2774,6 +2774,117 @@ SPA.toast = function(msg) {
   stack.appendChild(t);
   setTimeout(function() { if (t.parentNode) t.parentNode.removeChild(t); }, 3000);
 };
+
+// ----- Passphrase gate (soft, client-side) -----
+// Expected hash: test/dev override first, then the deploy-injected value.
+// Empty => gate disabled (fail-open). See site/js/passphrase_gate.js.
+function gateExpectedHash() {
+  if (typeof window !== 'undefined' && typeof window.__SY_GATE_HASH === 'string') {
+    return window.__SY_GATE_HASH;
+  }
+  return APP_GATE_HASH || '';
+}
+
+// Resolves true if access is allowed (gate disabled, already unlocked, or a
+// correct passphrase was just entered); false if the user cancelled.
+function ensureUnlocked() {
+  var expected = gateExpectedHash();
+  if (!PassphraseGate.isGateEnabled(expected)) return Promise.resolve(true);
+  if (PassphraseGate.isUnlocked(expected, localStorage)) return Promise.resolve(true);
+  return SPA.passphrasePrompt(expected);
+}
+
+SPA.passphrasePrompt = function(expectedHash) {
+  return new Promise(function(resolve) {
+    var prev = document.activeElement;
+    var backdrop = document.createElement('div');
+    backdrop.className = 'sy-modal-backdrop';
+    var modal = document.createElement('div');
+    modal.className = 'sy-modal';
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+
+    var h = document.createElement('h3');
+    h.className = 'sy-modal-title';
+    h.textContent = GATE_COPY;
+    modal.appendChild(h);
+
+    var input = document.createElement('input');
+    input.type = 'password';
+    input.id = 'sy-gate-input';
+    input.className = 'sy-modal-input';
+    input.setAttribute('autocomplete', 'current-password');
+    modal.appendChild(input);
+
+    var err = document.createElement('div');
+    err.className = 'sy-modal-error';
+    err.style.display = 'none';
+    err.textContent = 'Невірний пароль';
+    modal.appendChild(err);
+
+    var actions = document.createElement('div');
+    actions.className = 'sy-modal-actions';
+    var cancelBtn = document.createElement('button');
+    cancelBtn.className = 'sy-modal-btn';
+    cancelBtn.type = 'button';
+    cancelBtn.textContent = 'Скасувати';
+    var okBtn = document.createElement('button');
+    okBtn.className = 'sy-modal-btn primary';
+    okBtn.type = 'button';
+    okBtn.textContent = 'Увійти';
+    actions.appendChild(cancelBtn);
+    actions.appendChild(okBtn);
+    modal.appendChild(actions);
+    backdrop.appendChild(modal);
+    document.body.appendChild(backdrop);
+
+    var done = false;
+    function close(val) {
+      if (done) return; done = true;
+      backdrop.style.animation = 'sy-fade-in .12s reverse';
+      setTimeout(function() { if (backdrop.parentNode) backdrop.parentNode.removeChild(backdrop); }, 120);
+      document.removeEventListener('keydown', onKey, true);
+      if (prev && prev.focus) try { prev.focus(); } catch(_){}
+      resolve(val);
+    }
+    function submit() {
+      PassphraseGate.verifyPassphrase(input.value, expectedHash).then(function(ok) {
+        if (ok) {
+          PassphraseGate.recordUnlock(expectedHash, localStorage);
+          close(true);
+        } else {
+          err.style.display = '';
+          input.value = '';
+          input.focus();
+        }
+      });
+    }
+    function onKey(e) {
+      if (e.key === 'Escape') { e.preventDefault(); close(false); }
+      if (e.key === 'Enter')  { e.preventDefault(); submit(); }
+    }
+    backdrop.addEventListener('click', function(e) { if (e.target === backdrop) close(false); });
+    cancelBtn.addEventListener('click', function() { close(false); });
+    okBtn.addEventListener('click', submit);
+    document.addEventListener('keydown', onKey, true);
+    setTimeout(function() { input.focus(); }, 20);
+  });
+};
+
+// Intercept clicks on gated links from the index so the prompt appears BEFORE
+// navigation. Correct phrase -> navigate; cancel -> stay put (no navigation).
+document.addEventListener('click', function(e) {
+  var a = e.target && e.target.closest ? e.target.closest('a') : null;
+  if (!a) return;
+  var href = a.getAttribute('href') || '';
+  if (!/^#\/(preview|review)\//.test(href)) return;
+  var expected = gateExpectedHash();
+  if (!PassphraseGate.isGateEnabled(expected)) return;          // gate off -> normal nav
+  if (PassphraseGate.isUnlocked(expected, localStorage)) return; // already unlocked
+  e.preventDefault();
+  ensureUnlocked().then(function(ok) { if (ok) location.hash = href; });
+});
+
 var manifest = null;
 var reviewStatus = null;
 

--- a/site/index.html
+++ b/site/index.html
@@ -1052,7 +1052,10 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   gap: 8px;
   margin-top: 16px;
 }
-    .sy-modal-input { width: 100%; box-sizing: border-box; padding: 8px 10px; margin-top: 6px; font-size: 15px; border: 1px solid var(--border, #cccccc); border-radius: 6px; background: var(--bg, #ffffff); color: var(--fg, #111111); }
+    .sy-modal-input-wrap { position: relative; margin-top: 6px; }
+    .sy-modal-input { display: block; width: 100%; box-sizing: border-box; padding: 8px 38px 8px 10px; font-size: 15px; border: 1px solid var(--border, #cccccc); border-radius: 6px; background: var(--bg, #ffffff); color: var(--fg, #111111); }
+    .sy-gate-reveal { position: absolute; right: 6px; top: 50%; transform: translateY(-50%); background: none; border: 0; margin: 0; padding: 4px 6px; font-size: 16px; line-height: 1; cursor: pointer; opacity: .55; }
+    .sy-gate-reveal:hover, .sy-gate-reveal.revealed { opacity: 1; }
     .sy-modal-error { color: #c0392b; font-size: 13px; margin-top: 6px; }
 .sy-modal-btn {
   background: var(--bg4);
@@ -1804,6 +1807,8 @@ var I18N = {
     'gate.title': '\u0412\u0432\u0435\u0434\u0456\u0442\u044C \u043F\u0430\u0440\u043E\u043B\u044C \u0434\u043B\u044F \u0434\u043E\u0441\u0442\u0443\u043F\u0443',
     'gate.error': '\u041D\u0435\u0432\u0456\u0440\u043D\u0438\u0439 \u043F\u0430\u0440\u043E\u043B\u044C',
     'gate.submit': '\u0423\u0432\u0456\u0439\u0442\u0438',
+    'gate.reveal': '\u041F\u043E\u043A\u0430\u0437\u0430\u0442\u0438 \u043F\u0430\u0440\u043E\u043B\u044C',
+    'gate.hide': '\u0421\u0445\u043E\u0432\u0430\u0442\u0438 \u043F\u0430\u0440\u043E\u043B\u044C',
     'preview.resize_player': '\u041F\u043E\u0442\u044F\u0433\u043D\u0456\u0442\u044C, \u0449\u043E\u0431 \u0437\u043C\u0456\u043D\u0438\u0442\u0438 \u0432\u0438\u0441\u043E\u0442\u0443 \u043F\u043B\u0435\u0454\u0440\u0430',
     'preview.resize_subs': '\u041F\u043E\u0442\u044F\u0433\u043D\u0456\u0442\u044C, \u0449\u043E\u0431 \u0437\u043C\u0456\u043D\u0438\u0442\u0438 \u0432\u0438\u0441\u043E\u0442\u0443 \u0441\u0443\u0431\u0442\u0438\u0442\u0440\u0456\u0432',
     'search.placeholder': '\u041F\u043E\u0448\u0443\u043A \u043F\u0440\u043E\u043C\u043E\u0432...',
@@ -1923,6 +1928,8 @@ var I18N = {
     'gate.title': 'Enter the password to continue',
     'gate.error': 'Wrong password',
     'gate.submit': 'Enter',
+    'gate.reveal': 'Show password',
+    'gate.hide': 'Hide password',
     'preview.resize_player': 'Drag to resize the player',
     'preview.resize_subs': 'Drag to resize the subtitles',
     'search.placeholder': 'Search talks...',
@@ -2819,12 +2826,30 @@ SPA.passphrasePrompt = function(expectedHash) {
     h.textContent = t('gate.title');
     modal.appendChild(h);
 
+    var inputWrap = document.createElement('div');
+    inputWrap.className = 'sy-modal-input-wrap';
     var input = document.createElement('input');
     input.type = 'password';
     input.id = 'sy-gate-input';
     input.className = 'sy-modal-input';
     input.setAttribute('autocomplete', 'current-password');
-    modal.appendChild(input);
+    inputWrap.appendChild(input);
+    var reveal = document.createElement('button');
+    reveal.type = 'button';
+    reveal.className = 'sy-gate-reveal';
+    reveal.textContent = '\u{1F441}'; // eye
+    reveal.setAttribute('aria-label', t('gate.reveal'));
+    reveal.title = t('gate.reveal');
+    reveal.addEventListener('click', function() {
+      var show = input.type === 'password';
+      input.type = show ? 'text' : 'password';
+      reveal.classList.toggle('revealed', show);
+      reveal.setAttribute('aria-label', show ? t('gate.hide') : t('gate.reveal'));
+      reveal.title = show ? t('gate.hide') : t('gate.reveal');
+      input.focus();
+    });
+    inputWrap.appendChild(reveal);
+    modal.appendChild(inputWrap);
 
     var err = document.createElement('div');
     err.className = 'sy-modal-error';

--- a/site/index.html
+++ b/site/index.html
@@ -1054,8 +1054,11 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 }
     .sy-modal-input-wrap { position: relative; margin-top: 6px; }
     .sy-modal-input { display: block; width: 100%; box-sizing: border-box; padding: 8px 38px 8px 10px; font-size: 15px; border: 1px solid var(--border, #cccccc); border-radius: 6px; background: var(--bg, #ffffff); color: var(--fg, #111111); }
-    .sy-gate-reveal { position: absolute; right: 6px; top: 50%; transform: translateY(-50%); background: none; border: 0; margin: 0; padding: 4px 6px; font-size: 16px; line-height: 1; cursor: pointer; opacity: .55; }
-    .sy-gate-reveal:hover, .sy-gate-reveal.revealed { opacity: 1; }
+    .sy-gate-reveal { position: absolute; right: 5px; top: 50%; transform: translateY(-50%); display: flex; align-items: center; justify-content: center; width: 30px; height: 30px; padding: 0; margin: 0; background: none; border: 0; border-radius: 6px; color: var(--fg5); cursor: pointer; transition: color .12s ease, background-color .12s ease; }
+    .sy-gate-reveal svg { width: 18px; height: 18px; display: block; }
+    .sy-gate-reveal:hover { color: var(--fg2); background: var(--bg4); }
+    .sy-gate-reveal:active { transform: translateY(-50%) scale(.9); }
+    .sy-gate-reveal:focus-visible { outline: 2px solid var(--border3); outline-offset: 1px; color: var(--fg2); }
     .sy-modal-error { color: #c0392b; font-size: 13px; margin-top: 6px; }
 .sy-modal-btn {
   background: var(--bg4);
@@ -2834,16 +2837,20 @@ SPA.passphrasePrompt = function(expectedHash) {
     input.className = 'sy-modal-input';
     input.setAttribute('autocomplete', 'current-password');
     inputWrap.appendChild(input);
+    var EYE_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1.6 12S5.1 5.2 12 5.2 22.4 12 22.4 12 18.9 18.8 12 18.8 1.6 12 1.6 12Z"/><circle cx="12" cy="12" r="3.1"/></svg>';
+    var EYE_OFF_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9.9 5.4A10.6 10.6 0 0 1 12 5.2c6.9 0 10.4 6.8 10.4 6.8a18.3 18.3 0 0 1-2.4 3.4M6 6A18 18 0 0 0 1.6 12S5.1 18.8 12 18.8a10.2 10.2 0 0 0 4-.8"/><path d="M9.9 9.9a3 3 0 0 0 4.2 4.2"/><line x1="3.2" y1="3.2" x2="20.8" y2="20.8"/></svg>';
     var reveal = document.createElement('button');
     reveal.type = 'button';
     reveal.className = 'sy-gate-reveal';
-    reveal.textContent = '\u{1F441}'; // eye
+    reveal.innerHTML = EYE_SVG;
     reveal.setAttribute('aria-label', t('gate.reveal'));
+    reveal.setAttribute('aria-pressed', 'false');
     reveal.title = t('gate.reveal');
     reveal.addEventListener('click', function() {
       var show = input.type === 'password';
       input.type = show ? 'text' : 'password';
-      reveal.classList.toggle('revealed', show);
+      reveal.innerHTML = show ? EYE_OFF_SVG : EYE_SVG;
+      reveal.setAttribute('aria-pressed', show ? 'true' : 'false');
       reveal.setAttribute('aria-label', show ? t('gate.hide') : t('gate.reveal'));
       reveal.title = show ? t('gate.hide') : t('gate.reveal');
       input.focus();

--- a/site/index.html
+++ b/site/index.html
@@ -1050,6 +1050,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   display: flex;
   justify-content: flex-end;
   gap: 8px;
+  margin-top: 16px;
 }
     .sy-modal-input { width: 100%; box-sizing: border-box; padding: 8px 10px; margin-top: 6px; font-size: 15px; border: 1px solid var(--border, #cccccc); border-radius: 6px; background: var(--bg, #ffffff); color: var(--fg, #111111); }
     .sy-modal-error { color: #c0392b; font-size: 13px; margin-top: 6px; }

--- a/site/index.html
+++ b/site/index.html
@@ -21,6 +21,7 @@
 <script src="js/add_talk_data.js"></script>
 <script src="js/shell_version.js"></script>
 <script src="js/talk_actions.js"></script>
+<script src="js/passphrase_gate.js"></script>
 <style>
 /* --- Theme: CSS custom properties --- */
 :root {
@@ -1050,6 +1051,8 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   justify-content: flex-end;
   gap: 8px;
 }
+    .sy-modal-input { width: 100%; box-sizing: border-box; padding: 8px 10px; margin-top: 6px; font-size: 15px; border: 1px solid var(--border, #cccccc); border-radius: 6px; background: var(--bg, #ffffff); color: var(--fg, #111111); }
+    .sy-modal-error { color: #c0392b; font-size: 13px; margin-top: 6px; }
 .sy-modal-btn {
   background: var(--bg4);
   color: var(--fg);
@@ -1770,6 +1773,8 @@ var PAGES_BASE = location.pathname.replace(/\/[^/]*$/, '');
 // ============================================================
 var APP_DEPLOY_SHA = ''; // app-shell version (index.html + js/*.js) at deploy
 var APP_DEPLOY_DATE = ''; // deploy date YYYY-MM-DD
+var APP_GATE_HASH = ''; // passphrase-gate PBKDF2 hash, injected at deploy from the GATE_PASSPHRASE secret (empty => gate disabled / fail-open)
+var GATE_COPY = 'Введіть пароль для доступу'; // passphrase prompt heading
 
 // ============================================================
 // Cache — schema versioned, auto-migrates on format change

--- a/site/js/passphrase_gate.js
+++ b/site/js/passphrase_gate.js
@@ -1,0 +1,86 @@
+// Passphrase gate — Python twin: tools/passphrase_gate.py.
+//
+// SOFT gate, NOT encryption: this file ships in the public SPA and the gated
+// content is public on GitHub regardless. PBKDF2 only raises the cost of
+// brute-forcing the phrase from the (public) hash; it does not protect content.
+//
+// Single source: loaded by the browser via <script src="js/passphrase_gate.js">
+// in site/index.html AND required by tests/test_passphrase_gate.js. The hashing
+// stays byte-identical to the .py twin (shared vectors in
+// tests/fixtures/passphrase_gate_vectors.json).
+//
+// GATE_SALT / GATE_ITERATIONS are the single source of truth for the KDF params
+// (deploy-pages.yml greps them out to compute the injected hash).
+
+(function () {
+  var GATE_SALT = 'a3f1c92e6b4d80571e2c9f3a6d8b0e47'; // 16-byte hex (public)
+  var GATE_ITERATIONS = 200000;
+  var STORAGE_KEY = 'sy_gate';
+
+  function hexToBytes(hex) {
+    var out = new Uint8Array(hex.length / 2);
+    for (var i = 0; i < out.length; i++) out[i] = parseInt(hex.substr(i * 2, 2), 16);
+    return out;
+  }
+  function bytesToHex(buf) {
+    var b = new Uint8Array(buf), s = '';
+    for (var i = 0; i < b.length; i++) s += (b[i] < 16 ? '0' : '') + b[i].toString(16);
+    return s;
+  }
+
+  function derivePassphraseHash(phrase) {
+    // Node (tests): synchronous PBKDF2, wrapped so the API matches the browser's
+    // async Web Crypto path. Both are RFC 2898 PBKDF2-HMAC-SHA256 -> identical.
+    if (typeof module !== 'undefined' && module.exports) {
+      var nodeCrypto = require('crypto');
+      var hex = nodeCrypto
+        .pbkdf2Sync(Buffer.from(phrase, 'utf-8'), Buffer.from(GATE_SALT, 'hex'), GATE_ITERATIONS, 32, 'sha256')
+        .toString('hex');
+      return Promise.resolve(hex);
+    }
+    var enc = new TextEncoder();
+    return crypto.subtle
+      .importKey('raw', enc.encode(phrase), { name: 'PBKDF2' }, false, ['deriveBits'])
+      .then(function (key) {
+        return crypto.subtle.deriveBits(
+          { name: 'PBKDF2', salt: hexToBytes(GATE_SALT), iterations: GATE_ITERATIONS, hash: 'SHA-256' },
+          key,
+          256
+        );
+      })
+      .then(function (bits) { return bytesToHex(bits); });
+  }
+
+  function verifyPassphrase(phrase, expectedHash) {
+    if (!expectedHash) return Promise.resolve(false);
+    return derivePassphraseHash(phrase).then(function (h) { return h === expectedHash; });
+  }
+
+  function isGateEnabled(expectedHash) { return !!expectedHash; }
+
+  function isUnlocked(expectedHash, storage) {
+    if (!expectedHash) return false;
+    try { return storage.getItem(STORAGE_KEY) === expectedHash; } catch (e) { return false; }
+  }
+
+  function recordUnlock(expectedHash, storage) {
+    try { storage.setItem(STORAGE_KEY, expectedHash); } catch (e) {}
+  }
+
+  var api = {
+    GATE_SALT: GATE_SALT,
+    GATE_ITERATIONS: GATE_ITERATIONS,
+    STORAGE_KEY: STORAGE_KEY,
+    derivePassphraseHash: derivePassphraseHash,
+    verifyPassphrase: verifyPassphrase,
+    isGateEnabled: isGateEnabled,
+    isUnlocked: isUnlocked,
+    recordUnlock: recordUnlock,
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api; // Node (tests)
+  } else {
+    this.PassphraseGate = api; // Browser: single namespace global
+  }
+}).call(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/tests/fixtures/passphrase_gate_vectors.json
+++ b/tests/fixtures/passphrase_gate_vectors.json
@@ -1,0 +1,14 @@
+{
+  "salt": "a3f1c92e6b4d80571e2c9f3a6d8b0e47",
+  "iterations": 200000,
+  "vectors": [
+    {
+      "phrase": "test-passphrase",
+      "hash": "289fa9ee16cb75d517736c68cd7d9a646fde31efead2e17b59c3219bd1548f5f"
+    },
+    {
+      "phrase": "correct-horse-battery",
+      "hash": "f3267b29331e95b8d025040f16559d2744232110081a3cf1fe8a38592bebd3c7"
+    }
+  ]
+}

--- a/tests/test_passphrase_gate.js
+++ b/tests/test_passphrase_gate.js
@@ -1,0 +1,73 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const Gate = require('../site/js/passphrase_gate');
+
+const data = JSON.parse(
+  fs.readFileSync(path.join(__dirname, 'fixtures', 'passphrase_gate_vectors.json'), 'utf-8')
+);
+
+function memStorage(initial) {
+  const m = Object.assign({}, initial || {});
+  return {
+    getItem(k) { return k in m ? m[k] : null; },
+    setItem(k, v) { m[k] = String(v); },
+  };
+}
+
+describe('passphrase_gate — constants match the shared fixture', () => {
+  it('GATE_SALT and GATE_ITERATIONS equal the fixture', () => {
+    assert.strictEqual(Gate.GATE_SALT, data.salt);
+    assert.strictEqual(Gate.GATE_ITERATIONS, data.iterations);
+  });
+});
+
+describe('passphrase_gate — derivePassphraseHash (cross-language)', () => {
+  data.vectors.forEach((vec) => {
+    it('reproduces the frozen hash for ' + vec.phrase, async () => {
+      assert.strictEqual(await Gate.derivePassphraseHash(vec.phrase), vec.hash);
+    });
+  });
+});
+
+describe('passphrase_gate — verifyPassphrase', () => {
+  const expected = data.vectors[0].hash;
+  it('true for the correct phrase', async () => {
+    assert.strictEqual(await Gate.verifyPassphrase(data.vectors[0].phrase, expected), true);
+  });
+  it('false for a wrong phrase', async () => {
+    assert.strictEqual(await Gate.verifyPassphrase('nope', expected), false);
+  });
+  it('false when the expected hash is empty (gate disabled)', async () => {
+    assert.strictEqual(await Gate.verifyPassphrase(data.vectors[0].phrase, ''), false);
+  });
+});
+
+describe('passphrase_gate — isGateEnabled', () => {
+  it('false for empty, true for a hash', () => {
+    assert.strictEqual(Gate.isGateEnabled(''), false);
+    assert.strictEqual(Gate.isGateEnabled(data.vectors[0].hash), true);
+  });
+});
+
+describe('passphrase_gate — unlock state (stores + compares the hash)', () => {
+  const expected = data.vectors[0].hash;
+  it('false when storage is empty', () => {
+    assert.strictEqual(Gate.isUnlocked(expected, memStorage()), false);
+  });
+  it('false when the stored hash differs (rotation re-prompts)', () => {
+    const s = memStorage({ sy_gate: 'old-rotated-away-hash' });
+    assert.strictEqual(Gate.isUnlocked(expected, s), false);
+  });
+  it('true when the stored hash equals the expected hash', () => {
+    const s = memStorage({ sy_gate: expected });
+    assert.strictEqual(Gate.isUnlocked(expected, s), true);
+  });
+  it('recordUnlock writes the expected hash under sy_gate', () => {
+    const s = memStorage();
+    Gate.recordUnlock(expected, s);
+    assert.strictEqual(s.getItem('sy_gate'), expected);
+    assert.strictEqual(Gate.isUnlocked(expected, s), true);
+  });
+});

--- a/tests/test_passphrase_gate.py
+++ b/tests/test_passphrase_gate.py
@@ -1,0 +1,35 @@
+"""Tests for the passphrase-gate hash (tools/passphrase_gate.py).
+
+Twin of site/js/passphrase_gate.js. SOFT gate, not encryption: the hash ships
+publicly and the gated content is public on GitHub regardless. These tests pin
+the PBKDF2 output and the cross-language vectors shared with the JS twin.
+"""
+
+from pathlib import Path
+
+from tools.passphrase_gate import derive_hash, main
+
+SALT = "a3f1c92e6b4d80571e2c9f3a6d8b0e47"
+ITERS = 200000
+VECTORS_PATH = Path(__file__).parent / "fixtures" / "passphrase_gate_vectors.json"
+
+
+def test_derive_hash_matches_known_reference():
+    assert (
+        derive_hash("test-passphrase", SALT, ITERS)
+        == "289fa9ee16cb75d517736c68cd7d9a646fde31efead2e17b59c3219bd1548f5f"
+    )
+
+
+def test_derive_hash_is_64_hex_chars():
+    h = derive_hash("anything", SALT, ITERS)
+    assert len(h) == 64
+    assert all(c in "0123456789abcdef" for c in h)
+
+
+def test_cli_hash_prints_only_the_hash(capsys):
+    main(["hash", "--salt", SALT, "--iterations", str(ITERS), "test-passphrase"])
+    out = capsys.readouterr().out.strip()
+    assert out == "289fa9ee16cb75d517736c68cd7d9a646fde31efead2e17b59c3219bd1548f5f"
+    # The phrase must never leak to stdout.
+    assert "test-passphrase" not in out

--- a/tests/test_passphrase_gate.py
+++ b/tests/test_passphrase_gate.py
@@ -5,6 +5,7 @@ publicly and the gated content is public on GitHub regardless. These tests pin
 the PBKDF2 output and the cross-language vectors shared with the JS twin.
 """
 
+import json
 from pathlib import Path
 
 from tools.passphrase_gate import derive_hash, main
@@ -33,3 +34,17 @@ def test_cli_hash_prints_only_the_hash(capsys):
     assert out == "289fa9ee16cb75d517736c68cd7d9a646fde31efead2e17b59c3219bd1548f5f"
     # The phrase must never leak to stdout.
     assert "test-passphrase" not in out
+
+
+def test_cross_language_vectors_match():
+    """Frozen vectors shared byte-for-byte with tests/test_passphrase_gate.js.
+
+    This is the contract that keeps the Python and JS hashes identical. Phrases
+    are synthetic — NEVER the real passphrase.
+    """
+    data = json.loads(VECTORS_PATH.read_text(encoding="utf-8"))
+    assert data["salt"] == SALT
+    assert data["iterations"] == ITERS
+    assert data["vectors"], "vectors file must not be empty"
+    for vec in data["vectors"]:
+        assert derive_hash(vec["phrase"], data["salt"], data["iterations"]) == vec["hash"]

--- a/tests/test_passphrase_gate.py
+++ b/tests/test_passphrase_gate.py
@@ -48,3 +48,12 @@ def test_cross_language_vectors_match():
     assert data["vectors"], "vectors file must not be empty"
     for vec in data["vectors"]:
         assert derive_hash(vec["phrase"], data["salt"], data["iterations"]) == vec["hash"]
+
+
+def test_js_module_constants_match_vectors():
+    """The JS twin's GATE_SALT/GATE_ITERATIONS must match the fixture, so the
+    deploy workflow (which greps them out of the JS) computes the right hash."""
+    js = (Path(__file__).parent.parent / "site" / "js" / "passphrase_gate.js").read_text()
+    data = json.loads(VECTORS_PATH.read_text(encoding="utf-8"))
+    assert f"GATE_SALT = '{data['salt']}'" in js
+    assert f"GATE_ITERATIONS = {data['iterations']}" in js

--- a/tests/test_passphrase_gate.py
+++ b/tests/test_passphrase_gate.py
@@ -57,3 +57,11 @@ def test_js_module_constants_match_vectors():
     data = json.loads(VECTORS_PATH.read_text(encoding="utf-8"))
     assert f"GATE_SALT = '{data['salt']}'" in js
     assert f"GATE_ITERATIONS = {data['iterations']}" in js
+
+
+def test_index_html_has_gate_hash_placeholder():
+    """The deploy workflow seds this exact line; if it ever changes, the deploy
+    silently ships an empty (disabled) gate. Pin the sed target."""
+    idx = (Path(__file__).parent.parent / "site" / "index.html").read_text()
+    assert "var APP_GATE_HASH = '';" in idx
+    assert "js/passphrase_gate.js" in idx

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -5513,8 +5513,13 @@ class TestPassphraseGate:
         rb = reveal.bounding_box()
         ib = inp.bounding_box()
         assert rb["x"] > ib["x"] + ib["width"] / 2  # right half of the field
+        # An <svg> icon (not an emoji glyph), and a state that flips on click.
+        assert reveal.locator("svg").count() == 1
+        assert reveal.get_attribute("aria-pressed") == "false"
         reveal.click()
         assert inp.get_attribute("type") == "text"  # revealed
         assert inp.input_value() == "secret123"  # value preserved
+        assert reveal.get_attribute("aria-pressed") == "true"  # state visibly flips
         reveal.click()
         assert inp.get_attribute("type") == "password"  # masked again
+        assert reveal.get_attribute("aria-pressed") == "false"

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -5498,3 +5498,23 @@ class TestPassphraseGate:
         # as the buttons crowding (and visually overlapping) the field.
         gap = okb["y"] - (inp["y"] + inp["height"])
         assert gap >= 10, f"buttons crowd the input: gap={gap:.1f}px (want >= 10)"
+
+    def test_gate_password_reveal_toggle(self, server, page):
+        _enable_gate(page)
+        goto_spa(page, server)
+        page.wait_for_selector("a.preview-link", timeout=10000)
+        page.click("a.preview-link")
+        page.wait_for_selector("#sy-gate-input", timeout=2000)
+        inp = page.locator("#sy-gate-input")
+        page.fill("#sy-gate-input", "secret123")
+        assert inp.get_attribute("type") == "password"  # masked by default
+        # The reveal toggle sits inside the field, on the right.
+        reveal = page.locator(".sy-gate-reveal")
+        rb = reveal.bounding_box()
+        ib = inp.bounding_box()
+        assert rb["x"] > ib["x"] + ib["width"] / 2  # right half of the field
+        reveal.click()
+        assert inp.get_attribute("type") == "text"  # revealed
+        assert inp.input_value() == "secret123"  # value preserved
+        reveal.click()
+        assert inp.get_attribute("type") == "password"  # masked again

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -5485,3 +5485,16 @@ class TestPassphraseGate:
         goto_spa(page, server, "#/preview/2001-01-01_Test-Talk/Test-Video")
         page.wait_for_selector("#view-preview.active", timeout=6000)
         assert page.locator("#sy-gate-input").count() == 0
+
+    def test_gate_modal_buttons_do_not_overlap_input(self, server, page):
+        _enable_gate(page)
+        goto_spa(page, server)
+        page.wait_for_selector("a.preview-link", timeout=10000)
+        page.click("a.preview-link")
+        page.wait_for_selector("#sy-gate-input", timeout=2000)
+        inp = page.locator("#sy-gate-input").bounding_box()
+        okb = page.locator(".sy-modal-btn.primary").bounding_box()
+        # The buttons must sit clearly BELOW the input — a flush/zero gap renders
+        # as the buttons crowding (and visually overlapping) the field.
+        gap = okb["y"] - (inp["y"] + inp["height"])
+        assert gap >= 10, f"buttons crowd the input: gap={gap:.1f}px (want >= 10)"

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -5404,3 +5404,59 @@ class TestIndexCardXssDefenses:
             "a => (a.getAttribute('href') || '').toLowerCase().startsWith('javascript:')).length"
         )
         assert bad == 0, "a javascript: amruta_url survived into an anchor href"
+
+
+GATE_TEST_PHRASE = "test-passphrase"
+GATE_TEST_HASH = "289fa9ee16cb75d517736c68cd7d9a646fde31efead2e17b59c3219bd1548f5f"
+
+
+def _enable_gate(pg):
+    """Inject the expected hash so the gate is active (set BEFORE goto)."""
+    pg.add_init_script(f"window.__SY_GATE_HASH = '{GATE_TEST_HASH}';")
+
+
+class TestPassphraseGate:
+    def test_clicking_preview_link_prompts_on_index(self, server, page):
+        _enable_gate(page)
+        goto_spa(page, server)
+        page.wait_for_selector("a.preview-link", timeout=10000)
+        page.click("a.preview-link")
+        page.wait_for_selector("#sy-gate-input", timeout=2000)
+        # Still on the index; preview NOT rendered.
+        assert "active" in page.locator("#view-index").get_attribute("class")
+        assert "active" not in page.locator("#view-preview").get_attribute("class")
+
+    def test_wrong_passphrase_shows_error_no_nav(self, server, page):
+        _enable_gate(page)
+        goto_spa(page, server)
+        page.wait_for_selector("a.preview-link", timeout=10000)
+        page.click("a.preview-link")
+        page.fill("#sy-gate-input", "wrong-phrase")
+        page.click(".sy-modal-btn.primary")
+        page.wait_for_selector(".sy-modal-error", state="visible", timeout=2000)
+        assert "active" not in page.locator("#view-preview").get_attribute("class")
+        assert page.locator("#sy-gate-input").count() == 1  # modal still open
+
+    def test_correct_passphrase_navigates_to_preview(self, server, page):
+        _enable_gate(page)
+        goto_spa(page, server)
+        page.wait_for_selector("a.preview-link", timeout=10000)
+        page.click("a.preview-link")
+        page.fill("#sy-gate-input", GATE_TEST_PHRASE)
+        page.press("#sy-gate-input", "Enter")
+        # 6000ms: PBKDF2(200k) verify + preview render can be slow on CI.
+        page.wait_for_selector("#view-preview.active", timeout=6000)
+        # close() removes the backdrop on a 120ms animation timer; wait it out
+        # before asserting (same pattern as test_cancel_stays_on_index).
+        page.wait_for_selector(".sy-modal", state="detached", timeout=2000)
+        assert page.locator(".sy-modal").count() == 0
+
+    def test_cancel_stays_on_index(self, server, page):
+        _enable_gate(page)
+        goto_spa(page, server)
+        page.wait_for_selector("a.preview-link", timeout=10000)
+        page.click("a.preview-link")
+        page.wait_for_selector("#sy-gate-input", timeout=2000)
+        page.click(".sy-modal-btn:not(.primary)")
+        page.wait_for_selector(".sy-modal", state="detached", timeout=2000)
+        assert "active" in page.locator("#view-index").get_attribute("class")

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -5460,3 +5460,28 @@ class TestPassphraseGate:
         page.click(".sy-modal-btn:not(.primary)")
         page.wait_for_selector(".sy-modal", state="detached", timeout=2000)
         assert "active" in page.locator("#view-index").get_attribute("class")
+
+    def test_deep_link_to_review_while_locked_redirects_and_prompts(self, server, page):
+        _enable_gate(page)
+        goto_spa(page, server, "#/review/2001-01-01_Test-Talk")
+        page.wait_for_selector("#sy-gate-input", timeout=4000)
+        # Redirected to the index; review NOT rendered.
+        assert "active" in page.locator("#view-index").get_attribute("class")
+        assert "active" not in page.locator("#view-review").get_attribute("class")
+        # Correct phrase -> proceeds to the originally-requested review.
+        page.fill("#sy-gate-input", GATE_TEST_PHRASE)
+        page.press("#sy-gate-input", "Enter")
+        page.wait_for_selector("#view-review.active", timeout=6000)
+
+    def test_already_unlocked_browser_skips_prompt(self, server, page):
+        _enable_gate(page)
+        page.add_init_script(f"localStorage.setItem('sy_gate', '{GATE_TEST_HASH}');")
+        goto_spa(page, server, "#/preview/2001-01-01_Test-Talk/Test-Video")
+        page.wait_for_selector("#view-preview.active", timeout=6000)
+        assert page.locator("#sy-gate-input").count() == 0
+
+    def test_gate_disabled_opens_without_prompt(self, server, page):
+        # No _enable_gate(): APP_GATE_HASH is empty -> fail-open.
+        goto_spa(page, server, "#/preview/2001-01-01_Test-Talk/Test-Video")
+        page.wait_for_selector("#view-preview.active", timeout=6000)
+        assert page.locator("#sy-gate-input").count() == 0

--- a/tests/test_spa_cache.js
+++ b/tests/test_spa_cache.js
@@ -3449,4 +3449,27 @@ describe('i18n: no hardcoded UI text in HTML body', () => {
     errors = errors.filter(e => !e.startsWith('t('));
     assert.strictEqual(errors.length, 0, 'Hardcoded toast messages: ' + errors.join(', '));
   });
+
+  it('passphrase gate modal uses i18n, not hardcoded strings', () => {
+    var idx = html.indexOf('SPA.passphrasePrompt');
+    assert.ok(idx > -1, 'SPA.passphrasePrompt not found');
+    var end = html.indexOf('// Intercept clicks on gated links', idx);
+    assert.ok(end > idx, 'gate click-interceptor boundary not found');
+    var fn = html.substring(idx, end);
+    ['Введіть пароль для доступу', 'Невірний пароль', 'Скасувати', 'Увійти'].forEach((lit) => {
+      assert.ok(!fn.includes(lit), 'gate modal must not hardcode "' + lit + '"; use t()');
+    });
+    ["t('gate.title')", "t('gate.error')", "t('gate.submit')", "t('modal.cancel')"].forEach((call) => {
+      assert.ok(fn.includes(call), 'gate modal must use ' + call);
+    });
+  });
+
+  it('gate i18n keys are defined in both locales (uk + en)', () => {
+    var script = html.match(/<script>([\s\S]*)<\/script>/)[1];
+    var i18n = script.match(/var I18N\s*=\s*\{([\s\S]*?)\n\};/)[1];
+    ['gate.title', 'gate.error', 'gate.submit'].forEach((k) => {
+      var count = (i18n.match(new RegExp("'" + k.replace('.', '\\.') + "'\\s*:", 'g')) || []).length;
+      assert.strictEqual(count, 2, k + ' should be defined in both locales (found ' + count + ')');
+    });
+  });
 });

--- a/tests/test_spa_cache.js
+++ b/tests/test_spa_cache.js
@@ -1931,7 +1931,11 @@ describe('Preview: cleanup on navigation', () => {
   it('player paused in route() when navigating away from preview', () => {
     var idx = html.indexOf('function route()');
     assert.ok(idx > -1, 'route function not found');
-    var chunk = html.substring(idx, idx + 500);
+    // Slice the whole route() body (up to the next top-level function) rather
+    // than a fixed-width window, so code inserted at the top of route() (e.g.
+    // the passphrase-gate deep-link guard) can't push the pause out of view.
+    var after = html.indexOf('\nfunction ', idx + 1);
+    var chunk = html.substring(idx, after > -1 ? after : idx + 2000);
     assert.ok(chunk.includes('.pause()'), 'route should pause player when leaving preview');
   });
 

--- a/tests/test_spa_cache.js
+++ b/tests/test_spa_cache.js
@@ -3450,26 +3450,20 @@ describe('i18n: no hardcoded UI text in HTML body', () => {
     assert.strictEqual(errors.length, 0, 'Hardcoded toast messages: ' + errors.join(', '));
   });
 
-  it('passphrase gate modal uses i18n, not hardcoded strings', () => {
-    var idx = html.indexOf('SPA.passphrasePrompt');
-    assert.ok(idx > -1, 'SPA.passphrasePrompt not found');
-    var end = html.indexOf('// Intercept clicks on gated links', idx);
-    assert.ok(end > idx, 'gate click-interceptor boundary not found');
-    var fn = html.substring(idx, end);
-    ['Введіть пароль для доступу', 'Невірний пароль', 'Скасувати', 'Увійти'].forEach((lit) => {
-      assert.ok(!fn.includes(lit), 'gate modal must not hardcode "' + lit + '"; use t()');
-    });
-    ["t('gate.title')", "t('gate.error')", "t('gate.submit')", "t('modal.cancel')"].forEach((call) => {
-      assert.ok(fn.includes(call), 'gate modal must use ' + call);
-    });
-  });
-
-  it('gate i18n keys are defined in both locales (uk + en)', () => {
+  it('no hardcoded Cyrillic string literals in JS (use t()/I18N)', () => {
+    // Global guard: any user-facing Cyrillic text in the SPA's JS must go
+    // through t()/I18N so it can be localized. A bare `el.textContent = '...'`
+    // (as the passphrase gate originally had) is invisible to the showToast /
+    // data-i18n scanners above — this catches it everywhere.
     var script = html.match(/<script>([\s\S]*)<\/script>/)[1];
-    var i18n = script.match(/var I18N\s*=\s*\{([\s\S]*?)\n\};/)[1];
-    ['gate.title', 'gate.error', 'gate.submit'].forEach((k) => {
-      var count = (i18n.match(new RegExp("'" + k.replace('.', '\\.') + "'\\s*:", 'g')) || []).length;
-      assert.strictEqual(count, 2, k + ' should be defined in both locales (found ' + count + ')');
-    });
+    // The I18N dictionary is the one place Cyrillic literals legitimately live.
+    var i18nMatch = script.match(/var I18N\s*=\s*\{[\s\S]*?\n\s*\};/);
+    var scanned = i18nMatch ? script.replace(i18nMatch[0], '') : script;
+    var litRe = /(['"])((?:\\.|(?!\1).)*?)\1/g;
+    var m, offenders = [];
+    while ((m = litRe.exec(scanned)) !== null) {
+      if (/[Ѐ-ӿ]/.test(m[2])) offenders.push(m[2].slice(0, 60));
+    }
+    assert.deepStrictEqual(offenders, [], 'Hardcoded Cyrillic JS literals (use t()): ' + offenders.join(' | '));
   });
 });

--- a/tests/test_spa_cache.js
+++ b/tests/test_spa_cache.js
@@ -3455,7 +3455,9 @@ describe('i18n: no hardcoded UI text in HTML body', () => {
     // through t()/I18N so it can be localized. A bare `el.textContent = '...'`
     // (as the passphrase gate originally had) is invisible to the showToast /
     // data-i18n scanners above — this catches it everywhere.
-    var script = html.match(/<script>([\s\S]*)<\/script>/)[1];
+    // Case-insensitive (i) so CodeQL's bad-tag-filter query is satisfied; our
+    // index.html uses a lowercase <script>, so matching is unchanged in practice.
+    var script = html.match(/<script>([\s\S]*)<\/script>/i)[1];
     // The I18N dictionary is the one place Cyrillic literals legitimately live.
     var i18nMatch = script.match(/var I18N\s*=\s*\{[\s\S]*?\n\s*\};/);
     var scanned = i18nMatch ? script.replace(i18nMatch[0], '') : script;

--- a/tools/passphrase_gate.py
+++ b/tools/passphrase_gate.py
@@ -1,0 +1,40 @@
+"""Passphrase-gate hash — Python twin of site/js/passphrase_gate.js.
+
+Used by .github/workflows/deploy-pages.yml to turn the GATE_PASSPHRASE secret
+into the PBKDF2 hash injected into the SPA (var APP_GATE_HASH). The literal
+passphrase is NEVER printed or committed; only the hash is emitted.
+
+This is a SOFT gate, NOT encryption: the hash ships publicly in the deployed
+site and the content behind the gate is public on GitHub regardless. The JS
+twin (site/js/passphrase_gate.js) must produce identical output, enforced by
+the shared vectors in tests/fixtures/passphrase_gate_vectors.json.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def derive_hash(phrase: str, salt_hex: str, iterations: int) -> str:
+    """PBKDF2-HMAC-SHA256(phrase, salt) -> 32-byte digest as lowercase hex."""
+    dk = hashlib.pbkdf2_hmac("sha256", phrase.encode("utf-8"), bytes.fromhex(salt_hex), iterations, dklen=32)
+    return dk.hex()
+
+
+def main(argv: list[str] | None = None) -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Compute the passphrase-gate hash.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    h = sub.add_parser("hash", help="phrase -> PBKDF2 hex hash")
+    h.add_argument("phrase")
+    h.add_argument("--salt", required=True, help="salt as hex")
+    h.add_argument("--iterations", type=int, required=True)
+    args = parser.parse_args(argv)
+
+    if args.cmd == "hash":
+        print(derive_hash(args.phrase, args.salt, args.iterations))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Soft, client-side passphrase gate. On first navigation to a talk's **preview** or **review**, the SPA prompts for a passphrase; a correct phrase (checked against a slow PBKDF2 hash) unlocks both views per-browser until the passphrase is rotated. The index (talk list) stays open.

## Honest threat model
This is **obfuscation / a soft gate, NOT encryption** — same stance as the `video_ref` work (#448). The transcripts, SRT, and `video_ref`s behind preview/review are fetched from the **public** GitHub repo, and the gate logic + hash ship publicly in the deployed JS. The gate stops casual/accidental browsing and lets one shared passphrase be handed to collaborators; it does **not** protect against anyone who reads the JS or fetches GitHub raw directly. Its real win: the **literal passphrase never appears in the repo or git history**.

## How it works
- **Hash-checked, not stored plaintext.** The passphrase lives only in the `GATE_PASSPHRASE` Actions secret. `deploy-pages.yml` computes a PBKDF2-HMAC-SHA256 hash from the secret and `sed`-injects it into `var APP_GATE_HASH` at deploy time (the same injection seam already used for `APP_DEPLOY_SHA`). In source the placeholder stays empty.
- **Unlock = store + compare the hash.** On a correct entry the expected hash is written to `localStorage['sy_gate']` and compared on every gated access — so rotating the passphrase (new secret → new injected hash) automatically re-prompts everyone. Rotation means re-running the deploy workflow (changing the secret alone doesn't trigger it).
- **Two entry points.** A click-interceptor on the index prompts *before* navigating (cancel = stay on index); a `route()` deep-link guard catches pasted `#/preview|#/review` URLs (redirect to index → prompt → proceed on success).
- **Fail-open + loud deploy.** Empty hash ⇒ gate disabled (local dev / tests / a missing secret). The deploy step asserts the hash is non-empty and fails loudly so a misconfigured secret can never silently ship an open gate.
- **Salt + iterations** are committed public constants in `site/js/passphrase_gate.js` (single source of truth; the workflow greps them). Modal copy is localized (UK + EN) via `t()`.

## Pieces
- `tools/passphrase_gate.py` + `site/js/passphrase_gate.js` — PBKDF2 twins, byte-identical (shared vectors in `tests/fixtures/passphrase_gate_vectors.json`, synthetic phrases only).
- `site/index.html` — modal, helpers, click-interceptor, `route()` guard, deploy placeholder, i18n keys.
- `.github/workflows/deploy-pages.yml` — hash injection step.
- Tests: Python + Node unit tests, Playwright E2E (prompt, wrong→error, correct→nav, cancel→stay, deep-link→redirect, persisted-unlock, fail-open), plus i18n/integrity guards.

Built TDD via the design spec and implementation plan under `docs/superpowers/`. All suites green (893 Python, 529 JS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)