### PR TITLE
optimize_srt: hard-max rescue tier in cascade_redistribute

### DIFF
--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -5,6 +5,7 @@ import json
 from tools.config import OptimizeConfig
 from tools.optimize_srt import (
     build_blocks_from_uk_whisper,
+    cascade_redistribute,
     find_best_split_point,
     find_block_split_point,
     merge_short_blocks,
@@ -225,3 +226,41 @@ def test_optimize_without_whisper_json(sample_srt_path, tmp_srt):
 
     blocks = parse_srt(tmp_srt)
     assert len(blocks) > 0
+
+
+# --- cascade_redistribute ---
+
+
+def _cps(block):
+    chars = len(block["text"].replace("\n", ""))
+    return chars / ((block["end_ms"] - block["start_ms"]) / 1000.0)
+
+
+def test_cascade_redistribute_hard_max_rescue_uses_dense_donors():
+    """A block above hard_max_cps surrounded only by above-target neighbors
+    must still be rescued: donors with slack up to (just below) hard_max_cps
+    are eligible, not only sub-target ones."""
+    config = OptimizeConfig()  # target 15, hard max 20
+    blocks = [
+        {"idx": 1, "start_ms": 0, "end_ms": 3200, "text": "a" * 50},  # CPS 15.6
+        {"idx": 2, "start_ms": 3280, "end_ms": 6480, "text": "b" * 50},  # CPS 15.6
+        {"idx": 3, "start_ms": 6560, "end_ms": 8760, "text": "c" * 62},  # CPS 28.2
+        {"idx": 4, "start_ms": 8840, "end_ms": 12040, "text": "d" * 50},  # CPS 15.6
+        {"idx": 5, "start_ms": 12120, "end_ms": 15320, "text": "e" * 50},  # CPS 15.6
+    ]
+    result = cascade_redistribute(blocks, config, [])
+    assert all(_cps(b) <= config.hard_max_cps for b in result), [round(_cps(b), 1) for b in result]
+
+
+def test_cascade_redistribute_leaves_soft_blocks_untouched():
+    """Blocks between target and hard max must NOT be densified by the
+    hard-max rescue tier — it only fixes hard violations."""
+    config = OptimizeConfig()
+    blocks = [
+        {"idx": 1, "start_ms": 0, "end_ms": 3400, "text": "a" * 55},  # CPS 16.2
+        {"idx": 2, "start_ms": 3480, "end_ms": 6980, "text": "b" * 60},  # CPS 17.1
+        {"idx": 3, "start_ms": 7060, "end_ms": 10460, "text": "c" * 55},  # CPS 16.2
+    ]
+    before = [(b["start_ms"], b["end_ms"]) for b in blocks]
+    result = cascade_redistribute(blocks, config, [])
+    assert [(b["start_ms"], b["end_ms"]) for b in result] == before

--- a/tools/optimize_srt.py
+++ b/tools/optimize_srt.py
@@ -703,8 +703,10 @@ def merge_short_blocks(blocks, config):
     return blocks, total_merged
 
 
-def cascade_redistribute(blocks, config, report):
-    """Steal time from neighbor blocks (up to 8 blocks away) to reduce CPS."""
+def _cascade_pass(blocks, config, recipient_min_cps, level_cps):
+    """One redistribution pass: blocks with CPS above ``recipient_min_cps``
+    receive time (aiming at ``level_cps``) from neighbors whose CPS stays
+    below ``level_cps`` after donating. Returns (blocks, count)."""
     SEARCH_RADIUS = 8
     redistributed = 0
 
@@ -715,10 +717,10 @@ def cascade_redistribute(blocks, config, report):
             dur = b["end_ms"] - b["start_ms"]
             cps = chars / (dur / 1000.0) if dur > 0 else 999
 
-            if cps <= config.target_cps:
+            if cps <= recipient_min_cps:
                 continue
 
-            needed_dur = int((chars / config.target_cps) * 1000)
+            needed_dur = int((chars / level_cps) * 1000)
             extra_needed = needed_dur - dur
             if extra_needed <= 0:
                 continue
@@ -732,8 +734,8 @@ def cascade_redistribute(blocks, config, report):
                 nb_dur = nb["end_ms"] - nb["start_ms"]
                 nb_cps = nb_chars / (nb_dur / 1000.0) if nb_dur > 0 else 999
 
-                if nb_cps < config.target_cps:
-                    nb_min_dur = int((nb_chars / config.target_cps) * 1000)
+                if nb_cps < level_cps:
+                    nb_min_dur = int((nb_chars / level_cps) * 1000)
                     nb_can_give = max(0, nb_dur - nb_min_dur - config.min_gap_ms)
                     give = min(extra_needed, nb_can_give)
                     if give > 30:
@@ -754,8 +756,8 @@ def cascade_redistribute(blocks, config, report):
                 nb_dur = nb["end_ms"] - nb["start_ms"]
                 nb_cps = nb_chars / (nb_dur / 1000.0) if nb_dur > 0 else 999
 
-                if nb_cps < config.target_cps:
-                    nb_min_dur = int((nb_chars / config.target_cps) * 1000)
+                if nb_cps < level_cps:
+                    nb_min_dur = int((nb_chars / level_cps) * 1000)
                     nb_can_give = max(0, nb_dur - nb_min_dur - config.min_gap_ms)
                     give = min(extra_needed, nb_can_give)
                     if give > 30:
@@ -772,8 +774,32 @@ def cascade_redistribute(blocks, config, report):
         if iter_redis == 0:
             break
 
+    return blocks, redistributed
+
+
+def cascade_redistribute(blocks, config, report):
+    """Steal time from neighbor blocks (up to 8 blocks away) to reduce CPS.
+
+    Two tiers:
+    1. Gentle leveling toward ``target_cps`` — donors only below target, so
+       normal talks get comfortable padding without densifying anyone.
+    2. Hard-max rescue — dense passages (neighbors all above target) have no
+       sub-target donors, so tier 1 leaves blocks above ``hard_max_cps``.
+       Re-run the pass for those violators only, leveling recipient and
+       donors to just below the hard ceiling (5% margin keeps int-truncated
+       durations safely under the validator's strict ``> hard_max`` check).
+    """
+    blocks, redistributed = _cascade_pass(blocks, config, config.target_cps, config.target_cps)
+
+    rescue_level = config.hard_max_cps * 0.95
+    rescued = 0
+    if rescue_level > config.target_cps:
+        blocks, rescued = _cascade_pass(blocks, config, config.hard_max_cps, rescue_level)
+
     if redistributed:
         report.append(f"  Phase 7 - Cascade time redistribution: {redistributed}")
+    if rescued:
+        report.append(f"  Phase 7 - Hard-max rescue redistribution: {rescued}")
 
     return blocks
 


### PR DESCRIPTION
## Problem

Pipeline run [26957029199](https://github.com/sy-tools/sy-subtitles/actions/runs/26957029199) failed at **Validate subtitles** for `1982-08-06_The-Importance-of-Dedication-and-Devotion`: `[FAIL] CPS ≤ 20.0` — 10 blocks left at CPS up to 28.2 after optimization.

Root cause: Phase 7 (`cascade_redistribute`) levels blocks toward `target_cps` (15) and accepts **only sub-target donors**. In dense dialogue passages (the Linda conversation — avg CPS 16–19) there are no sub-15 neighbors, so blocks above the hard ceiling stay unfixable. Known issue, previously worked around per-talk with `--target-cps 19` (Raksha-Bandhan 1984).

## Fix

After the existing gentle pass, run a **hard-max rescue pass** for blocks still above `hard_max_cps`: donors may have any CPS below 95% of the hard ceiling (19.0 for the default 20), and recipients level to that same mark — minimal time theft, and soft (15–20 CPS) blocks are never densified (guarded by test).

## Verification

- TDD: new test fails on main (`[15.6, 15.6, 28.2, 15.6, 15.6]` — violator untouched), passes with fix
- Full suite: 522 passed (1 unrelated flaky SPA test, passes in isolation)
- Failing talk rebuilt from run artifacts with **pipeline-default flags**: CPS>20 **21 → 0**, max CPS 20.0, full validation **PASSED**
- `GOLDEN_TALKS_SCOPE=all`: failure set **identical** to main (41 pre-existing, 0 new)

Salvaged subtitles for the failing talk follow in a separate PR (data only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)