### PR TITLE
sync_pr: validate with build_manifest mode flags

### DIFF
--- a/tests/test_golden_talks.py
+++ b/tests/test_golden_talks.py
@@ -20,54 +20,11 @@ import os
 from pathlib import Path
 
 import pytest
-import yaml
 
 from tools.optimize_srt import optimize
 from tools.srt_utils import parse_srt
+from tools.validate_subtitles import manifest_validate_flags as _mode_flags
 from tools.validate_subtitles import validate
-
-
-def _mode_flags(srt_path: Path) -> dict:
-    """Return validate() kwargs matching how the pipeline validated this video.
-
-    Reads `final/build_manifest.yaml` written during pipeline commit. The
-    manifest tells us which mode produced the SRT so golden validation
-    mirrors the pipeline's `--skip-*` flags exactly — running stricter
-    than production would flag legitimate pipeline outputs as broken.
-
-    Legacy talks built before the manifest landed keep their historical
-    strict treatment (all checks on).
-    """
-    manifest_path = srt_path.parent / "build_manifest.yaml"
-    if not manifest_path.is_file():
-        return {}  # legacy: strict validate
-    with open(manifest_path, encoding="utf-8") as f:
-        manifest = yaml.safe_load(f) or {}
-    role = manifest.get("role")
-    mode = manifest.get("mode")
-    # All manifest-aware calls share the pipeline's --skip-duration-check:
-    # long title blocks and short interjection blocks are tolerated by the
-    # pipeline's primary+secondary validates, so golden must not be stricter.
-    flags: dict = {"skip_duration_check": True}
-    if role == "secondary":
-        # Secondary = derivative (offset / resync from primary). Text came
-        # from primary (already validated); timing is shifted/warped, CPS
-        # may spike in a few places where primary's silences collapse.
-        flags.update(skip_text_check=True, skip_time_check=True, skip_cps_check=True)
-        return flags
-    if role == "primary" and mode == "en-srt":
-        # En-srt primary: transcript-only content is legitimately dropped
-        # by Opus (no EN counterpart), so text preservation is replaced by
-        # a block-count sanity against the EN SRT.
-        flags["skip_text_check"] = True
-        en_srt = srt_path.parent.parent / "source" / "en.srt"
-        if en_srt.is_file():
-            flags["en_srt_path"] = str(en_srt)
-            flags["compare_block_count"] = True
-        return flags
-    # Primary + whisper mode: only duration-skip (matches pipeline).
-    return flags
-
 
 ROOT = Path(__file__).resolve().parent.parent
 TALKS = ROOT / "talks"

--- a/tests/test_sync_pr.py
+++ b/tests/test_sync_pr.py
@@ -209,3 +209,40 @@ class TestSyncPrIntegration:
 
         transcript = (repo_path / "talks" / "test" / "transcript_uk.txt").read_text(encoding="utf-8")
         assert transcript == BASE_TRANSCRIPT
+
+    def test_new_en_srt_mode_srt_validates_with_manifest_flags(self, repo):
+        """A PR that ADDS a final/uk.srt built in en-srt mode (transcript
+        already on main, e.g. from an earlier failed pipeline run) must be
+        validated with the build_manifest.yaml mode flags: en-srt primaries
+        legitimately drop transcript-only blocks (closing signatures), so
+        text preservation is replaced by a block-count sanity vs
+        source/en.srt — exactly like the pipeline and golden tests do.
+        Reproduces the 1982-08-06 salvage PR failing the sync check."""
+        repo_path, _ = repo
+        talk = repo_path / "talks" / "ensrt"
+        (talk / "Video1" / "final").mkdir(parents=True)
+        (talk / "Video1" / "source").mkdir(parents=True)
+        (talk / "meta.yaml").write_text("videos:\n  - slug: Video1\n    title: V\n", encoding="utf-8")
+        # Transcript carries a closing signature paragraph that the en-srt
+        # build drops (no EN counterpart).
+        (talk / "transcript_uk.txt").write_text(BASE_TRANSCRIPT + "\nВічно люблячa вас Мати.\n", encoding="utf-8")
+        _git(repo_path, "add", "talks")
+        _git(repo_path, "commit", "-q", "-m", "ensrt talk: transcript only")
+        base_sha = _git(repo_path, "rev-parse", "HEAD").strip()
+
+        # PR: pipeline-built artifacts — SRT without the signature block,
+        # the EN SRT timing source, and the manifest recording the mode.
+        (talk / "Video1" / "final" / "uk.srt").write_text(BASE_SRT, encoding="utf-8")
+        (talk / "Video1" / "source" / "en.srt").write_text(BASE_SRT, encoding="utf-8")
+        (talk / "Video1" / "final" / "build_manifest.yaml").write_text(
+            "role: primary\nmode: en-srt\n", encoding="utf-8"
+        )
+        _git(repo_path, "add", "talks")
+        _git(repo_path, "commit", "-q", "-m", "add built uk.srt (en-srt mode)")
+
+        exit_code = run(base_sha)
+        assert exit_code == 0
+
+        # Untouched by sync — the SRT is already final.
+        srt_after = (talk / "Video1" / "final" / "uk.srt").read_text(encoding="utf-8")
+        assert srt_after == BASE_SRT

--- a/tools/sync_pr.py
+++ b/tools/sync_pr.py
@@ -44,6 +44,7 @@ import yaml
 from .sync_common import load_base_from_git
 from .sync_srt_to_transcript import sync_srt_to_transcript
 from .sync_transcript_to_srt import sync_transcript
+from .validate_subtitles import manifest_validate_flags
 from .validate_subtitles import validate as validate_subtitles
 
 
@@ -213,14 +214,18 @@ def _process_talk(
         # Validate the updated SRT against the updated transcript. Matches
         # the old bash step's flags: we skip time/duration checks because
         # Step B doesn't touch timecodes (except via optimize, which
-        # recomputes them safely).
+        # recomputes them safely). On top of that, apply the build mode
+        # flags from build_manifest.yaml — en-srt primaries legitimately
+        # drop transcript-only blocks and secondaries are derivative, so
+        # validating stricter than the pipeline would reject its outputs.
         print(f"  [{talk_id}/{slug}] validate", file=sys.stderr)
+        flags = {"skip_time_check": True, "skip_duration_check": True}
+        flags.update(manifest_validate_flags(srt_file))
         try:
             passed, _report = validate_subtitles(
                 srt_path=str(srt_file),
                 transcript_path=str(transcript_path),
-                skip_time_check=True,
-                skip_duration_check=True,
+                **flags,
             )
         except Exception as exc:  # noqa: BLE001
             _gha_error(f"{talk_id}/{slug}: validate raised: {exc}")

--- a/tools/validate_subtitles.py
+++ b/tools/validate_subtitles.py
@@ -16,7 +16,10 @@ Usage:
 import argparse
 import re
 import unicodedata
+from pathlib import Path
 from typing import Literal, NamedTuple
+
+import yaml
 
 from .config import OptimizeConfig
 from .srt_utils import (
@@ -321,6 +324,48 @@ def check_statistics(srt_blocks, config, report):
         report.append(f'    #{idx}: CPS={cps:.1f} ({chars}ch/{dur:.1f}s) "{text_short}"')
 
     return stats
+
+
+def manifest_validate_flags(srt_path) -> dict:
+    """Return validate() kwargs matching how the pipeline validated this video.
+
+    Reads `final/build_manifest.yaml` next to the SRT (written during
+    pipeline commit). The manifest tells us which mode produced the SRT so
+    re-validation mirrors the pipeline's `--skip-*` flags exactly — running
+    stricter than production would flag legitimate pipeline outputs as
+    broken. Legacy talks built before the manifest landed get {} (strict).
+    """
+    srt_path = Path(srt_path)
+    manifest_path = srt_path.parent / "build_manifest.yaml"
+    if not manifest_path.is_file():
+        return {}  # legacy: strict validate
+    with open(manifest_path, encoding="utf-8") as f:
+        manifest = yaml.safe_load(f) or {}
+    role = manifest.get("role")
+    mode = manifest.get("mode")
+    # All manifest-aware calls share the pipeline's --skip-duration-check:
+    # long title blocks and short interjection blocks are tolerated by the
+    # pipeline's primary+secondary validates, so re-checks must not be
+    # stricter.
+    flags: dict = {"skip_duration_check": True}
+    if role == "secondary":
+        # Secondary = derivative (offset / resync from primary). Text came
+        # from primary (already validated); timing is shifted/warped, CPS
+        # may spike in a few places where primary's silences collapse.
+        flags.update(skip_text_check=True, skip_time_check=True, skip_cps_check=True)
+        return flags
+    if role == "primary" and mode == "en-srt":
+        # En-srt primary: transcript-only content is legitimately dropped
+        # by Opus (no EN counterpart), so text preservation is replaced by
+        # a block-count sanity against the EN SRT.
+        flags["skip_text_check"] = True
+        en_srt = srt_path.parent.parent / "source" / "en.srt"
+        if en_srt.is_file():
+            flags["en_srt_path"] = str(en_srt)
+            flags["compare_block_count"] = True
+        return flags
+    # Primary + whisper mode: only duration-skip (matches pipeline).
+    return flags
 
 
 def validate(


### PR DESCRIPTION
## Problem

The `sync-subtitles` PR check failed on #467 (salvaged en-srt build): `sync_pr` Step B validates every changed `uk.srt` with the **strict** text-preservation check, but en-srt-mode builds legitimately drop transcript-only blocks (closing signatures, stage directions). The pipeline and golden tests already handle this by reading `final/build_manifest.yaml` and applying mode-appropriate `--skip-*` flags — `sync_pr` didn't.

## Fix

- Move the golden tests' `_mode_flags` helper into `tools.validate_subtitles.manifest_validate_flags` (single source of truth)
- `sync_pr` Step B now merges those manifest flags into its validate call (en-srt primary → skip text check + block-count sanity vs `source/en.srt`; secondary → derivative flags; no manifest → strict as before)
- `tests/test_golden_talks.py` imports the shared helper instead of duplicating it

## Verification

- TDD: new integration test in `test_sync_pr.py` reproduces the #467 failure (new en-srt `uk.srt`, transcript pre-existing on main) — fails on main, passes with fix
- 614 passed (non-SPA suite) + golden fixture + sync_pr suites green
- `GOLDEN_TALKS_SCOPE=all` failure set unchanged vs main

Unblocks #467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)