### PR TITLE
fix(preview): smooth, gap-aware subtitle overlay

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -182,6 +182,14 @@ textarea.input { resize: vertical; font-family: monospace; font-size: 13px; }
   position: relative; width: 100%; min-height: 60px; padding: 12px 16px;
   background: var(--overlay-bg); color: #fff; font-size: 40px;
   line-height: 1.4; text-align: center; border-radius: 0 0 4px 4px;
+  /* box-sizing so the JS-pinned height (offsetHeight, a border-box value) is
+     interpreted consistently across modes. The hold through gaps is applied as
+     an inline `height` with `important` priority (see the render loop): only
+     that beats the fullscreen `height: auto !important` (min-height is forced to
+     0 there and does not work). On release the inline height is removed, so the
+     resized embedded mode (height: var(--preview-subs-h)) and fullscreen keep
+     their own sizing — no resize regression. */
+  box-sizing: border-box;
 }
 #subtitle-overlay:empty { min-height: 20px; }
 #subtitle-overlay:empty::after { content: '\200B'; }
@@ -925,6 +933,11 @@ body.preview-subs-resize-active-body * { cursor: ns-resize !important; user-sele
   height: auto !important;
   max-height: 60vh;
   overflow: hidden;
+  /* Fullscreen only: the render loop pins an explicit px height every frame
+     (measured from content), so subtitle-to-subtitle size changes are px→px and
+     ease here instead of snapping. Embedded has no transition (instant), per
+     design. The inline `height: Npx !important` set by JS beats the auto above. */
+  transition: height 0.2s ease;
 }
 /* Fullscreen mirrors the embedded resize handle: --preview-subs-scale is
    set by JS as a unitless number; if absent (no drag yet) the fallback 1
@@ -3686,41 +3699,93 @@ function showPreview(talkId, videoSlug) {
     if (ok && stillOnSameVideo() && previewState.mode === 'edit') renderEditList();
   });
 
-  // Cache the two hot-path DOM nodes written from timeupdate so the
-  // ~4Hz tick doesn't re-query the tree on every frame.
+  // Hot-path DOM nodes, cached once: the overlay is rewritten from a
+  // requestAnimationFrame loop (~60fps) that polls the player's true position,
+  // NOT the Vimeo `timeupdate` event. timeupdate fires only ~4×/sec (~250ms) —
+  // too coarse to render the deliberate 80ms gaps between subtitles, so the
+  // overlay jumped block-to-block and never went blank. player.getCurrentTime()
+  // is a local page↔iframe postMessage (~0.5ms, monotonic), so reading it every
+  // frame gives smooth, flicker-free sync that shows the gaps.
   var overlayEl = document.getElementById('subtitle-overlay');
   var timeEl = document.getElementById('time-display');
+  var viewEl = document.getElementById('view-preview');
+
+  // Sole writer of the overlay + time display, called every animation frame.
+  function renderOverlayAt(sec) {
+    previewState.currentTime = sec;
+    var ms = Math.round(sec * 1000);
+    var idx = findActiveSubtitleIdx(previewState.subtitles, ms);
+    var text = '';
+    if (idx !== -1) {
+      var lang = previewState.srtLang || 'uk';
+      var langEdits = (previewState.edits && previewState.edits[lang]) || {};
+      text = Object.prototype.hasOwnProperty.call(langEdits, idx)
+        ? langEdits[idx]
+        : previewState.subtitles[idx].text;
+    }
+    // Re-run the height logic on a fullscreen toggle too (not just text changes),
+    // so a toggle while paused re-pins correctly for the new mode.
+    var fs = !!(viewEl && viewEl.classList.contains('fs-mode'));
+    var modeChanged = fs !== previewState.lastFsMode;
+    previewState.lastFsMode = fs;
+    if (text !== previewState.lastText || modeChanged) {
+      if (text === '') {
+        // Entering a gap: pin the box to the height of the subtitle that is
+        // still showing so the background holds through the 80ms pause instead
+        // of collapsing and bouncing. Inline `height` with `important` priority
+        // — fullscreen sets `height: auto !important` and forces min-height to
+        // 0, so only this wins in every mode.
+        overlayEl.style.setProperty('height', overlayEl.offsetHeight + 'px', 'important');
+        overlayEl.textContent = '';
+      } else if (fs) {
+        // Fullscreen: keep an explicit measured px height every subtitle so the
+        // change is px→px and the CSS height transition eases it (interpolating
+        // to/from `auto` is impossible). Measure natural height, then pin it.
+        overlayEl.textContent = text;
+        overlayEl.style.removeProperty('height');
+        overlayEl.style.setProperty('height', overlayEl.offsetHeight + 'px', 'important');
+      } else {
+        // Embedded: release to the natural content (auto-expand) or the user's
+        // resized height (var) — instant, no transition, per design.
+        overlayEl.style.removeProperty('height');
+        overlayEl.textContent = text;
+      }
+      previewState.lastText = text;
+    }
+    var s = Math.floor(sec);
+    if (s !== previewState.lastSec) {
+      timeEl.textContent =
+        String(Math.floor(s/3600)).padStart(2,'0') + ':' + String(Math.floor((s%3600)/60)).padStart(2,'0') + ':' + String(s%60).padStart(2,'0');
+      previewState.lastSec = s;
+    }
+  }
 
   if (!sameVideo && embedUrl) {
     try {
       var player = new Vimeo.Player(iframe);
       previewState.player = player;
+      // Token guarding the rAF loop: a fresh entry for the same video (player
+      // rebuilt) installs a new token, so the prior loop sees the mismatch and
+      // stops. Navigating to a different video stops it via stillOnSameVideo().
+      var rafToken = {};
+      previewState._rafToken = rafToken;
+      var pollInFlight = false;
+      function overlayLoop() {
+        if (!stillOnSameVideo() || previewState._rafToken !== rafToken) return;
+        // In-flight guard: at most one getCurrentTime() outstanding. It resolves
+        // in well under a frame, so most frames still get a fresh position.
+        if (!pollInFlight) {
+          pollInFlight = true;
+          player.getCurrentTime().then(function(sec) {
+            pollInFlight = false;
+            if (stillOnSameVideo() && previewState._rafToken === rafToken) renderOverlayAt(sec);
+          }).catch(function() { pollInFlight = false; });
+        }
+        requestAnimationFrame(overlayLoop);
+      }
       player.ready().then(function() {
         console.log('[SPA] Vimeo player ready');
-        player.on('timeupdate', function(data) {
-          if (!stillOnSameVideo()) return;
-          previewState.currentTime = data.seconds;
-          var ms = Math.round(data.seconds * 1000);
-          var idx = findActiveSubtitleIdx(previewState.subtitles, ms);
-          var text = '';
-          if (idx !== -1) {
-            var lang = previewState.srtLang || 'uk';
-            var langEdits = (previewState.edits && previewState.edits[lang]) || {};
-            text = Object.prototype.hasOwnProperty.call(langEdits, idx)
-              ? langEdits[idx]
-              : previewState.subtitles[idx].text;
-          }
-          if (text !== previewState.lastText) {
-            overlayEl.textContent = text;
-            previewState.lastText = text;
-          }
-          var s = Math.floor(data.seconds);
-          if (s !== previewState.lastSec) {
-            timeEl.textContent =
-              String(Math.floor(s/3600)).padStart(2,'0') + ':' + String(Math.floor((s%3600)/60)).padStart(2,'0') + ':' + String(s%60).padStart(2,'0');
-            previewState.lastSec = s;
-          }
-        });
+        requestAnimationFrame(overlayLoop);
       }).catch(function(err) {
         console.warn('[SPA] Vimeo player error:', err);
       });
@@ -3733,6 +3798,10 @@ function showPreview(talkId, videoSlug) {
 }
 
 function vimeoEmbed(url) {
+  // A video with no/undecodable link (video.vimeo_url undefined) must not crash
+  // the caller — showPreview reaches here for a link-less video opened by deep
+  // link, and `undefined.match(...)` would throw and abort the whole preview.
+  if (!url) return '';
   var m = url.match(/vimeo\.com\/(\d+)\/([a-f0-9]+)/);
   if (m) return 'https://player.vimeo.com/video/' + m[1] + '?h=' + m[2];
   m = url.match(/vimeo\.com\/(\d+)(?![\/\w])/);

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -363,6 +363,145 @@ class TestPreviewView:
         }""")
         assert text == "Перший субтитр"
 
+    def test_overlay_tracks_playhead_into_gap_without_timeupdate(self, server, page):
+        # The deliberate gap between subtitles (here 5.0s..6.0s) must show as a
+        # blank overlay. The overlay is driven by polling the player position
+        # (getCurrentTime) every animation frame, NOT by the ~4x/sec timeupdate
+        # event — so a playhead resting in the gap blanks the overlay even though
+        # no timeupdate sample landed there. Moving _currentTime WITHOUT firing a
+        # timeupdate reproduces exactly that case; the old event-driven overlay
+        # would stay stuck on the previous subtitle.
+        self._goto_preview(server, page)
+        # Precondition: block 1 (1.0s..5.0s) is showing, so a later blank is a
+        # real transition, not the empty overlay the page starts with.
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_function(
+            "document.getElementById('subtitle-overlay').textContent === 'Перший субтитр'",
+            timeout=2000,
+        )
+        # Move the playhead into the gap without emitting a timeupdate.
+        page.evaluate("window._vimeoPlayer._currentTime = 5.5")
+        page.wait_for_function(
+            "document.getElementById('subtitle-overlay').textContent === ''",
+            timeout=2000,
+        )
+
+    def test_overlay_height_held_through_gap(self, server, page):
+        # During the brief 80ms gaps the overlay must not collapse its height —
+        # a multi-line subtitle dropping to an empty (1-line) box and back is a
+        # jarring vertical bounce. The overlay holds the prior subtitle's height
+        # while blank, so the background stays put through the pause.
+        self._goto_preview(server, page)
+        # Force the (short) subtitle text to wrap to several lines so a collapse
+        # to an empty 1-line box would be unmistakable.
+        page.evaluate("document.getElementById('subtitle-overlay').style.maxWidth = '70px'")
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_function(
+            "document.getElementById('subtitle-overlay').textContent === 'Перший субтитр'",
+            timeout=2000,
+        )
+        page.wait_for_timeout(300)  # let the height settle
+        h_text = page.evaluate("document.getElementById('subtitle-overlay').offsetHeight")
+        # Into the gap (no timeupdate) — overlay blanks but must keep its height.
+        page.evaluate("window._vimeoPlayer._currentTime = 5.5")
+        page.wait_for_function(
+            "document.getElementById('subtitle-overlay').textContent === ''",
+            timeout=2000,
+        )
+        page.wait_for_timeout(300)  # past any height transition
+        h_gap = page.evaluate("document.getElementById('subtitle-overlay').offsetHeight")
+        assert h_text > 90, f"expected a multi-line subtitle, got {h_text}px"
+        assert h_gap >= h_text - 5, f"overlay collapsed in gap: {h_text} -> {h_gap}"
+
+    def test_overlay_fullscreen_pins_explicit_height(self, server, page):
+        # Fullscreen eases size changes between subtitles, which needs an explicit
+        # px height every frame (CSS cannot transition to/from `auto`). So in
+        # fs-mode each subtitle pins a measured px height; embedded does not.
+        self._goto_preview(server, page)
+        page.evaluate("document.getElementById('view-preview').classList.add('fs-mode')")
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_function(
+            "document.getElementById('subtitle-overlay').textContent === 'Перший субтитр'",
+            timeout=2000,
+        )
+        h = page.evaluate("document.getElementById('subtitle-overlay').style.getPropertyValue('height')")
+        assert h.endswith("px"), f"fullscreen should pin an explicit px height, got {h!r}"
+
+    def test_overlay_embedded_does_not_pin_height(self, server, page):
+        # Embedded keeps the default sizing (const + auto-expand, or the user's
+        # resized height): no explicit height pinned for a shown subtitle.
+        self._goto_preview(server, page)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_function(
+            "document.getElementById('subtitle-overlay').textContent === 'Перший субтитр'",
+            timeout=2000,
+        )
+        h = page.evaluate("document.getElementById('subtitle-overlay').style.getPropertyValue('height')")
+        assert h == "", f"embedded should not pin a height, got {h!r}"
+
+    # NOTE: the fullscreen tests below simulate fs via the `.fs-mode` class —
+    # they cover the CSS/JS behaviour, NOT the native requestFullscreen path.
+
+    def test_overlay_height_held_through_gap_fullscreen(self, server, page):
+        # The reported bug was the fullscreen gradient band collapsing on gaps.
+        # The hold uses inline `height:!important` specifically because fs sets
+        # `height: auto !important` and forces min-height to 0 — a "cleaner"
+        # min-height refactor would pass the embedded hold test but silently
+        # re-break fullscreen. This is the guard for that.
+        self._goto_preview(server, page)
+        page.evaluate("document.getElementById('view-preview').classList.add('fs-mode')")
+        page.evaluate("document.getElementById('subtitle-overlay').style.maxWidth = '70px'")
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_function(
+            "document.getElementById('subtitle-overlay').textContent === 'Перший субтитр'",
+            timeout=2000,
+        )
+        page.wait_for_timeout(300)
+        h_text = page.evaluate("document.getElementById('subtitle-overlay').offsetHeight")
+        page.evaluate("window._vimeoPlayer._currentTime = 5.5")
+        page.wait_for_function(
+            "document.getElementById('subtitle-overlay').textContent === ''",
+            timeout=2000,
+        )
+        page.wait_for_timeout(300)
+        h_gap = page.evaluate("document.getElementById('subtitle-overlay').offsetHeight")
+        assert h_text > 90, f"expected a multi-line subtitle, got {h_text}px"
+        assert h_gap >= h_text - 5, f"fullscreen overlay collapsed in gap: {h_text} -> {h_gap}"
+
+    def test_overlay_releases_pinned_height_on_exit_fullscreen(self, server, page):
+        # Exiting fullscreen (even while paused) must release the pinned px height
+        # so embedded returns to its default/auto sizing. The render loop's
+        # mode-change branch is the only thing that does this; nothing else covers it.
+        self._goto_preview(server, page)
+        page.evaluate("document.getElementById('view-preview').classList.add('fs-mode')")
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_function(
+            "document.getElementById('subtitle-overlay').style.getPropertyValue('height').endsWith('px')",
+            timeout=2000,
+        )
+        page.evaluate("document.getElementById('view-preview').classList.remove('fs-mode')")
+        page.wait_for_function(
+            "document.getElementById('subtitle-overlay').style.getPropertyValue('height') === ''",
+            timeout=2000,
+        )
+
+    def test_overlay_follows_scrub_while_paused(self, server, page):
+        # Polling getCurrentTime each frame means a scrub updates the overlay with
+        # no play/seeked event — a behaviour gained by dropping the event handlers.
+        self._goto_preview(server, page)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_function(
+            "document.getElementById('subtitle-overlay').textContent === 'Перший субтитр'",
+            timeout=2000,
+        )
+        # Scrub into block 2 (6..10s) by setting the raw field — no event fired.
+        page.evaluate("window._vimeoPlayer._currentTime = 7")
+        page.wait_for_function(
+            "document.getElementById('subtitle-overlay').textContent !== 'Перший субтитр'"
+            " && document.getElementById('subtitle-overlay').textContent !== ''",
+            timeout=2000,
+        )
+
     def test_marker_add(self, server, page):
         self._goto_preview(server, page)
         page.evaluate("window._vimeoPlayer._setTime(2)")
@@ -370,6 +509,20 @@ class TestPreviewView:
         page.click("#btn-mark")
         count = page.locator("#marker-count").text_content()
         assert count == "1"
+
+    def test_vimeo_embed_handles_missing_url(self, server, page):
+        # showPreview calls vimeoEmbed(video.vimeo_url) for a link-less video
+        # reached by deep link; a falsy URL must return '' rather than throwing
+        # on undefined.match() and aborting the whole preview render.
+        self._goto_preview(server, page)
+        res = page.evaluate(
+            "() => { try { return {ok: true, v: vimeoEmbed(undefined)}; }"
+            " catch (e) { return {ok: false, err: String(e)}; } }"
+        )
+        assert res["ok"], f"vimeoEmbed threw on undefined: {res.get('err')}"
+        assert res["v"] == ""
+        assert page.evaluate("vimeoEmbed(null)") == ""
+        assert page.evaluate("vimeoEmbed('not a url')") == ""
 
 
 class TestReviewView:
@@ -553,6 +706,9 @@ class TestMarkers:
         assert markers is not None
         assert len(markers) == 1
         assert markers[0]["text"] == "Перший субтитр"
+        # Time comes from the polled position (previewState.currentTime), so it
+        # must match where we set the player, not stay at 0.
+        assert abs(markers[0]["time"] - 2) < 0.5, f"marker time off: {markers[0]['time']}"
 
     def test_marker_count_increments(self, server, page):
         """Adding multiple markers updates the count."""


### PR DESCRIPTION
## Problem
In the preview/review SPA the subtitle overlay was driven by Vimeo's `timeupdate` event (~4 Hz / ~250 ms). The deliberate **80 ms gaps** between subtitles fell *between* samples, so the overlay jumped block-to-block and the pauses were never shown. When that was first made high-frequency, a naïve interpolation introduced a second problem — a millisecond text flicker at boundaries — and the empty-gap state exposed a vertical "flap" of the overlay background.

## Fix
- **Sync:** a `requestAnimationFrame` loop polls `player.getCurrentTime()` (~60 fps; a local page↔iframe postMessage, ~0.5 ms, monotonic) instead of `timeupdate`. The true position is read every frame → 80 ms gaps are visible, no text flicker, no drift. Measured: 120 reads/s, 0 backward steps.
- **Background hold:** through a gap the overlay box height is pinned (inline `height: !important`) so it doesn't collapse/bounce. Works in **embedded and fullscreen** (fullscreen forces `min-height:0`, so only an important inline height wins). On a subtitle the pin is released → default/auto sizing or the user's resized height (no resize-handle regression).
- **Fullscreen smooth resize:** each subtitle pins an explicit *measured* px height, so size changes between differently-sized subtitles ease via a CSS `height` transition (px↔px) instead of snapping. Embedded stays instant by design.
- **Cleanup:** removed the now-unused interpolation clock module and all player event handlers (`timeupdate`/`play`/`pause`/`seeked`) — polling needs none, and seek-while-paused works for free.
- **Tangential robustness fix (found during investigation):** `vimeoEmbed()` now returns `''` for a falsy URL instead of throwing on `undefined.match()` — a link-less video opened by deep link no longer aborts the whole `showPreview` render.

## Tests
Deterministic E2E regression coverage (no animation-frame/timing asserts):
gap blanking without a timeupdate, height hold (embedded + fullscreen), fullscreen explicit-px pinning, pin release on fullscreen exit, scrub-while-paused, marker time from the polled position, and `vimeoEmbed` null-safety.

- Full preview suite: **333 passed**
- JS suite: **542 passed**

## Verify locally
Preview the 1984 Raksha Bandhan talk, pick **EN** (684 deliberate 80 ms gaps), play in both embedded and fullscreen: pauses are visible, no text flicker, the background holds through gaps, and in fullscreen the size eases between subtitles.

## Note
The `vimeoEmbed` null-guard is tangential to the subtitle work; happy to split it into its own PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
