### PR TITLE
Add 1978-12-09 en.srt (Our Understanding of Sahaja Yoga)

### DIFF
--- a/talks/1978-12-09_Our-Understanding-of-Sahaja-Yoga-Seminar/Our-Understanding-of-SY/final/en.srt
+++ b/talks/1978-12-09_Our-Understanding-of-Sahaja-Yoga-Seminar/Our-Understanding-of-SY/final/en.srt
@@ -1,0 +1,5056 @@
+1
+00:00:04,597 --> 00:00:08,530
+Today if you ask me one or two questions it would be better
+
+2
+00:00:08,610 --> 00:00:12,476
+and I will give you the answers because this is between us
+
+3
+00:00:12,556 --> 00:00:17,356
+– those who have had the experience and those who are practically there,
+
+4
+00:00:17,436 --> 00:00:20,436
+and there are very few new people here I see.
+
+5
+00:00:20,516 --> 00:00:25,329
+But those who are at least acquainted with the vibrations and all that,
+
+6
+00:00:25,409 --> 00:00:28,746
+should ask me questions to begin with,
+
+7
+00:00:28,826 --> 00:00:36,260
+because then otherwise I will be tackling new persons later on. Hmm.
+
+8
+00:00:36,340 --> 00:00:42,520
+Yogi: Mother you said in Caxton Hall that if a person doesn’t speak to
+
+9
+00:00:42,600 --> 00:00:49,831
+their mother for a long time…can you elaborate on that theme again please.
+
+10
+00:00:49,911 --> 00:00:55,660
+Shri Mataji: You see, you are born from a mother, alright?
+
+11
+00:00:55,740 --> 00:01:03,614
+You are not born hanging from a tree, and neither you are thrown
+
+12
+00:01:03,694 --> 00:01:07,960
+from the heavens and suddenly you are found, born on this Earth.
+
+13
+00:01:08,040 --> 00:01:10,901
+You are born from a mother in her womb.
+
+14
+00:01:10,981 --> 00:01:15,825
+Her blood flows into you for nine months. You live upon her.
+
+15
+00:01:15,905 --> 00:01:19,571
+You are a part and parcel of her being for nine months,
+
+16
+00:01:19,651 --> 00:01:22,717
+which is the most important time of your life.
+
+17
+00:01:23,920 --> 00:01:28,504
+Now, she is there to give you, first, the sense of security.
+
+18
+00:01:29,904 --> 00:01:32,637
+In a mother’s womb a child feels secured.
+
+19
+00:01:33,104 --> 00:01:36,637
+If the mother is upset it has an effect on the child.
+
+20
+00:01:36,717 --> 00:01:41,450
+If there’s something wrong with her then that is affected on the child,
+
+21
+00:01:41,530 --> 00:01:43,870
+in the sense, physically, also.
+
+22
+00:01:44,670 --> 00:01:50,640
+It’s such a deep relationship exists between you and your mother that
+
+23
+00:01:50,720 --> 00:01:55,320
+I’ll have to write a book to tell you how much it is deep within you.
+
+24
+00:01:55,400 --> 00:01:56,829
+But, within us,
+
+25
+00:01:56,909 --> 00:02:03,710
+the power of Kundalini is the power of a Mother and not of a Father.
+
+26
+00:02:03,790 --> 00:02:08,520
+The Father is the Witness as a Spirit and the Mother is the Kundalini,
+
+27
+00:02:08,600 --> 00:02:10,580
+and the Kundalini has to rise.
+
+28
+00:02:10,660 --> 00:02:17,408
+Now it is the Mother in you that is the Kundalini and your own mother.
+
+29
+00:02:17,488 --> 00:02:22,621
+It very much depends what kind of relationship you have with your own mother.
+
+30
+00:02:22,701 --> 00:02:26,301
+Supposing you do not know how to love your own mother,
+
+31
+00:02:26,381 --> 00:02:30,115
+you can never love your mother country,
+
+32
+00:02:30,195 --> 00:02:34,400
+you can never love it.
+
+33
+00:02:34,480 --> 00:02:36,035
+That is the beginning.
+
+34
+00:02:36,115 --> 00:02:39,660
+The training starts there only, with your mother.
+
+35
+00:02:39,740 --> 00:02:45,688
+If that point is lacking then you cannot have a full blooming of that love.
+
+36
+00:02:45,768 --> 00:02:49,901
+Now maybe the mother has not been a very good mother possibly.
+
+37
+00:02:49,981 --> 00:02:55,861
+There are according to Sanskrit words, as I told you,
+
+38
+00:02:55,941 --> 00:03:01,220
+there cannot be a bad mother – kumata – but sometimes she could be bad also.
+
+39
+00:03:02,000 --> 00:03:07,640
+So the idea of a ‘bad mother’ is more brought forth by
+
+40
+00:03:07,720 --> 00:03:13,620
+the intervention of law into mother child relationship.
+
+41
+00:03:13,700 --> 00:03:18,270
+When the mother is being punished by
+
+42
+00:03:18,350 --> 00:03:22,651
+law for correcting her child or doing
+
+43
+00:03:22,731 --> 00:03:27,761
+something, the artificiality starts; when people can sue their mothers.
+
+44
+00:03:27,841 --> 00:03:33,190
+The responsibility of the law is not
+
+45
+00:03:33,270 --> 00:03:36,571
+to disturb the natural relationships.
+
+46
+00:03:36,651 --> 00:03:41,651
+If they start disturbing the natural relationship the artificiality starts.
+
+47
+00:03:41,731 --> 00:03:42,731
+And that’s why,
+
+48
+00:03:42,811 --> 00:03:49,395
+in the countries where law has taken charge of children and such things,
+
+49
+00:03:50,655 --> 00:03:56,255
+without understanding the basic thing that it is a natural thing to love your child.
+
+50
+00:03:56,805 --> 00:04:01,645
+Instead of that, if they had encouraged mothers who were more loving,
+
+51
+00:04:01,725 --> 00:04:05,005
+more kind, if they had even training to mothers,
+
+52
+00:04:05,085 --> 00:04:07,151
+how to be more kind and gentle,
+
+53
+00:04:07,231 --> 00:04:12,055
+if they had given more impetus
+
+54
+00:04:12,135 --> 00:04:16,480
+to people to be good mothers.
+
+55
+00:04:16,560 --> 00:04:21,160
+Instead of having beauty contests if they had ‘good mother contests’.
+
+56
+00:04:21,240 --> 00:04:29,310
+If motherhood had been upheld by political and economic institutions,
+
+57
+00:04:29,390 --> 00:04:32,780
+then it would have been much better.
+
+58
+00:04:33,620 --> 00:04:39,440
+But the whole society is turning to self-destruction, so the law, first, takes over.
+
+59
+00:04:39,564 --> 00:04:42,030
+So the child is quite sure of itself.
+
+60
+00:04:42,110 --> 00:04:45,056
+Now an eighteen year old boy in the family,
+
+61
+00:04:45,136 --> 00:04:50,362
+who gets the dole (unemployment payments), then he thinks no end of himself.
+
+62
+00:04:50,442 --> 00:04:55,388
+He answers back his mother; he talks in a very rude manner to the mother.
+
+63
+00:04:55,468 --> 00:05:01,068
+It’s alright to say you have done it for an eighteen year old boy but you don’t know
+
+64
+00:05:01,148 --> 00:05:06,614
+that [maybe] he is the eldest boy; the other children in the family follow him up.
+
+65
+00:05:06,694 --> 00:05:09,960
+So they pick it up when they are even very young.
+
+66
+00:05:10,040 --> 00:05:14,706
+The idea of giving money to boys at that age also is extremely harmful
+
+67
+00:05:14,786 --> 00:05:19,452
+because when he gets the money the other children think they must also
+
+68
+00:05:19,532 --> 00:05:24,492
+get some money, so they start charging mother for the work that they are
+
+69
+00:05:24,572 --> 00:05:29,252
+doing – you must pay 5p for bringing a glass of water for the mother.
+
+70
+00:05:29,332 --> 00:05:32,865
+Then the mothers now are of a different type. I mean,
+
+71
+00:05:32,945 --> 00:05:35,545
+there are so many mothers who say that,
+
+72
+00:05:35,625 --> 00:05:40,358
+“It is not a thing that we should love our children; it’s not natural”!
+
+73
+00:05:40,438 --> 00:05:42,638
+Artificial has become natural and
+
+74
+00:05:42,718 --> 00:05:44,718
+natural has become artificial.
+
+75
+00:05:44,798 --> 00:05:49,664
+How is it, within these [last] ten or fifteen years, suddenly the mothers
+
+76
+00:05:49,744 --> 00:05:53,424
+have become so funny? Now, because of these pressures,
+
+77
+00:05:53,504 --> 00:05:57,540
+what happens is that we develop a feeling against our mother.
+
+78
+00:05:57,620 --> 00:06:00,220
+We start judging our mother and father.
+
+79
+00:06:00,300 --> 00:06:02,100
+We should never judge them.
+
+80
+00:06:02,180 --> 00:06:05,713
+We are not to judge them because we have chosen them.
+
+81
+00:06:05,793 --> 00:06:09,071
+They are there just as part and parcel of ourselves.
+
+82
+00:06:09,151 --> 00:06:12,930
+Supposing your nose is broken: Do you start judging yourself,
+
+83
+00:06:13,010 --> 00:06:15,610
+“My nose is broken, my nose is broken”?
+
+84
+00:06:15,690 --> 00:06:17,350
+Do you discard your nose?
+
+85
+00:06:17,430 --> 00:06:19,710
+In the same way your parents are.
+
+86
+00:06:19,790 --> 00:06:21,923
+You cannot discard your parents!
+
+87
+00:06:22,003 --> 00:06:24,869
+But the whole society is working like this.
+
+88
+00:06:24,949 --> 00:06:26,415
+It’s a vicious circle.
+
+89
+00:06:26,495 --> 00:06:30,895
+Now, if I say, “You go and talk to your mother,” then you can say,
+
+90
+00:06:30,975 --> 00:06:33,108
+“My mother is not a good person.
+
+91
+00:06:33,188 --> 00:06:36,734
+She is this and that.” Then I have to say, “Alright,
+
+92
+00:06:36,814 --> 00:06:39,880
+then you forgive her.” Then you don’t like it.
+
+93
+00:06:39,960 --> 00:06:42,760
+You would expect me to tell you, “Alright,
+
+94
+00:06:42,840 --> 00:06:48,173
+just go and bash her.” You would be pleased if I tell you like that, some of you
+
+95
+00:06:48,253 --> 00:06:52,266
+would – “Go and beat her up!” But I would not say like that
+
+96
+00:06:52,346 --> 00:06:56,546
+because that’s not the way Sahaja Yogis are going to work away.
+
+97
+00:06:56,626 --> 00:07:01,492
+You must know that the whole society is in a whirlwind, it’s a whirlwind,
+
+98
+00:07:01,572 --> 00:07:06,385
+so somebody has to steady oneself and stop and try to change the winds.
+
+99
+00:07:06,465 --> 00:07:10,478
+And that’s why a Sahaja Yogi has to stand up and understand
+
+100
+00:07:10,558 --> 00:07:13,958
+that respect and reverence of parents is important.
+
+101
+00:07:14,038 --> 00:07:18,384
+But it is an actual thing, because if you are not good with your
+
+102
+00:07:18,464 --> 00:07:22,864
+mother your left side is weak; you have seen it on the vibrations.
+
+103
+00:07:22,944 --> 00:07:26,210
+Whatever I say you can see it on your vibrations.
+
+104
+00:07:26,290 --> 00:07:28,903
+You will be the loser, so forgive her.
+
+105
+00:07:28,983 --> 00:07:31,249
+Know that she has given you birth.
+
+106
+00:07:31,329 --> 00:07:36,942
+Maybe if she has been harsh to you, angry with you or done something – forgive her.
+
+107
+00:07:37,022 --> 00:07:42,515
+And you will be amazed, you can win her over, it’s not difficult because by your
+
+108
+00:07:42,595 --> 00:07:47,728
+goodness to her, by your over-goodness towards her, relatively, it will work.
+
+109
+00:07:47,808 --> 00:07:52,008
+And maybe, exceptionally, one person may be this thing (kumata)
+
+110
+00:07:52,088 --> 00:07:56,421
+but you cannot make a rule out of that; exceptionally one may be.
+
+111
+00:07:56,501 --> 00:08:02,101
+But if you have to change the society, the whole thinking, somebody has to stand up.
+
+112
+00:08:03,242 --> 00:08:08,255
+And it is a chakra within you, you know, where it touches a point of Void,
+
+113
+00:08:08,335 --> 00:08:11,499
+where the left-side touches the point of Void.
+
+114
+00:08:11,579 --> 00:08:16,525
+That is a centre, a very important centre for a mother, which [it] makes.
+
+115
+00:08:16,605 --> 00:08:20,500
+And do you know it is very near the centre of existence,
+
+116
+00:08:20,580 --> 00:08:23,260
+because your existence depends on that.
+
+117
+00:08:24,188 --> 00:08:29,721
+Supposing a child had no mother: he can never be a good husband, very difficult for
+
+118
+00:08:29,801 --> 00:08:33,201
+him to be a good husband because all the womanhood,
+
+119
+00:08:33,281 --> 00:08:35,414
+all the kindness, the sublimity,
+
+120
+00:08:35,494 --> 00:08:37,027
+the greatness of women,
+
+121
+00:08:37,107 --> 00:08:41,387
+is known through your mother to begin with; or a woman who does
+
+122
+00:08:41,467 --> 00:08:46,933
+not have a mother, can never be a good wife or could not be a good mother herself.
+
+123
+00:08:47,013 --> 00:08:52,479
+All these things are there so we have to stop it and change it. This is the point.
+
+124
+00:08:52,559 --> 00:08:56,492
+Sahaja Yogis must know that we have to change and transform
+
+125
+00:08:56,572 --> 00:09:00,172
+ourselves and that is the point [where] they feel bad.
+
+126
+00:09:00,252 --> 00:09:05,585
+We are not only responsible for our change but we have to bring about the change
+
+127
+00:09:05,665 --> 00:09:09,678
+in the whole world, where the society is getting destroyed,
+
+128
+00:09:09,758 --> 00:09:13,958
+the human beings are getting destroyed, so we have to stand up.
+
+129
+00:09:14,038 --> 00:09:16,771
+So we have to change our way of thinking.
+
+130
+00:09:18,050 --> 00:09:20,650
+What’s wrong in talking to your mother?
+
+131
+00:09:20,730 --> 00:09:23,863
+She’s not going to kill you if you talk to her.
+
+132
+00:09:23,947 --> 00:09:25,680
+Why don’t you talk to her?
+
+133
+00:09:25,760 --> 00:09:28,893
+Because you hate her, you want her to feel bad.
+
+134
+00:09:32,227 --> 00:09:34,960
+I mean, you don’t go and hit your mother.
+
+135
+00:09:35,040 --> 00:09:39,706
+This is the only way you can really be harsh to her, is not to talk to
+
+136
+00:09:39,786 --> 00:09:45,525
+her – [so] she feels rejected by her own child whom she has created.
+
+137
+00:09:45,605 --> 00:09:49,338
+God must be feeling that way also the way we reject Him.
+
+138
+00:09:57,465 --> 00:09:59,878
+Everybody’s left side improves now.
+
+139
+00:09:59,958 --> 00:10:04,824
+But try to love and you will enjoy, because loving is the greatest thing.
+
+140
+00:10:04,904 --> 00:10:09,104
+To love someone is adoration, absolute adoration, is reverence.
+
+141
+00:10:09,184 --> 00:10:12,784
+If you love someone then you know that it is so great,
+
+142
+00:10:12,864 --> 00:10:15,397
+it makes you so great to love someone.
+
+143
+00:10:17,722 --> 00:10:22,855
+It’s a very great feeling that, “I love someone”; it’s like a Lord one feels,
+
+144
+00:10:22,935 --> 00:10:24,601
+“Oh I love this one and I
+
+145
+00:10:24,681 --> 00:10:26,281
+love so many and so many
+
+146
+00:10:26,361 --> 00:10:29,441
+are there!” And that person need not love me,
+
+147
+00:10:29,521 --> 00:10:34,854
+I mean I don’t think all the Sahaja Yogis love me so much as I love them, maybe.
+
+148
+00:10:34,934 --> 00:10:38,534
+But I’m very proud of my Sahaja Yogis and I love them.
+
+149
+00:10:38,648 --> 00:10:43,728
+This is the most joy-giving thing is to love, yourself. To be able to love,
+
+150
+00:10:43,808 --> 00:10:48,501
+that’s the greatest ability a person should have – is to love others.
+
+151
+00:10:48,581 --> 00:10:51,047
+And in love, forgiveness is the most;
+
+152
+00:10:51,127 --> 00:10:54,993
+that’s why Christ said forgiveness is the greatest weapon.
+
+153
+00:10:55,073 --> 00:10:57,673
+And what do you achieve by not talking?
+
+154
+00:10:57,753 --> 00:10:59,779
+I mean, what do you achieve?
+
+155
+00:10:59,859 --> 00:11:05,059
+Let us see the other side of it; what do we achieve by not talking to someone?
+
+156
+00:11:11,357 --> 00:11:15,970
+Rationally. It’s a sweet method of course, if sometimes children do,
+
+157
+00:11:16,050 --> 00:11:18,383
+“I am not talking to you,” you see.
+
+158
+00:11:18,463 --> 00:11:21,329
+Then you can have a little play about that.
+
+159
+00:11:21,409 --> 00:11:23,342
+But it should be just a play.
+
+160
+00:11:23,422 --> 00:11:26,022
+If it is a serious stuff it’s nonsense.
+
+161
+00:11:26,102 --> 00:11:30,635
+It’s just to play about, is very good that, “I’m not talking to you,
+
+162
+00:11:30,715 --> 00:11:36,394
+I’m not going to talk to you for some time,” he knows that.
+
+163
+00:11:36,474 --> 00:11:38,274
+But then it is not serious,
+
+164
+00:11:39,628 --> 00:11:43,894
+it is just to bring out certain points and it’s nice that mother
+
+165
+00:11:43,974 --> 00:11:46,840
+should come and cuddle you and persuade you
+
+166
+00:11:46,920 --> 00:11:52,790
+and try to help you – that’s a good thing.
+
+167
+00:11:52,870 --> 00:11:59,020
+But the way we are serious
+
+168
+00:11:59,100 --> 00:12:06,088
+about it is something wrong. Yogi:
+
+169
+00:12:06,168 --> 00:12:07,501
+Can you tell us what
+
+170
+00:12:17,004 --> 00:12:18,270
+the vibrations are?
+
+171
+00:12:27,920 --> 00:12:33,220
+Shri Mataji: Vibrations, as I said, that is the manifestation of the Spirit.
+
+172
+00:12:33,300 --> 00:12:36,261
+But it is a very vague way of expressing it.
+
+173
+00:12:36,341 --> 00:12:44,121
+Now see, if there’s a nice flame before me, this candle has been enlightened.
+
+174
+00:12:44,201 --> 00:12:45,534
+Now what does it do?
+
+175
+00:12:47,294 --> 00:12:54,440
+It gives you light. Alright, but how does it give you light?
+
+176
+00:12:54,520 --> 00:12:58,020
+By throwing light towards you, by emitting light.
+
+177
+00:12:58,100 --> 00:13:02,683
+It is the emitting, of pulsation from the Self.
+
+178
+00:13:05,753 --> 00:13:07,566
+This light, this is light.
+
+179
+00:13:07,646 --> 00:13:10,312
+Actually there is sound, there is light;
+
+180
+00:13:10,392 --> 00:13:13,592
+very high frequency sound – very high frequency.
+
+181
+00:13:13,672 --> 00:13:16,538
+Actually many types of sounds are mixed in.
+
+182
+00:13:16,618 --> 00:13:19,951
+There’s is magnetism in this, in these vibrations.
+
+183
+00:13:20,031 --> 00:13:23,431
+It has all the five elements -the subtle of all the
+
+184
+00:13:23,511 --> 00:13:27,177
+five elements (tanmatras) inside these vibrations only.
+
+185
+00:13:27,257 --> 00:13:32,790
+They are talking, they are telling you, they are guiding you, they are helping you.
+
+186
+00:13:32,870 --> 00:13:36,070
+It’s because the Spirit is working through them.
+
+187
+00:13:36,150 --> 00:13:40,616
+Like this light that you take in your hand: you go in the darkness,
+
+188
+00:13:40,696 --> 00:13:45,896
+and you see that there is an impediment in between [and] you have to cross it.
+
+189
+00:13:45,976 --> 00:13:49,907
+So you get the idea with this light.
+
+190
+00:13:49,987 --> 00:13:52,120
+The light is doing that for you.
+
+191
+00:13:52,200 --> 00:13:58,980
+So, when the Spirit pulsates in your conscious mind,
+
+192
+00:13:59,060 --> 00:14:03,230
+in your conscious mind, then it is a Self-realised personality.
+
+193
+00:14:03,310 --> 00:14:07,380
+But in the unconscious it is there, all the time working.
+
+194
+00:14:07,460 --> 00:14:10,281
+Actually the Spirit Itself comes out.
+
+195
+00:14:10,361 --> 00:14:15,520
+It’s as big as your thumb is.
+
+196
+00:14:15,600 --> 00:14:21,860
+But you can contain your thumb in your heart.
+
+197
+00:14:21,940 --> 00:14:28,650
+That is the reflection of the God Almighty within us,
+
+198
+00:14:29,380 --> 00:14:37,540
+because heart receives that image within itself,
+
+199
+00:14:37,620 --> 00:14:42,295
+it is pulsating and is emitting the
+
+200
+00:14:42,375 --> 00:14:49,180
+Knowledge through our unconscious.
+
+201
+00:14:53,720 --> 00:14:57,186
+Spirit is an unconscious being till we are realised.
+
+202
+00:14:57,860 --> 00:15:02,550
+Once we are realised it becomes conscious,
+
+203
+00:15:02,630 --> 00:15:06,480
+it starts emitting itself and pulsating.
+
+204
+00:15:07,220 --> 00:15:08,880
+And what is Spirit?
+
+205
+00:15:09,800 --> 00:15:15,199
+Is God Almighty Himself, in a miniature form, which is reflected within us.
+
+206
+00:15:15,319 --> 00:15:20,580
+The more we clean our heart, which represents all the seven chakras within us.
+
+207
+00:15:20,660 --> 00:15:23,260
+There are seven auras around our heart.
+
+208
+00:15:23,340 --> 00:15:28,340
+All the seven chakras which are here in the Sahasrara, the seats are there,
+
+209
+00:15:28,420 --> 00:15:33,390
+and all the seven chakras that are there, within us, have seven auras
+
+210
+00:15:33,470 --> 00:15:40,810
+around our heart and when all of them are clear-cut, absolutely clear, pure,
+
+211
+00:15:40,890 --> 00:15:46,860
+integrated then the complete emission starts,
+
+212
+00:15:46,940 --> 00:15:48,790
+of those vibrations.
+
+213
+00:15:53,494 --> 00:15:58,528
+They are much more than I can explain because, say, the other day,
+
+214
+00:15:58,608 --> 00:16:04,088
+a lady was writing a letter to me and she was saying that, “Mother I am so sorry.
+
+215
+00:16:04,168 --> 00:16:07,834
+I have my accommodation problem is at the climax…” and,
+
+216
+00:16:07,914 --> 00:16:10,047
+very frustrating letter you see,
+
+217
+00:16:10,127 --> 00:16:14,260
+to begin with and absolutely as if she was going to be doomed,
+
+218
+00:16:14,340 --> 00:16:16,140
+the way she was writing it!
+
+219
+00:16:16,220 --> 00:16:19,153
+And, I mean, such a trivial thing like that,
+
+220
+00:16:19,233 --> 00:16:23,433
+but she was very concerned because she didn’t know where to go.
+
+221
+00:16:23,513 --> 00:16:26,379
+And first half of the letter was like that.
+
+222
+00:16:26,459 --> 00:16:31,659
+Second half was this that, “Mother, just now I have received a letter from the
+
+223
+00:16:31,739 --> 00:16:36,301
+authorities that they have allotted me a very beautiful place” in such and such
+
+224
+00:16:36,381 --> 00:16:40,539
+place!! (laughing) Now, I would say this is all vibrations because it is
+
+225
+00:16:40,619 --> 00:16:45,412
+All-pervading now, and you become one with the All-pervading Power so how it helps!
+
+226
+00:16:45,492 --> 00:16:49,881
+Because when she was writing to me, the vibrations were feeling it, what she
+
+227
+00:16:49,961 --> 00:16:54,350
+was writing from the paper, so they communicated to the All-pervading Power.
+
+228
+00:16:54,430 --> 00:16:57,086
+And as the Angels, or you can say the Deities,
+
+229
+00:16:57,166 --> 00:16:59,418
+also, can understand and they must have
+
+230
+00:16:59,498 --> 00:17:02,443
+thought, “Why bother Mother with all this nonsense,
+
+231
+00:17:02,523 --> 00:17:04,659
+better give her the letter as soon as
+
+232
+00:17:04,739 --> 00:17:08,146
+possible, finish it off!” So in the second letter she says,
+
+233
+00:17:08,226 --> 00:17:10,226
+“I’m such a fool to write this
+
+234
+00:17:10,306 --> 00:17:13,306
+but I must write to you to give you the night
+
+235
+00:17:13,386 --> 00:17:16,319
+and the day of my life.” So she wrote to me.
+
+236
+00:17:16,399 --> 00:17:19,132
+So, it can work out that way, that quick.
+
+237
+00:17:19,212 --> 00:17:24,478
+So the vibrations are actually the things which are the doers and the enjoyers.
+
+238
+00:17:24,558 --> 00:17:26,824
+They are the one, who enjoy, also,
+
+239
+00:17:26,904 --> 00:17:30,304
+if they find a very good Self-realised soul coming.
+
+240
+00:17:30,384 --> 00:17:34,984
+Then you just feel the Self-realised soul and you say, “Oh very good.
+
+241
+00:17:35,064 --> 00:17:39,344
+Come along, come along. Just have it” Everybody starts enjoying
+
+242
+00:17:39,424 --> 00:17:42,170
+that joy that’s coming from that person.
+
+243
+00:17:42,250 --> 00:17:43,863
+And that is what it is,
+
+244
+00:17:43,943 --> 00:17:49,224
+that you start enjoying that beauty in that person through the vibrations.
+
+245
+00:17:49,304 --> 00:17:53,237
+It’s a multi-dimensional thing – though it looks so simple,
+
+246
+00:17:53,317 --> 00:17:56,317
+that you are feeling in the hand, that’s all.
+
+247
+00:17:56,397 --> 00:18:00,530
+So it is a multi-dimensional thing just like the God Almighty.
+
+248
+00:18:00,610 --> 00:18:04,410
+And, for your information, it is only He does everything.
+
+249
+00:18:04,490 --> 00:18:07,356
+So only the vibrations work out everything.
+
+250
+00:18:07,436 --> 00:18:10,636
+We really do not do anything whatsoever – [if we
+
+251
+00:18:10,716 --> 00:18:13,916
+think we do] we are living in a fool’s paradise!
+
+252
+00:18:17,519 --> 00:18:18,399
+For example,
+
+253
+00:18:18,479 --> 00:18:24,078
+a tree dies and you chain it over and make a nice seat for me to sit down – so what?
+
+254
+00:18:24,158 --> 00:18:28,824
+Tree is dead and you make a seat and you say, “Oh, we have built this,
+
+255
+00:18:28,904 --> 00:18:31,997
+we have done that!” Nothing! What do you do?
+
+256
+00:18:32,077 --> 00:18:35,690
+Can you sprout even a small, little seed? You cannot.
+
+257
+00:18:40,417 --> 00:18:45,350
+But these vibrations only, which connect you with the All-pervading Power,
+
+258
+00:18:45,430 --> 00:18:48,630
+which are part of the All-pervading power, these
+
+259
+00:18:48,710 --> 00:18:52,923
+pervading Almighty’s eyes, you can say – they are the ones who
+
+260
+00:18:53,003 --> 00:18:56,936
+look after each and every minute thing in this whole world.
+
+261
+00:18:57,016 --> 00:19:00,235
+Can you think of such a multi-dimensional thing?
+
+262
+00:19:02,896 --> 00:19:06,096
+Now you have seen how vibrations work on people,
+
+263
+00:19:06,176 --> 00:19:08,789
+how they dissolve even the thick bones
+
+264
+00:19:08,869 --> 00:19:14,469
+and how they bring out the Kundalini here and how you see the softness on your head.
+
+265
+00:19:14,549 --> 00:19:19,080
+Just you cannot explain how, because they only do everything.
+
+266
+00:19:19,160 --> 00:19:25,391
+They have the universal communication centres and they have universal
+
+267
+00:19:25,471 --> 00:19:29,951
+broadcasting stations, they have universal TV centres there.
+
+268
+00:19:30,031 --> 00:19:31,364
+Everything is there.
+
+269
+00:19:33,221 --> 00:19:37,421
+In short, you just copy them a little bit and you think you are
+
+270
+00:19:37,501 --> 00:19:41,501
+doing something but you really don’t do anything whatsoever.
+
+271
+00:19:43,680 --> 00:19:48,280
+That’s why it is said that Brahma – this is the expression of Brahma,
+
+272
+00:19:48,360 --> 00:19:53,506
+these vibrations are the Brahma – is the only Truth, the rest is all avidya,
+
+273
+00:19:53,586 --> 00:19:56,079
+is all a maya, is just an illusion.
+
+274
+00:19:56,159 --> 00:19:58,099
+We live in illusions you see.
+
+275
+00:20:00,834 --> 00:20:05,500
+He is the Enjoyer, He is the Doer, you are just in between to see Him.
+
+276
+00:20:05,580 --> 00:20:09,380
+It would be like this mic (microphone) thinking that he’s
+
+277
+00:20:09,460 --> 00:20:13,393
+giving the lecture of Sahaja Yoga – it’s really like that!!
+
+278
+00:20:21,799 --> 00:20:28,255
+So to explain what is vibrations may
+
+279
+00:20:28,335 --> 00:20:32,127
+not be so simple in all its details.
+
+280
+00:20:32,207 --> 00:20:35,940
+But the overall idea I have given to you. Is it alright?
+
+281
+00:20:36,020 --> 00:20:42,426
+Rustom: Mother, I wanted to ask what is the function for the
+
+282
+00:20:42,506 --> 00:20:47,172
+Left-Swadishthana in all of us because it’s been catching all weekend.
+
+283
+00:20:47,252 --> 00:20:49,118
+Shri Mataji: You all had it?
+
+284
+00:20:50,949 --> 00:20:53,295
+Alright. I’ll ask ?? and then this.
+
+285
+00:20:54,481 --> 00:20:57,494
+What’s that? Who asked me there? New person:
+
+286
+00:20:57,574 --> 00:21:02,707
+You were talking about the mother and child’s relationship with their parents
+
+287
+00:21:02,787 --> 00:21:05,720
+and you said that maybe you don’t like them,
+
+288
+00:21:05,800 --> 00:21:08,466
+but that’s too bad, we have chosen them.
+
+289
+00:21:08,546 --> 00:21:10,412
+Would you elaborate on that?
+
+290
+00:21:10,520 --> 00:21:13,392
+Shri Mataji: We have chosen our parents.
+
+291
+00:21:13,472 --> 00:21:15,405
+Oh we have definitely chosen.
+
+292
+00:21:15,485 --> 00:21:18,818
+I mean, most of you have, because mediocre people,
+
+293
+00:21:18,898 --> 00:21:23,378
+those who are absolutely mediocre, just like very primitive souls.
+
+294
+00:21:23,458 --> 00:21:27,738
+We should not say, ‘primitive people’ but we can say ‘primitive
+
+295
+00:21:27,818 --> 00:21:31,284
+souls’ because there’s a difference between the two.
+
+296
+00:21:31,364 --> 00:21:34,310
+A person may be, say the king you had here,
+
+297
+00:21:34,390 --> 00:21:38,190
+who killed his seven wives, he was a very primitive soul.
+
+298
+00:21:38,270 --> 00:21:41,736
+He might be a king but he was a very primitive soul.
+
+299
+00:21:41,816 --> 00:21:43,349
+So the primitive souls,
+
+300
+00:21:43,429 --> 00:21:48,629
+they are not so particular as to who is their father or mother, and they also,
+
+301
+00:21:48,709 --> 00:21:53,909
+sometimes, choose horribly primitive people as their parents, also, sometimes.
+
+302
+00:21:53,989 --> 00:21:57,170
+So both the extremes choose – those who are very
+
+303
+00:21:57,250 --> 00:22:00,983
+primitive and those who are very advanced always choose.
+
+304
+00:22:01,063 --> 00:22:05,609
+And you being the seekers, you have also chosen your parents before
+
+305
+00:22:05,689 --> 00:22:09,889
+taking your birth, definitely, through the All-pervading Power.
+
+306
+00:22:12,897 --> 00:22:17,809
+So many of you have had parents because
+
+307
+00:22:17,889 --> 00:22:20,702
+of your previous relationships with them.
+
+308
+00:22:20,782 --> 00:22:25,312
+You might have seen that if we attach to some people like a mother,
+
+309
+00:22:25,392 --> 00:22:30,525
+sometimes like a father, in this lifetime also you might be feeling that way.
+
+310
+00:22:30,605 --> 00:22:33,138
+Because in India also the situation is
+
+311
+00:22:33,218 --> 00:22:35,751
+a little funny but still in India it’s
+
+312
+00:22:35,831 --> 00:22:40,697
+very common that you start feeling for somebody as if she is your mother.
+
+313
+00:22:41,787 --> 00:22:47,253
+Yesterday I saw that Starkey of your BBC1 feeling for a lady, something like that.
+
+314
+00:22:47,333 --> 00:22:51,493
+So imagine that Starkey, such a starkingly (sic) dry person,
+
+315
+00:22:51,573 --> 00:22:54,506
+having that kind of feeling for an old lady!
+
+316
+00:22:54,586 --> 00:22:58,719
+So the reason is that he might have been connected with her in
+
+317
+00:22:58,799 --> 00:23:03,123
+his previous lives and might have been his own mother, like that.
+
+318
+00:23:03,203 --> 00:23:08,269
+So maybe you might have felt about someone like that in previous lives that,
+
+319
+00:23:08,349 --> 00:23:10,815
+“Oh, I wish she was my mother.” Maybe
+
+320
+00:23:10,895 --> 00:23:14,441
+she was the mother of your friend or someone and you
+
+321
+00:23:14,521 --> 00:23:18,254
+thought that she was a very good mother, so you have it.
+
+322
+00:23:18,334 --> 00:23:20,334
+You want that mother? Alright?
+
+323
+00:23:20,414 --> 00:23:23,547
+Now when you see her you get frightened of her.
+
+324
+00:23:23,627 --> 00:23:27,960
+So you will not ask that type, now you will ask for another type.
+
+325
+00:23:28,040 --> 00:23:30,506
+So you have to go through many types,
+
+326
+00:23:30,586 --> 00:23:35,690
+but better do one completely so that you don’t have to come back to the same.
+
+327
+00:23:35,770 --> 00:23:39,903
+So better know about one completely by loving that person then
+
+328
+00:23:39,983 --> 00:23:43,849
+you are finished with one type; you get another type then.
+
+329
+00:23:43,929 --> 00:23:47,075
+So coming to his problem of Swadishthan, Left.
+
+330
+00:23:48,995 --> 00:23:51,255
+Are you all having catching here?
+
+331
+00:23:51,335 --> 00:23:56,900
+(Yogis/new people respond. Barely audible)
+
+332
+00:23:56,980 --> 00:24:10,830
+Shri Mataji: I am
+
+333
+00:24:10,910 --> 00:24:14,650
+happy
+
+334
+00:24:18,600 --> 00:24:22,610
+you could
+
+335
+00:24:29,005 --> 00:24:34,200
+see all that.
+
+336
+00:24:36,839 --> 00:24:42,305
+Actually, Gregoire told me that, “Mother, if you come from the very first day then
+
+337
+00:24:42,385 --> 00:24:47,918
+the attention will be on you and then we want to talk among ourselves about things.
+
+338
+00:24:47,998 --> 00:24:50,264
+And there are some people who have
+
+339
+00:24:50,344 --> 00:24:52,477
+not known much about Sahaja Yoga
+
+340
+00:24:52,557 --> 00:24:56,823
+and we would like to discuss.” I said, “Good idea, you go ahead.
+
+341
+00:24:56,903 --> 00:25:00,036
+I think it’s a good idea and you should do it.”
+
+342
+00:25:00,116 --> 00:25:03,849
+Gregoire: No, not exactly that Mother, this I can’t say!
+
+343
+00:25:03,929 --> 00:25:09,395
+Shri Mataji: But what I’m trying to say is that your intentions were good that you
+
+344
+00:25:09,475 --> 00:25:14,941
+were going to see for yourself, meet everyone and all of you suggested that to me.
+
+345
+00:25:15,021 --> 00:25:20,154
+I mean, everybody said that, “We would like to discuss among ourselves.” Now.
+
+346
+00:25:20,234 --> 00:25:22,967
+So there are children of different types.
+
+347
+00:25:23,047 --> 00:25:28,180
+You said, “Let’s see now what happens.” But it’s a good idea, very good idea,
+
+348
+00:25:28,260 --> 00:25:31,193
+because I would like you to mature like this
+
+349
+00:25:31,273 --> 00:25:36,006
+and to understand, because this is a very good thing that has happened.
+
+350
+00:25:36,086 --> 00:25:38,752
+Now, I will say why it is good? Alright?
+
+351
+00:25:38,832 --> 00:25:42,498
+Because, supposing you are all the time under my saree,
+
+352
+00:25:42,578 --> 00:25:47,111
+hidden down here, you are never going to face these horrible things.
+
+353
+00:25:47,191 --> 00:25:52,124
+And some of you, even today, do not believe that there are [dead] spirits.
+
+354
+00:25:52,204 --> 00:25:55,198
+It’s better to face it. Better to face it.
+
+355
+00:25:55,278 --> 00:26:00,811
+Now, there are also people who get possessed, also there, and they know what it is.
+
+356
+00:26:00,891 --> 00:26:04,110
+But those who were never possessed do not believe in it.
+
+357
+00:26:04,190 --> 00:26:07,390
+Actually they do believe because I am saying it,
+
+358
+00:26:07,470 --> 00:26:11,670
+but actually inside they do not believe that there are spirits.
+
+359
+00:26:11,750 --> 00:26:16,016
+So it was nice to face them here, first of all, alright to know.
+
+360
+00:26:16,096 --> 00:26:20,362
+Then secondly you are not to remain all the time under my saree.
+
+361
+00:26:20,442 --> 00:26:23,442
+This is called as palla in Sanskrit language.
+
+362
+00:26:23,522 --> 00:26:25,055
+So you have to face it.
+
+363
+00:26:25,135 --> 00:26:30,468
+And it’s a very nice thing that has happened that you have been able to face it.
+
+364
+00:26:30,548 --> 00:26:32,014
+Now you are over that.
+
+365
+00:26:32,094 --> 00:26:36,654
+Now, any place you go to, all the devils will run away from there!
+
+366
+00:26:36,734 --> 00:26:41,814
+Not only that but nobody of this kind would be going to those places again.
+
+367
+00:26:43,934 --> 00:26:50,408
+So, that’s a very
+
+368
+00:26:50,488 --> 00:26:55,255
+good thing
+
+369
+00:26:55,335 --> 00:27:00,731
+that has happened
+
+370
+00:27:00,811 --> 00:27:05,411
+and that you have taken it up upon yourselves. It’s a very big thing.
+
+371
+00:27:05,491 --> 00:27:08,024
+I liked it. I really liked this thing,
+
+372
+00:27:08,104 --> 00:27:13,170
+that you wanted to take it up and come down here and that you could feel it.
+
+373
+00:27:13,250 --> 00:27:16,331
+Now, I would say that none of you are harmed;
+
+374
+00:27:16,411 --> 00:27:20,630
+none of you is harmed actually; none of you.
+
+375
+00:27:20,710 --> 00:27:25,610
+Only thing you felt that, because you are in collective consciousness.
+
+376
+00:27:25,690 --> 00:27:29,675
+You must feel the aim of your life, you must know.
+
+377
+00:27:29,755 --> 00:27:32,821
+And also Left Swadishthana is caught by people
+
+378
+00:27:32,901 --> 00:27:37,054
+who indulge in unauthorised ways of God.
+
+379
+00:27:37,134 --> 00:27:42,614
+And so you recognise that, all of them who have been here have been unauthorised.
+
+380
+00:27:42,694 --> 00:27:44,774
+Without any argument you know.
+
+381
+00:27:44,854 --> 00:27:49,187
+So, that’s a training, and which you understand it, first of all.
+
+382
+00:27:49,267 --> 00:27:51,867
+Secondly none of you are caught up now.
+
+383
+00:27:51,947 --> 00:27:57,280
+Just if you see, none of you have got anything of Swadishthana left (remaining).
+
+384
+00:27:57,360 --> 00:28:08,800
+You never catch actually.
+
+385
+00:28:08,880 --> 00:28:14,430
+After all, you are the instrument so you are the indicator. You just indicate.
+
+386
+00:28:15,141 --> 00:28:18,541
+If you could just learn how to be a witness to that
+
+387
+00:28:18,621 --> 00:28:21,821
+indication you will never feel [that] you catch.
+
+388
+00:28:28,045 --> 00:28:32,311
+Now, what you have felt catching is the Left Vishuddhi actually:
+
+389
+00:28:32,391 --> 00:28:38,141
+is that you are feeling guilty about it, that, “Why were we panicked?” (laughing)
+
+390
+00:28:38,221 --> 00:28:42,771
+So if you say one thing, the other thing comes up.
+
+391
+00:28:42,851 --> 00:28:46,517
+“What was there to be panicked?” (laughing) So the Left
+
+392
+00:28:46,597 --> 00:28:49,730
+Vishuddhi is catching and showing. See the joy!
+
+393
+00:28:49,810 --> 00:28:52,410
+Sahaja Yoga is such a joker I tell you.
+
+394
+00:28:52,490 --> 00:28:56,836
+Yogini: We thought – why were we here – last night! Shri Mataji:
+
+395
+00:28:56,916 --> 00:28:59,382
+You must have been blaming the place.
+
+396
+00:28:59,462 --> 00:29:03,928
+You must have been saying that, “Oh, Why did we come to this place?
+
+397
+00:29:04,008 --> 00:29:07,808
+We could have gone to some other place and worked it out.
+
+398
+00:29:07,888 --> 00:29:12,221
+All these people have been here!” No, you have to work very hard.
+
+399
+00:29:12,301 --> 00:29:15,701
+You have to go to much worse places than these are.
+
+400
+00:29:15,781 --> 00:29:19,206
+You are soldiers and soldiers have to be on the battlefield.
+
+401
+00:29:19,286 --> 00:29:21,619
+Yogi: We won a few battles I think.
+
+402
+00:29:21,699 --> 00:29:24,299
+Shri Mataji: You have! You have won it!
+
+403
+00:29:24,379 --> 00:29:29,045
+But you are not enjoying the victory because you are involved into it.
+
+404
+00:29:29,125 --> 00:29:31,391
+Once you know, “Yes we had to win.
+
+405
+00:29:31,471 --> 00:29:33,804
+We have won it,” then you enjoy it.
+
+406
+00:29:33,884 --> 00:29:38,884
+But on the contrary now you are feeling, “Why did we panic?” So this is it.
+
+407
+00:29:38,964 --> 00:29:40,030
+You never catch.
+
+408
+00:29:40,110 --> 00:29:45,376
+But the more you start thinking that, “We are catching,” then you really catch!
+
+409
+00:29:45,456 --> 00:29:49,460
+You are the Eternal Being.
+
+410
+00:29:49,540 --> 00:29:52,671
+You are the one which cannot catch anything.
+
+411
+00:29:52,751 --> 00:29:56,351
+You are the one which cannot be destroyed by anything.
+
+412
+00:29:56,431 --> 00:30:02,867
+You are that, so how can you be caught up?
+
+413
+00:30:02,947 --> 00:30:05,547
+Only change your attitude about things,
+
+414
+00:30:05,627 --> 00:30:09,107
+and then you will know that you have not caught up.
+
+415
+00:30:09,187 --> 00:30:12,720
+It’s all a drama: Mother not coming in the beginning,
+
+416
+00:30:12,800 --> 00:30:16,085
+when she’s coming, it’s all a drama, nicely done.
+
+417
+00:30:16,165 --> 00:30:20,523
+I was very happy and I was happy also that Gregoire suggested it.
+
+418
+00:30:20,603 --> 00:30:23,754
+Though I don’t know if he suggested it with the
+
+419
+00:30:23,834 --> 00:30:27,200
+idea of becoming a big soldier but he did become!
+
+420
+00:30:27,280 --> 00:30:29,590
+His idea was good, very good idea.
+
+421
+00:30:29,670 --> 00:30:33,136
+And it was not [only] his but everybody was feeling,
+
+422
+00:30:33,216 --> 00:30:37,580
+I could read your mind that you all wanted to go beforehand and talk to
+
+423
+00:30:37,660 --> 00:30:41,006
+the new people and tell them about it and give them a little
+
+424
+00:30:41,086 --> 00:30:45,021
+lecture about it because they have not known much about Sahaj Yog.
+
+425
+00:30:45,101 --> 00:30:49,034
+They have been much more with the others and some have come
+
+426
+00:30:49,114 --> 00:30:52,847
+for the first time – for them it is all Greek and Latin!
+
+427
+00:30:52,927 --> 00:30:54,393
+So it was a good idea.
+
+428
+00:30:54,473 --> 00:30:59,339
+It was a very good thing and this is very much related to what I am going
+
+429
+00:30:59,419 --> 00:31:01,885
+to say to you today. So now an I say?
+
+430
+00:31:01,965 --> 00:31:03,698
+Oh this question, alright.
+
+431
+00:31:03,778 --> 00:31:05,844
+Is that a question (you want to
+
+432
+00:31:05,924 --> 00:31:07,990
+ask) or taking out your badhas?
+
+433
+00:31:08,070 --> 00:31:11,474
+Shri Mataji: No you are alright.
+
+434
+00:31:11,554 --> 00:31:14,220
+That’s why you were responsible I think,
+
+435
+00:31:14,300 --> 00:31:20,107
+so you were taking the responsibility too much and that’s why you were heated up.
+
+436
+00:31:20,187 --> 00:31:22,140
+Now you are cool. Alright?
+
+437
+00:31:22,220 --> 00:31:24,740
+You are not responsible for anything.
+
+438
+00:31:24,820 --> 00:31:30,492
+Yogi: At the last meeting at Caxton Hall a person I worked on someone and he
+
+439
+00:31:30,572 --> 00:31:35,718
+was taking lots of drugs and this person kept recognising various people.
+
+440
+00:31:35,798 --> 00:31:39,278
+He would say, “Oh yes I’ve seen that person before,
+
+441
+00:31:39,358 --> 00:31:43,171
+Oh yes, I’ve seen that person before.” Now, do you think
+
+442
+00:31:43,251 --> 00:31:46,864
+it’s because the person had been taking lots of drugs
+
+443
+00:31:46,944 --> 00:31:50,624
+that they were going into the collective subconscious?
+
+444
+00:31:50,704 --> 00:31:52,384
+Shri Mataji: No, no, no.
+
+445
+00:31:52,464 --> 00:31:55,344
+You see, he’s a drug man you can’t bother.
+
+446
+00:31:55,424 --> 00:32:00,090
+I have seen some people who were drunk, quite funny they are, you see,
+
+447
+00:32:00,170 --> 00:32:04,850
+somebody came to our house and they were given drinks, and he came to
+
+448
+00:32:04,930 --> 00:32:10,396
+me and he said, “Oh you must meet Dr. Gan!” I said, “Alright,” then again he said,
+
+449
+00:32:10,476 --> 00:32:14,076
+“You must meet Dr. Gan!” Again he said the same thing.
+
+450
+00:32:14,156 --> 00:32:16,307
+I said, “Why is he saying?” So, I couldn’t understand.
+
+451
+00:32:16,387 --> 00:32:20,587
+Then my husband told me something he’s heard from someone that,
+
+452
+00:32:20,667 --> 00:32:25,333
+“You have to meet Dr. Gan,” so he’s telling you all the time the same.
+
+453
+00:32:25,413 --> 00:32:28,746
+So you see these drunk or drug people are diseased
+
+454
+00:32:28,826 --> 00:32:31,959
+– you are not to bother as to what he’s saying.
+
+455
+00:32:32,039 --> 00:32:35,372
+There’s nothing, no truth in it, what he’s saying.
+
+456
+00:32:35,452 --> 00:32:40,452
+If he says, “I recognise you,” it’s just maybe another trick of the bhoots.
+
+457
+00:32:40,532 --> 00:32:43,103
+I don’t know, it’s nothing important.
+
+458
+00:32:43,183 --> 00:32:46,396
+They can do anything and they can say anything.
+
+459
+00:32:46,476 --> 00:32:49,449
+They are not normal people. They are sick,
+
+460
+00:32:49,529 --> 00:32:56,887
+they are sick people – temporarily sick
+
+461
+00:32:56,967 --> 00:33:00,158
+– so you cannot just trust them.
+
+462
+00:33:00,238 --> 00:33:05,451
+And there is a big craze in the West to say, I have heard people saying that,
+
+463
+00:33:05,531 --> 00:33:07,931
+“I was in Egypt,” (in another life).
+
+464
+00:33:08,011 --> 00:33:11,744
+I said, “How do you know?” “Because such and such person
+
+465
+00:33:11,824 --> 00:33:15,090
+told me I was in Egypt.” I said, “What difference
+
+466
+00:33:15,170 --> 00:33:18,703
+does it make whether you were in Egypt or you were in
+
+467
+00:33:18,783 --> 00:33:22,516
+India or whatever?” Whatever you are today is the point!
+
+468
+00:33:22,596 --> 00:33:26,529
+So they are paying money for that, to know what they were!!
+
+469
+00:33:26,609 --> 00:33:29,675
+That is also there, it’s a big craze going on.
+
+470
+00:33:29,755 --> 00:33:34,555
+But that’s not [the point that] you have to find out what you have been.
+
+471
+00:33:34,635 --> 00:33:37,701
+I mean, how do you explain it, why people ask?
+
+472
+00:33:37,781 --> 00:33:40,514
+I don’t know how to answer this question.
+
+473
+00:33:40,594 --> 00:33:45,460
+I don’t understand, why should you ask anyone, “Where was I?” Then people
+
+474
+00:33:45,540 --> 00:33:50,340
+make money on this kind of a nonsense if you have, “What was my previous
+
+475
+00:33:50,420 --> 00:33:55,553
+birth?” Then somebody was telling me, “I was a pig in my last life,” He said,
+
+476
+00:33:55,633 --> 00:33:59,979
+“Mother do you agree I was a pig?” (laughter) What should I say?
+
+477
+00:34:00,059 --> 00:34:05,525
+Because if I say, “yes,” she may not like it, if I say, “no,” she may not like it.
+
+478
+00:34:05,605 --> 00:34:07,835
+So I just avoided the question.
+
+479
+00:34:07,915 --> 00:34:10,248
+But some sort of a thing like that.
+
+480
+00:34:10,328 --> 00:34:15,461
+It’s very silly but human beings have funny ideas you know. Now, to be a pig!
+
+481
+00:34:15,541 --> 00:34:19,013
+I mean, I would hate to be a pig! And the stench!
+
+482
+00:34:19,093 --> 00:34:22,939
+But they wouldn’t mind calling themselves.
+
+483
+00:34:23,019 --> 00:34:28,239
+I mean they are so funny that they would not mind calling
+
+484
+00:34:28,319 --> 00:34:31,865
+themselves pigs when they are human beings you see!!
+
+485
+00:34:31,945 --> 00:34:34,442
+I mean, you don’t know what to say.
+
+486
+00:34:34,522 --> 00:34:36,188
+I mean this is how it is.
+
+487
+00:34:37,802 --> 00:34:41,202
+They are not to be taken seriously, very seriously.
+
+488
+00:34:41,282 --> 00:34:45,748
+But it’s surprising that people are taken very seriously sometimes.
+
+489
+00:34:45,828 --> 00:34:50,294
+We had a group of people coming to Gavin’s place and there was one,
+
+490
+00:34:50,374 --> 00:34:54,574
+a realised soul who had become a drug addict, I don’t know how.
+
+491
+00:34:54,654 --> 00:34:56,654
+He fell into very bad company.
+
+492
+00:34:56,734 --> 00:35:01,000
+And the another fellow, whom he had regarded as something great,
+
+493
+00:35:01,080 --> 00:35:04,213
+was really mad, absolutely mad! Isn’t it Gavin?
+
+494
+00:35:04,293 --> 00:35:09,293
+He was so mad [that] I don’t know how this mad man was accepted by all this
+
+495
+00:35:09,373 --> 00:35:11,039
+group as something great.
+
+496
+00:35:11,119 --> 00:35:16,764
+He said, “He’s beautiful Mother, you don’t know,
+
+497
+00:35:16,844 --> 00:35:23,250
+he’s beautiful,” I said,
+
+498
+00:35:23,330 --> 00:35:26,635
+“But which part of the thing is beautiful?
+
+499
+00:35:26,715 --> 00:35:33,396
+You just tell me.” He is irrelevantly talking,
+
+500
+00:35:33,476 --> 00:35:37,382
+has no sense, and nothing!
+
+501
+00:35:37,462 --> 00:35:40,530
+He’s mad, actual mad.
+
+502
+00:35:40,610 --> 00:35:48,288
+You can see, he went into [a] lunatic asylum. I said,
+
+503
+00:35:48,368 --> 00:35:55,195
+“I don’t understand the worshippers of lunacy.”
+
+504
+00:35:55,275 --> 00:36:00,058
+This is like worshipping lunacy.
+
+505
+00:36:00,138 --> 00:36:05,504
+You just cannot understand this also,
+
+506
+00:36:05,584 --> 00:36:08,634
+so you just can’t say.
+
+507
+00:36:08,714 --> 00:36:12,780
+Next time, when you come to any such programmes or any place,
+
+508
+00:36:12,860 --> 00:36:16,140
+now you ask me, “What should we do Mother with
+
+509
+00:36:16,220 --> 00:36:19,820
+all the mad people?” And I will tell you what is to be
+
+510
+00:36:19,900 --> 00:36:24,628
+done so that you will not have so much of mosquito drama.
+
+511
+00:36:24,708 --> 00:36:28,641
+It was just a mosquito drama but I’m happy you have handled
+
+512
+00:36:28,721 --> 00:36:32,900
+it very well and you have gone just there, where you were.
+
+513
+00:36:36,350 --> 00:36:42,601
+Now, today, I am going to tell you about Sahaja Yogi, as you are Sahaja Yogis now.
+
+514
+00:36:42,681 --> 00:36:45,980
+You are reborn and you are realised-souls.
+
+515
+00:36:46,720 --> 00:36:50,740
+And what we have to think about ourselves.
+
+516
+00:36:54,650 --> 00:36:56,716
+That is a very important thing.
+
+517
+00:36:57,890 --> 00:37:01,245
+After Sahaja Yoga, as you say that,
+
+518
+00:37:01,325 --> 00:37:07,251
+you have got realisation, you have powers also,
+
+519
+00:37:07,331 --> 00:37:12,731
+and lots of powers are there which you are not aware of, that powers we have got.
+
+520
+00:37:12,811 --> 00:37:14,011
+Now,
+
+521
+00:37:15,660 --> 00:37:21,820
+the first power you have got is to correct yourself without conditioning yourself.
+
+522
+00:37:22,740 --> 00:37:25,740
+Before this, if I said, “Don’t do this,
+
+523
+00:37:25,820 --> 00:37:32,550
+don’t do that!” or you did that way, you were conditioned.
+
+524
+00:37:32,630 --> 00:37:37,100
+Let’s see what is conditioning then you will understand it better.
+
+525
+00:37:37,180 --> 00:37:43,170
+Say, it is all darkness and I cannot see anything inside out,
+
+526
+00:37:44,558 --> 00:37:46,091
+I am just involved into
+
+527
+00:37:46,171 --> 00:37:50,945
+my own body and I want to treat myself,
+
+528
+00:37:51,025 --> 00:37:56,980
+then I put my instruments into wrong places.
+
+529
+00:37:57,060 --> 00:38:01,610
+And the more wrong I do the more I try to re-correct
+
+530
+00:38:01,690 --> 00:38:04,756
+it and it goes even worse and worse and worse.
+
+531
+00:38:05,500 --> 00:38:11,880
+But supposing there is all light, and in you is the doctor who comes out of you.
+
+532
+00:38:13,015 --> 00:38:17,081
+You get separated from that doctor completely and the doctor,
+
+533
+00:38:17,161 --> 00:38:21,360
+who is not involved into your pains and into your troubles.
+
+534
+00:38:21,440 --> 00:38:27,340
+Who can see through what’s wrong with you and he is the only well-wisher you have,
+
+535
+00:38:28,740 --> 00:38:31,561
+then the operation is perfect.
+
+536
+00:38:31,641 --> 00:38:36,520
+There is no conditioning because there is no wrong doing anywhere,
+
+537
+00:38:36,600 --> 00:38:41,160
+he knows what to open, what to close, where to put it right.
+
+538
+00:38:41,240 --> 00:38:45,205
+This doctor is the Witness in you, he’s your Spirit.
+
+539
+00:38:45,285 --> 00:38:49,685
+When you start seeing through that Doctor, everything – you do not
+
+540
+00:38:49,765 --> 00:38:52,831
+feel bad about it. Just now, as you said that,
+
+541
+00:38:52,911 --> 00:38:57,457
+we are catching on the Left Swadishthan, it means a terrible thing.
+
+542
+00:38:58,097 --> 00:39:02,510
+It means that you are practising something which is unauthorised.
+
+543
+00:39:04,400 --> 00:39:06,333
+That means it is blasphemous.
+
+544
+00:39:07,180 --> 00:39:09,380
+You are doing something anti-God.
+
+545
+00:39:09,460 --> 00:39:12,940
+Taking the responsibility upon yourself to do that.
+
+546
+00:39:13,020 --> 00:39:18,020
+But you don’t feel bad about it because you are separated from yourself and
+
+547
+00:39:18,100 --> 00:39:20,766
+you see that, “If I am catching on this,
+
+548
+00:39:20,846 --> 00:39:22,979
+that means there is an effect of
+
+549
+00:39:23,059 --> 00:39:28,681
+something on me by which this part of the centre is suffering and I must correct
+
+550
+00:39:28,761 --> 00:39:33,980
+it.” And you start correcting it because you feel the pain within yourself.
+
+551
+00:39:35,760 --> 00:39:40,480
+Supposing your Agnya is catching here: means you are egoistical,
+
+552
+00:39:41,240 --> 00:39:47,639
+you are dominating, you are non-forgiving, you are like a Hitler.
+
+553
+00:39:49,570 --> 00:39:54,570
+But you don’t feel bad, once your Agnya is catching, it’s paining, you say,
+
+554
+00:39:54,650 --> 00:39:57,250
+“Take it out Mother my ego is colossal.
+
+555
+00:39:57,330 --> 00:40:00,250
+Take it out!” You don’t mind saying that.
+
+556
+00:40:00,330 --> 00:40:06,850
+If somebody had told this to Napoleon that, “You are egoistical,” he
+
+557
+00:40:06,930 --> 00:40:12,530
+would have killed him. If he had told this to Hitler he would have finished him off.
+
+558
+00:40:12,610 --> 00:40:15,071
+He carried on with all his vices,
+
+559
+00:40:15,151 --> 00:40:20,611
+all his self-destroying things with great pride but a Sahaja Yogi cannot.
+
+560
+00:40:20,691 --> 00:40:26,711
+So he has much more chances and much,
+
+561
+00:40:26,791 --> 00:40:31,910
+much instruments to clear himself and to make himself alright,
+
+562
+00:40:31,990 --> 00:40:35,670
+to change himself, without feeling hurt about it,
+
+563
+00:40:35,750 --> 00:40:40,255
+because he’s no more identified with his vices.
+
+564
+00:40:40,335 --> 00:40:45,895
+He’s not identified with his ego so he does not mind correcting himself, his ego.
+
+565
+00:40:45,975 --> 00:40:49,521
+He can do that very easily without conditioning him.
+
+566
+00:40:49,601 --> 00:40:54,947
+You see, about religions, the greatest objection was that it conditions people,
+
+567
+00:40:55,027 --> 00:40:58,960
+so they started the other side of it to decondition people.
+
+568
+00:40:59,040 --> 00:41:03,440
+So the permissiveness and licentiousness, the other side, started.
+
+569
+00:41:03,520 --> 00:41:06,920
+One was conditioning, the other was deconditioning.
+
+570
+00:41:07,000 --> 00:41:13,540
+But if you cannot be conditioned what is the question of deconditioning?
+
+571
+00:41:13,620 --> 00:41:18,060
+So, for a Sahaja Yogi, there is the power given,
+
+572
+00:41:18,140 --> 00:41:24,040
+of loving himself, that he corrects himself, in True Love.
+
+573
+00:41:24,587 --> 00:41:29,520
+I don’t know how much, really, we know how much we have to love ourselves.
+
+574
+00:41:29,600 --> 00:41:37,290
+If you truly love yourself, truly love yourself, then you would like
+
+575
+00:41:37,370 --> 00:41:42,850
+to do something of which you are really proud, within your heart.
+
+576
+00:41:42,930 --> 00:41:48,785
+Say, giving realisation to someone, is such a joy-giving thing within yourselves.
+
+577
+00:41:49,945 --> 00:41:51,745
+You feel so happy about it.
+
+578
+00:41:51,825 --> 00:41:56,291
+You may do hundreds of things in this world but you won’t feel that
+
+579
+00:41:56,371 --> 00:42:00,704
+way as you would feel when you have given realisation to someone.
+
+580
+00:42:03,260 --> 00:42:06,393
+Because it’s a living process which you can do.
+
+581
+00:42:07,200 --> 00:42:12,018
+But when you really understand yourself, the need of your Self,
+
+582
+00:42:12,098 --> 00:42:14,764
+then you really love yourself very well.
+
+583
+00:42:14,844 --> 00:42:18,910
+Otherwise you really do not know what to do to love yourself.
+
+584
+00:42:18,990 --> 00:42:24,390
+To love yourself means – you must know that this body of yours is a special body,
+
+585
+00:42:24,470 --> 00:42:30,640
+now, because it is emitting vibrations, it’s a temple of God so respect it.
+
+586
+00:42:32,720 --> 00:42:33,920
+Respect your body.
+
+587
+00:42:35,280 --> 00:42:37,460
+Don’t be vulgar about your body.
+
+588
+00:42:41,230 --> 00:42:45,421
+We really had, like Mary Magdalene somebody in India,
+
+589
+00:42:45,501 --> 00:42:50,525
+who came to us….(break
+
+590
+00:42:50,605 --> 00:42:54,850
+in recording)…
+
+591
+00:42:54,930 --> 00:43:00,975
+keep it clean, in the sense, yes I mean washing and this thing,
+
+592
+00:43:01,055 --> 00:43:03,933
+you know that’s not the point.
+
+593
+00:43:04,013 --> 00:43:07,260
+But even many people I have seen,
+
+594
+00:43:07,340 --> 00:43:14,980
+are not aware that we get uncleanliness from others, like shaking hands.
+
+595
+00:43:15,060 --> 00:43:20,680
+I mean, if there is someone, you have to shake hands, alright,
+
+596
+00:43:20,760 --> 00:43:23,093
+if you are that much developed that
+
+597
+00:43:23,173 --> 00:43:25,573
+you do not get unclean it’s alright.
+
+598
+00:43:25,653 --> 00:43:29,119
+But if you are not, be careful before shaking hands.
+
+599
+00:43:29,199 --> 00:43:31,545
+Better to say, “hello” and things.
+
+600
+00:43:31,625 --> 00:43:36,358
+You have to be a little particular about it because I have seen people,
+
+601
+00:43:36,438 --> 00:43:38,304
+when they shake their hands,
+
+602
+00:43:38,384 --> 00:43:43,650
+they do receive more bad vibrations than [they] give good vibrations to others.
+
+603
+00:43:43,730 --> 00:43:49,060
+Shaking hands or hugging others, or bringing your body to them only,
+
+604
+00:43:49,140 --> 00:43:54,273
+the vibrations, one has to be very careful as to [see that] you do not spoil.
+
+605
+00:43:55,490 --> 00:44:00,503
+Then this body is nurtured on food: so food also, is important that a food
+
+606
+00:44:00,583 --> 00:44:05,899
+that is cooked by a person who is loving, good, nice, is good for this body.
+
+607
+00:44:05,979 --> 00:44:09,620
+But if you eat a food cooked by a person who is, say,
+
+608
+00:44:09,700 --> 00:44:14,446
+a murderer (??) , immediately your body will revolt, your stomach will
+
+609
+00:44:14,526 --> 00:44:18,726
+revolt against it and that’s why, to keep your stomach alright,
+
+610
+00:44:18,806 --> 00:44:22,472
+try to avoid such places which give you bad vibrations.
+
+611
+00:44:22,552 --> 00:44:27,285
+Your digestion will be very bad if you go to places which are not good.
+
+612
+00:44:27,365 --> 00:44:31,031
+For example, going to Soho I always feel like vomiting!
+
+613
+00:44:31,111 --> 00:44:36,111
+Always, as soon as I go there I feel like vomiting, the whole of my stomach
+
+614
+00:44:36,191 --> 00:44:41,737
+and I must have vomited once or twice in that area, I’m sure about it. Maybe more.
+
+615
+00:44:41,817 --> 00:44:44,617
+But first I didn’t know it was so related,
+
+616
+00:44:44,697 --> 00:44:48,097
+I discovered that it was in Soho that this happens.
+
+617
+00:44:48,177 --> 00:44:54,001
+And this kind of a feeling comes up when you go to places like that.
+
+618
+00:44:54,081 --> 00:44:57,680
+So avoid all such places of vices and things.
+
+619
+00:44:59,014 --> 00:45:01,880
+Even if you see such pictures and all that.
+
+620
+00:45:01,960 --> 00:45:05,620
+Not that something goes that you are not above it –
+
+621
+00:45:05,700 --> 00:45:09,430
+you are – but I mean nobody likes filth, you know.
+
+622
+00:45:09,510 --> 00:45:13,176
+We are above everything but we cannot sit in the filth.
+
+623
+00:45:13,256 --> 00:45:14,989
+You are sensitive to this.
+
+624
+00:45:15,069 --> 00:45:19,415
+As animals are not sensitive to many filths that we have around,
+
+625
+00:45:19,495 --> 00:45:21,961
+but we are, in the same way you start
+
+626
+00:45:22,041 --> 00:45:25,321
+getting sensitive to the filth, the inner filth,
+
+627
+00:45:25,401 --> 00:45:29,134
+that subtler filth which we do not see, so you avoid it.
+
+628
+00:45:29,214 --> 00:45:32,280
+Try to avoid it and you will feel much better.
+
+629
+00:45:32,360 --> 00:45:36,026
+And you will yourself feel your priorities will change,
+
+630
+00:45:36,106 --> 00:45:39,906
+your friends will change, your everything will change and
+
+631
+00:45:39,986 --> 00:45:43,652
+automatically you will not like many things that people
+
+632
+00:45:43,732 --> 00:45:47,411
+are talking about and just your interest will go away.
+
+633
+00:45:47,491 --> 00:45:52,224
+For example, now I asked people just for one’s sake, “What about Jeremy
+
+634
+00:45:52,304 --> 00:45:56,931
+Thorpe?” ( A homosexual British Member of Parliament accused of murder) They
+
+635
+00:45:57,011 --> 00:46:01,296
+said, “Mother we are not reading that these days.” Normally some of you would
+
+636
+00:46:01,376 --> 00:46:05,383
+have known the whole case so well, even better than the pleader himself.
+
+637
+00:46:05,463 --> 00:46:08,802
+But they don’t read it now, just don’t read it. “It’s filth.
+
+638
+00:46:08,882 --> 00:46:10,941
+It’s horrid, horrid.” It’s like that.
+
+639
+00:46:11,021 --> 00:46:13,191
+Your tastes change, your styles change.
+
+640
+00:46:13,271 --> 00:46:16,332
+But allow it to grow and manifest itself and accept it.
+
+641
+00:46:16,412 --> 00:46:17,914
+Gradually it will work out.
+
+642
+00:46:17,994 --> 00:46:20,888
+If you press on it, say you are used to the smoking,
+
+643
+00:46:20,968 --> 00:46:23,584
+you will give up smoking, you will not like it.
+
+644
+00:46:23,664 --> 00:46:26,781
+First you will feel like vomiting about it and all that.
+
+645
+00:46:26,861 --> 00:46:31,369
+But still if you insist, “No, I must smoke, I must smoke,” then you can accept it
+
+646
+00:46:31,449 --> 00:46:35,901
+(the smoking) because then you are giving chance to your ego to accept yourself.
+
+647
+00:46:35,981 --> 00:46:38,597
+Now this is the part I’m saying about the body;
+
+648
+00:46:38,677 --> 00:46:42,740
+now you see all the angles of it – that how we affect our body very much.
+
+649
+00:46:42,820 --> 00:46:47,250
+Another thing is that, too much interest in food will go away, should go away.
+
+650
+00:46:47,330 --> 00:46:51,650
+You should not be too much interested in taste and food and this and that.
+
+651
+00:46:51,730 --> 00:46:53,331
+Also there are crazes about things:
+
+652
+00:46:53,411 --> 00:46:54,692
+the other day I met a lady,
+
+653
+00:46:54,772 --> 00:46:56,250
+she was very thin, I mean, and
+
+654
+00:46:56,330 --> 00:46:59,130
+absolutely I didn’t understand and I said,
+
+655
+00:46:59,210 --> 00:47:02,476
+“What’s the matter with you?” So she said, “Now I
+
+656
+00:47:02,556 --> 00:47:04,556
+eat all healthy food.” I said,
+
+657
+00:47:04,636 --> 00:47:08,969
+“How do you call it healthy?” She said, “There’s a ‘health store’
+
+658
+00:47:09,049 --> 00:47:11,982
+I go to and I waste my things from there and
+
+659
+00:47:12,062 --> 00:47:14,995
+only that thing I buy.” All this is a craze!
+
+660
+00:47:15,075 --> 00:47:20,075
+Spiritual health is very different from the so-called ‘vitaminised’ health.
+
+661
+00:47:20,155 --> 00:47:25,221
+You see, Spiritual health is the health you get from love, the food of love.
+
+662
+00:47:25,301 --> 00:47:29,160
+It’s different from food of so-called wrestlers bodies,
+
+663
+00:47:29,240 --> 00:47:32,511
+the kind of thing the wrestlers eat.
+
+664
+00:47:32,591 --> 00:47:38,191
+Food of love, we have to take it with love and give it with love and made with love,
+
+665
+00:47:38,271 --> 00:47:41,271
+that is the food is of the highest of all.
+
+666
+00:47:41,351 --> 00:47:43,544
+So, that’s the body part of it,
+
+667
+00:47:43,624 --> 00:47:47,624
+we can see how to look after the body is to not to think too
+
+668
+00:47:47,704 --> 00:47:49,970
+much about food and spontaneously,
+
+669
+00:47:50,050 --> 00:47:54,028
+if somebody gives you something with love, you just take it.
+
+670
+00:47:54,108 --> 00:47:55,832
+That’s how you should eat.
+
+671
+00:47:55,912 --> 00:47:59,758
+But if anybody gives you with hatred don’t take that food.
+
+672
+00:47:59,838 --> 00:48:04,230
+It’s better not to eat such a food than to eat a poisonous thing.
+
+673
+00:48:04,310 --> 00:48:06,443
+It’s poisonous for Sahaja Yogis.
+
+674
+00:48:07,461 --> 00:48:10,461
+Then another thing is to give to others also.
+
+675
+00:48:10,541 --> 00:48:13,821
+We have to be giving to others, food especially.
+
+676
+00:48:13,901 --> 00:48:18,047
+I don’t know how many of you bring chocolates for each other,
+
+677
+00:48:18,127 --> 00:48:21,860
+or something like this, or something nice that you find:
+
+678
+00:48:21,940 --> 00:48:24,540
+supposing you go somewhere and you find
+
+679
+00:48:24,620 --> 00:48:26,753
+some nice cherries or something,
+
+680
+00:48:26,833 --> 00:48:29,846
+then how many of you collect it and give it?
+
+681
+00:48:29,926 --> 00:48:34,192
+Do you bring them for Sahaja Yogis? “Alright let me take it for,
+
+682
+00:48:34,272 --> 00:48:39,872
+say in Sainsbury’s (shop), when I am there, let me take this money when I am there”.
+
+683
+00:48:39,952 --> 00:48:43,432
+This is how you are going to have the articulation,
+
+684
+00:48:43,512 --> 00:48:48,725
+means that you can articulate, you can communicate through this kind of love.
+
+685
+00:48:48,805 --> 00:48:51,005
+You see, a small thing like that,
+
+686
+00:48:51,085 --> 00:48:53,885
+you go somewhere, for Mother you do bring,
+
+687
+00:48:53,965 --> 00:48:59,578
+I know, but for each other, something small and to find out what does he like. Now,
+
+688
+00:48:59,658 --> 00:49:02,524
+I know Dinesh is uncomfortable because he’s
+
+689
+00:49:02,604 --> 00:49:04,841
+a tall fellow and I have been telling
+
+690
+00:49:04,921 --> 00:49:07,141
+him that you sit somewhere on a high thing,
+
+691
+00:49:07,221 --> 00:49:10,260
+because I’m feeling it, I can feel it within
+
+692
+00:49:10,340 --> 00:49:12,851
+myself because I love him and I can feel it
+
+693
+00:49:12,931 --> 00:49:15,384
+because I know tall people have a problem,
+
+694
+00:49:15,464 --> 00:49:17,858
+their height is too much and their centre
+
+695
+00:49:17,938 --> 00:49:20,449
+of gravity is all the time going like that.
+
+696
+00:49:20,529 --> 00:49:22,164
+There’s nothing wrong in it.
+
+697
+00:49:22,244 --> 00:49:24,930
+Anybody who should sit next to him should say,
+
+698
+00:49:25,010 --> 00:49:27,638
+“It’s alright, come along, sit down properly.
+
+699
+00:49:27,718 --> 00:49:30,171
+Come along, sit down properly.” It’s good.
+
+700
+00:49:30,251 --> 00:49:34,398
+And somebody who can sit on the ground should offer a seat saying that,
+
+701
+00:49:34,478 --> 00:49:38,040
+“Come along Dinesh, you can sit here.” It should be that way.
+
+702
+00:49:38,120 --> 00:49:40,573
+You see what I am trying to say [is] that:
+
+703
+00:49:40,653 --> 00:49:43,923
+let’s see small, small things that are needed by others.
+
+704
+00:49:44,003 --> 00:49:48,266
+It’s a very sweet way of living together is – let’s see what do you need.
+
+705
+00:49:48,346 --> 00:49:52,259
+I mean, you are going, say, to Germany now so I’ll be very happy if
+
+706
+00:49:52,339 --> 00:49:56,427
+you bring something for a friend of yours than for me – hundred times!
+
+707
+00:49:56,507 --> 00:49:59,076
+Because that is much more nourishing for me.
+
+708
+00:49:59,156 --> 00:50:00,908
+That’s my food, to think, “Oh,
+
+709
+00:50:00,988 --> 00:50:04,317
+my child has been so generous, and has been so generous.”
+
+710
+00:50:04,397 --> 00:50:08,719
+One day Gavin really gave me the very great happiness and I told him that.
+
+711
+00:50:08,799 --> 00:50:11,719
+You see, one day he invited me to his place and he
+
+712
+00:50:11,799 --> 00:50:14,719
+had lots of people that day and I was embarrassed.
+
+713
+00:50:14,799 --> 00:50:19,646
+I said, “Now Gavin has invited people for dinner but how can so many people be fed?
+
+714
+00:50:19,726 --> 00:50:21,478
+There are so many.” Of course,
+
+715
+00:50:21,558 --> 00:50:25,412
+I knew it would be sufficient but it was just a play I should say.
+
+716
+00:50:25,492 --> 00:50:29,288
+So I allowed about fifty percent of them to disappear and I said,
+
+717
+00:50:29,368 --> 00:50:34,215
+“Let’s have dinner now.” So then he gave us dinner but he was a little bit unhappy.
+
+718
+00:50:34,295 --> 00:50:38,967
+Next day he got up and he said, “Mother why did you ask half of them to go away?
+
+719
+00:50:39,047 --> 00:50:41,500
+And then why did you ask for food so late?
+
+720
+00:50:41,580 --> 00:50:46,019
+Because I had cooked for all of them.” And this was something so joy-giving.
+
+721
+00:50:46,099 --> 00:50:50,479
+I didn’t mind those twenty-five going away for this joy that I got, really.
+
+722
+00:50:50,559 --> 00:50:53,596
+Out of that same is that: how much we do for others?
+
+723
+00:50:53,676 --> 00:50:55,369
+Small, small things, you see.
+
+724
+00:50:55,449 --> 00:50:57,902
+And we should not be jealous in that part.
+
+725
+00:50:57,982 --> 00:51:01,350
+Like, supposing Mia does something for, say, our doctor,
+
+726
+00:51:01,430 --> 00:51:04,661
+then Lindsay should not be jealous of that, on the contrary
+
+727
+00:51:04,741 --> 00:51:07,160
+he should realise that it’s nice that he has done;
+
+728
+00:51:07,240 --> 00:51:11,440
+he should feel happy because doctor is also part of your being.
+
+729
+00:51:11,520 --> 00:51:14,091
+Actually as I feel happy, you should be happy.
+
+730
+00:51:14,171 --> 00:51:18,851
+From this you should know that, if it is done for others and if you see that,
+
+731
+00:51:18,931 --> 00:51:20,349
+it’s much more joy-giving than
+
+732
+00:51:20,429 --> 00:51:21,750
+if it is done for yourself.
+
+733
+00:51:21,830 --> 00:51:26,740
+I tell you it’s a headache, it’s a headache sometimes if something is done for you,
+
+734
+00:51:26,820 --> 00:51:30,900
+you get into a problem you see, “How am I to now pay it off?
+
+735
+00:51:30,980 --> 00:51:32,420
+Oh he’s done so nice now.
+
+736
+00:51:32,500 --> 00:51:35,580
+I must somehow or other try to pay it [back].
+
+737
+00:51:35,660 --> 00:51:40,340
+The same way as he is.” You feel that he has been so nice and so kind here and so
+
+738
+00:51:40,420 --> 00:51:41,805
+sweet and , “I am not that much,
+
+739
+00:51:41,885 --> 00:51:43,940
+I have never thought of these things how he is
+
+740
+00:51:44,020 --> 00:51:48,940
+capable of these things.” So, this idea can come because you have seen [that] you
+
+741
+00:51:49,020 --> 00:51:53,940
+go from one side to another, so as soon as these things happen, that will happen.
+
+742
+00:51:54,020 --> 00:51:55,781
+And also jealousies can come.
+
+743
+00:51:55,861 --> 00:51:57,683
+Both things should be avoided.
+
+744
+00:51:57,763 --> 00:52:00,678
+And should really enjoy to see a friend [happy].
+
+745
+00:52:00,758 --> 00:52:02,224
+Why we do it everyday?
+
+746
+00:52:02,304 --> 00:52:06,637
+You don’t know we do it everyday that way, in a very unknown way.
+
+747
+00:52:06,717 --> 00:52:11,583
+Supposing you read a nice story and what is the story you enjoy the best?
+
+748
+00:52:11,663 --> 00:52:17,196
+When you find two persons are loving each other without any selfishness. I mean why
+
+749
+00:52:17,276 --> 00:52:19,908
+do we enjoy? I mean, none of us are there.
+
+750
+00:52:19,988 --> 00:52:22,721
+The girl is not we and the boy is not we,
+
+751
+00:52:22,801 --> 00:52:24,027
+we are something different,
+
+752
+00:52:24,107 --> 00:52:25,521
+but we enjoy because we really
+
+753
+00:52:25,601 --> 00:52:29,067
+enjoy that, in the universal happiness that somebody
+
+754
+00:52:29,147 --> 00:52:32,401
+has done that for someone in that genuine way.
+
+755
+00:52:32,481 --> 00:52:37,147
+Those, I mean, the Indians who have been reading novels and things say
+
+756
+00:52:37,227 --> 00:52:39,427
+that there is a very great writer
+
+757
+00:52:39,507 --> 00:52:41,840
+that we have in our country – Sarat
+
+758
+00:52:41,920 --> 00:52:43,920
+Chandra – and if you ask them,
+
+759
+00:52:44,000 --> 00:52:46,466
+“Which is the story that you like the
+
+760
+00:52:46,546 --> 00:52:51,146
+best in that?” We’ll say, “There’s one ‘Ramer Sumati’,” is the story.
+
+761
+00:52:51,226 --> 00:52:54,586
+And in that story it’s the beauty of the artist,
+
+762
+00:52:54,666 --> 00:52:59,012
+of the writer is this way, is they show a sister-in-law an elder
+
+763
+00:52:59,092 --> 00:53:03,692
+sister-in-law having great love for the small, little brother-in-law,
+
+764
+00:53:03,772 --> 00:53:07,252
+a little one, who is a step-brother of her husband.
+
+765
+00:53:07,332 --> 00:53:12,465
+And this little brother-in-law first of all wants to find out about his would
+
+766
+00:53:12,545 --> 00:53:17,600
+be sister-in-law and goes and tells his brother that, “You see I must go and
+
+767
+00:53:17,680 --> 00:53:21,930
+see the girl first of all,” as in India it’s a custom that the elders go and
+
+768
+00:53:22,010 --> 00:53:26,149
+see the girl, “I must approve of the girl otherwise how can you marry her?
+
+769
+00:53:26,229 --> 00:53:30,256
+I must approve of the girl,” like a grandfather, you see, just all that.
+
+770
+00:53:30,336 --> 00:53:32,461
+Very sweetly built up the whole thing.
+
+771
+00:53:32,541 --> 00:53:36,903
+But it comes to the climax at a point where this lady has her mother there and
+
+772
+00:53:36,983 --> 00:53:41,569
+she’s a horrid thing and she hates this boy because the daughter loves that child.
+
+773
+00:53:41,649 --> 00:53:45,452
+And he’s just a little boy and he has the half property and all that
+
+774
+00:53:45,532 --> 00:53:49,111
+and he doesn’t understand, an eight year old simple boy you see.
+
+775
+00:53:49,191 --> 00:53:52,155
+So whatever he does she tries to find faults with it.
+
+776
+00:53:52,235 --> 00:53:56,765
+So he brings one tree of banyan, small, little tree he gets a shoot somewhere and
+
+777
+00:53:56,845 --> 00:54:01,487
+he brings it up in the centre of the house in the courtyard and he plants it there.
+
+778
+00:54:01,567 --> 00:54:04,475
+Of course it’s not going to live, it’s a dead stuff,
+
+779
+00:54:04,555 --> 00:54:07,888
+but like a child he brings it and plants it there.
+
+780
+00:54:07,968 --> 00:54:10,834
+So the climax is brought out by the artist,
+
+781
+00:54:10,914 --> 00:54:14,180
+I must say the way it’s brought out is beautiful.
+
+782
+00:54:14,260 --> 00:54:17,460
+So, when it is put there this old lady comes she
+
+783
+00:54:17,540 --> 00:54:20,873
+gets very angry and throws away all the thing out.
+
+784
+00:54:20,953 --> 00:54:25,953
+So the boy comes out in the morning time and he sees that the tree is gone,
+
+785
+00:54:26,033 --> 00:54:27,566
+now it’s no more there.
+
+786
+00:54:27,646 --> 00:54:31,430
+For him it’s something gone out of his life, he feels so unhappy.
+
+787
+00:54:31,510 --> 00:54:35,390
+So he goes to his sister-in-law and she’s standing before
+
+788
+00:54:35,470 --> 00:54:39,410
+him and he goes on the steps and he starts asking, “Why did you throw away?”
+
+789
+00:54:39,490 --> 00:54:42,150
+She says, “I did it,” because she didn’t want the mother to be there.
+
+790
+00:54:42,230 --> 00:54:43,629
+“Why did you do it? Why did you do
+
+791
+00:54:43,709 --> 00:54:47,650
+it?” You see, he starts breaking his head before here, showing all his
+
+792
+00:54:47,730 --> 00:54:49,210
+tortured being, that,
+
+793
+00:54:49,290 --> 00:54:50,611
+“Why did you do it?” So she just
+
+794
+00:54:50,691 --> 00:54:52,590
+takes him to her heart and she
+
+795
+00:54:52,670 --> 00:54:55,750
+says, “Do you know why I did it?” So he says,
+
+796
+00:54:55,830 --> 00:54:58,466
+“Why?” “Because if you put a Banyan tree in
+
+797
+00:54:58,546 --> 00:55:03,746
+the courtyard then the death of the elder sister-in-law takes place.” He said,
+
+798
+00:55:03,826 --> 00:55:07,359
+“Oh God! Really? Then have you thrown it permanently?
+
+799
+00:55:07,439 --> 00:55:11,825
+Throw it away in the river! I hope it will have no effect. Put something there.
+
+800
+00:55:11,905 --> 00:55:13,156
+Bring something just do something
+
+801
+00:55:13,236 --> 00:55:16,735
+that it is finished off.” You see, the whole thing is so beautifully brought in.
+
+802
+00:55:16,815 --> 00:55:21,495
+And the beauty of love between them we enjoy when we know what it is.
+
+803
+00:55:21,575 --> 00:55:26,069
+And that’s how we should look at things when anybody does for anything.
+
+804
+00:55:26,149 --> 00:55:28,255
+Where does the jealousy come in?
+
+805
+00:55:28,335 --> 00:55:31,281
+Just to kill our joy, just to kill our joy.
+
+806
+00:55:31,361 --> 00:55:35,641
+It is nice to to see this is done to others, so much beautiful.
+
+807
+00:55:35,721 --> 00:55:39,841
+That’s why the people who have been described in the novels may not have enjoyed
+
+808
+00:55:39,921 --> 00:55:45,387
+so much as we are enjoying them because we can see that much better and feel good.
+
+809
+00:55:45,467 --> 00:55:49,360
+But in every day to day life we do not do it, we do no do it.
+
+810
+00:55:49,440 --> 00:55:51,411
+For example, a step-mother-in-law,
+
+811
+00:55:51,491 --> 00:55:55,955
+if she’s horrid or step-mother she’s horrid, she’ll go and see a picture of a
+
+812
+00:55:56,035 --> 00:55:59,977
+step-mother and will weep there at the way the step-mother is stern,
+
+813
+00:56:00,057 --> 00:56:03,246
+and at home she will come and again beat her own child.
+
+814
+00:56:03,326 --> 00:56:04,891
+Human beings are like that.
+
+815
+00:56:04,971 --> 00:56:06,371
+So try to enjoy that.
+
+816
+00:56:06,451 --> 00:56:09,784
+You don’t know, human beings are very complicated.
+
+817
+00:56:09,864 --> 00:56:13,914
+If I see it I don’t understand, really, why they do it that way.
+
+818
+00:56:13,994 --> 00:56:15,907
+But when we can enjoy the novels,
+
+819
+00:56:15,987 --> 00:56:20,045
+why not the novel is just here between the friends, between all of us?
+
+820
+00:56:20,125 --> 00:56:22,792
+Let’s have a novel and a play among ourselves,
+
+821
+00:56:22,872 --> 00:56:25,857
+how we do beautiful things and how we try to love.
+
+822
+00:56:25,937 --> 00:56:30,203
+This is how we have to work out among ourselves by doing little,
+
+823
+00:56:30,283 --> 00:56:35,629
+little things here and there and that’s how we are going to beautify ourselves.
+
+824
+00:56:35,709 --> 00:56:40,736
+Now this joy-giving quality of enjoying others is present in you already,
+
+825
+00:56:40,816 --> 00:56:45,616
+is awakened now through Sahaja Yoga and trying to make your life joyous.
+
+826
+00:56:45,696 --> 00:56:48,829
+I have seen many Sahaja Yogis who say, “Mother,
+
+827
+00:56:48,909 --> 00:56:51,909
+we have got knowledge no doubt, our attention
+
+828
+00:56:51,989 --> 00:56:55,563
+is there, but what about the ananda, the joy?” I mean,
+
+829
+00:56:55,643 --> 00:56:58,239
+you are killing your joy every moment!
+
+830
+00:56:58,319 --> 00:57:03,199
+You are bent upon killing your joy every moment, what can I do about it?
+
+831
+00:57:03,279 --> 00:57:08,545
+Those who have been able to overcome that part, then there is more possibility.
+
+832
+00:57:08,625 --> 00:57:12,091
+On the other side of it, supposing somebody you see,
+
+833
+00:57:12,171 --> 00:57:15,917
+who is not doing the proper thing about Sahaj Yoga say,
+
+834
+00:57:15,997 --> 00:57:21,330
+somebody who has started drinking now, after Sahaja Yoga: Then you should go and
+
+835
+00:57:21,410 --> 00:57:22,876
+fight it out with him.
+
+836
+00:57:22,956 --> 00:57:28,022
+Sit down with him for day and night and fight it out with him and see to it.
+
+837
+00:57:28,102 --> 00:57:29,302
+You just say that,
+
+838
+00:57:29,382 --> 00:57:34,048
+“I’m going on a fast because you have taken to drinking.” Work it out!
+
+839
+00:57:34,128 --> 00:57:38,061
+Put all the pressures that are possible under your command.
+
+840
+00:57:38,141 --> 00:57:41,961
+Tell all the Sahaja Yogis, all of you work it out. You know,
+
+841
+00:57:42,041 --> 00:57:44,201
+I was very happy sometimes people told me, “Mother,
+
+842
+00:57:44,281 --> 00:57:48,907
+will you please put attention to such-and-such,” all of you put together, if
+
+843
+00:57:48,987 --> 00:57:53,667
+they say, then I say, “They are on right stages.” “We are all fasting
+
+844
+00:57:53,747 --> 00:57:56,013
+for such and such person,” “We are
+
+845
+00:57:56,093 --> 00:57:58,493
+doing this for such and such people.
+
+846
+00:57:58,573 --> 00:58:03,573
+We are working on such and such person.” And go and fight with that person,
+
+847
+00:58:03,653 --> 00:58:05,719
+tell him on his face and do it.
+
+848
+00:58:05,799 --> 00:58:07,399
+That something is great.
+
+849
+00:58:07,479 --> 00:58:09,879
+This is also another way of, really,
+
+850
+00:58:09,959 --> 00:58:13,572
+to communicate between yourselves, to think about the
+
+851
+00:58:13,652 --> 00:58:15,185
+emancipation of others,
+
+852
+00:58:15,265 --> 00:58:20,611
+about the awakening of others and to put them onto right stages. You will find,
+
+853
+00:58:20,691 --> 00:58:26,237
+all of you have some sort of a problem by which you do not open out to each other.
+
+854
+00:58:26,317 --> 00:58:29,183
+Open out to each other, talk to each other.
+
+855
+00:58:29,263 --> 00:58:32,263
+Openly discuss it. When you will go to India,
+
+856
+00:58:32,343 --> 00:58:37,809
+those who are coming, will see how these people are that way absolutely shameless!
+
+857
+00:58:37,889 --> 00:58:41,367
+They will say, “Come along, this is catching, take it out!
+
+858
+00:58:41,447 --> 00:58:43,208
+Beat me with shoes, do that.
+
+859
+00:58:43,288 --> 00:58:47,821
+Take my shoes and keep it with them and use that for taking it out.”
+
+860
+00:58:47,901 --> 00:58:50,634
+And they’ll say, “You beat me with shoes,
+
+861
+00:58:50,714 --> 00:58:52,608
+go on just beat me with shoes!
+
+862
+00:58:52,688 --> 00:58:56,248
+I am catching here, you go and beat me with shoes.”
+
+863
+00:58:56,328 --> 00:59:01,261
+Unless and until you get after your weaknesses you cannot get rid of them.
+
+864
+00:59:01,341 --> 00:59:04,541
+You should ask yourself, “Oh Mr., come along Mr.
+
+865
+00:59:04,621 --> 00:59:09,021
+Sahaja Yogi, now what is your name, this is your problem, alright?
+
+866
+00:59:09,101 --> 00:59:12,034
+So now let me take you to task!” See to your
+
+867
+00:59:12,114 --> 00:59:16,394
+weaknesses. See to your weaknesses and the strengths of others.
+
+868
+00:59:16,474 --> 00:59:20,754
+And build up your strength and ignore the weaknesses of others.
+
+869
+00:59:20,834 --> 00:59:25,434
+But, if it is destroying that person, then get together, many of you,
+
+870
+00:59:25,514 --> 00:59:29,394
+not one, many of you, and go to that person and save him.
+
+871
+00:59:29,474 --> 00:59:33,087
+This is how it is going to work out among yourselves.
+
+872
+00:59:33,167 --> 00:59:35,567
+Now the biggest problem of the West,
+
+873
+00:59:35,647 --> 00:59:37,713
+because now we are dealing with
+
+874
+00:59:37,793 --> 00:59:42,139
+the majority of the Western people, is E-G-O, absolutely simple.
+
+875
+00:59:42,219 --> 00:59:47,552
+It’s a very simple thing and I have given you the reason why there is so much of
+
+876
+00:59:47,632 --> 00:59:53,401
+ego and why we have been working through ego and how we have been depending on her.
+
+877
+00:59:53,481 --> 00:59:57,034
+Now this Mr. Ego is the one which gives you ideas.
+
+878
+00:59:57,114 --> 01:00:01,971
+It goes to such a limit of ideas giving that even people commit sin
+
+879
+01:00:02,051 --> 01:00:06,784
+because their ego is satisfied by saying, “What do I care for this God?
+
+880
+01:00:07,340 --> 01:00:11,061
+Who is He?” “What are these scriptures?
+
+881
+01:00:11,141 --> 01:00:17,141
+What do I care?” So this Mr. Ego can take human beings to any limit,
+
+882
+01:00:17,221 --> 01:00:23,005
+any limit of self-destruction and
+
+883
+01:00:23,085 --> 01:00:27,972
+one has to be careful about it.
+
+884
+01:00:28,052 --> 01:00:33,602
+This Mr. Ego only gives you a sense of jealousy, because it gets hurt immediately.
+
+885
+01:00:33,682 --> 01:00:37,482
+Now in this programme, if I do not take the names of two,
+
+886
+01:00:37,562 --> 01:00:40,895
+three people – immediately their ego will be hurt.
+
+887
+01:00:42,741 --> 01:00:48,421
+They will think, “Why didn’t you take my name?” And ego identifies with many things,
+
+888
+01:00:48,501 --> 01:00:52,701
+which is a very big problem also, which is such a subtle thing.
+
+889
+01:00:52,781 --> 01:00:59,315
+Now, for example, two friends are there, so they will always club together.
+
+890
+01:00:59,395 --> 01:01:03,261
+Then, if I say one thing to one friend he’ll say, “Mother,
+
+891
+01:01:03,341 --> 01:01:06,715
+why don’t you say to the other friend?” They will
+
+892
+01:01:06,795 --> 01:01:10,128
+say, “Why don’t you say this to other friend?” But
+
+893
+01:01:10,208 --> 01:01:13,808
+not to the whole congregation but to the other friend.
+
+894
+01:01:13,888 --> 01:01:16,754
+All the time that friend is pushed forward.
+
+895
+01:01:16,834 --> 01:01:21,634
+He says, “Why don’t you look after this friend of mine?” Or they’ll push
+
+896
+01:01:21,714 --> 01:01:26,447
+forward in everything, somebody whom they think must be pushed forward.
+
+897
+01:01:26,527 --> 01:01:30,260
+And this kind of identification in someone is ego’s job.
+
+898
+01:01:30,340 --> 01:01:32,606
+And that’s how it keeps you there.
+
+899
+01:01:32,686 --> 01:01:35,952
+It gives you identifications, this way, that way.
+
+900
+01:01:36,032 --> 01:01:38,578
+And you have to disentangle yourself.
+
+901
+01:01:38,658 --> 01:01:43,385
+Know, “As far as my growth is concerned, I’m alone. There I am alone.
+
+902
+01:01:43,465 --> 01:01:47,198
+As far as my own achievements are concerned, I am alone.
+
+903
+01:01:47,278 --> 01:01:49,780
+I am not identified with anyone.
+
+904
+01:01:49,860 --> 01:01:55,621
+I am identified with Truth.” But as far as the Sahaja Yoga and the whole thing,
+
+905
+01:01:55,701 --> 01:02:00,880
+is concerned then all of us must do it together that way.
+
+906
+01:02:00,960 --> 01:02:04,570
+We should all feel it, that way, together.
+
+907
+01:02:04,650 --> 01:02:07,450
+So there won’t be any problem when you all
+
+908
+01:02:07,530 --> 01:02:10,330
+live together but you will enjoy yourself.
+
+909
+01:02:10,410 --> 01:02:17,750
+Small things like saying, “Why don’t you come to my place?” Call them over.
+
+910
+01:02:17,830 --> 01:02:21,777
+Then you tell others like this. You are all saints.
+
+911
+01:02:22,880 --> 01:02:26,501
+A day will come when you will be respected much
+
+912
+01:02:26,581 --> 01:02:30,410
+more than all these kings and queens put together.
+
+913
+01:02:30,490 --> 01:02:35,090
+You are saints and you have to behave like saints towards each other,
+
+914
+01:02:35,170 --> 01:02:36,436
+you have to respect
+
+915
+01:02:37,310 --> 01:02:42,990
+because you are saints and that God is in you now emitting It’s light as vibrations.
+
+916
+01:02:43,070 --> 01:02:46,470
+Every Sahaja Yogi must respect another Sahaja Yogi.
+
+917
+01:02:49,917 --> 01:02:53,050
+And it is a simple thing which one should know.
+
+918
+01:02:53,130 --> 01:02:57,530
+But we do not know it so well because of the one problem – is ego.
+
+919
+01:02:57,610 --> 01:03:03,090
+But in India people understand it because the ego is not so much developed there,
+
+920
+01:03:03,170 --> 01:03:04,236
+that may be why.
+
+921
+01:03:04,316 --> 01:03:09,116
+I wrote to them about a lot of people might be wanting to come to India,
+
+922
+01:03:09,196 --> 01:03:12,589
+what about them? So everyone wrote to me, “Mother,
+
+923
+01:03:12,669 --> 01:03:18,269
+what a great pleasure that saints are coming to our country now. To our country they
+
+924
+01:03:18,349 --> 01:03:21,712
+are visiting. Oh we’ll be having a big festivity.
+
+925
+01:03:22,292 --> 01:03:27,310
+We are going to have a festival
+
+926
+01:03:27,390 --> 01:03:32,230
+of things.”
+
+927
+01:03:32,310 --> 01:03:36,441
+And they were
+
+928
+01:03:36,521 --> 01:03:40,296
+going to take a house in Bombay for 30,000 rupees for
+
+929
+01:03:40,376 --> 01:03:43,909
+a month for you people, because “it should be proper,
+
+930
+01:03:43,989 --> 01:03:47,655
+it should be comfortable.” I said, “Now, nothing doing!
+
+931
+01:03:47,735 --> 01:03:50,468
+There will be hardly twelve people coming
+
+932
+01:03:50,548 --> 01:03:53,548
+and you just don’t spend so much money.” They
+
+933
+01:03:53,628 --> 01:03:58,561
+would have given you a red carpet treatment and those who have been there,
+
+934
+01:03:58,641 --> 01:04:01,574
+you can ask them how they have treated them.
+
+935
+01:04:01,654 --> 01:04:05,120
+“Because the saints are coming and we must serve the
+
+936
+01:04:05,200 --> 01:04:08,266
+saints and they are saints and we must respect
+
+937
+01:04:08,346 --> 01:04:12,146
+them.” This is the idea they have there. In the same way,
+
+938
+01:04:12,226 --> 01:04:17,026
+you should know we have to respect each other because we are all saints.
+
+939
+01:04:17,106 --> 01:04:19,772
+We have entered into the Kingdom of God.
+
+940
+01:04:19,852 --> 01:04:24,185
+We have been blessed by Him and we have to understand that we are
+
+941
+01:04:24,265 --> 01:04:28,798
+all individually dear to God and He has bestowed upon us that Light.
+
+942
+01:04:28,878 --> 01:04:33,544
+If you do not respect each other properly Sahaja Yoga cannot work out.
+
+943
+01:04:33,624 --> 01:04:37,090
+And not [to be] identified with anyone, like I said.
+
+944
+01:04:37,170 --> 01:04:42,716
+I sometimes see those acrobats you have, in the air, when the aeroplanes go round;
+
+945
+01:04:42,796 --> 01:04:48,396
+how they are keeping the distance alright, respecting each other properly, everyone.
+
+946
+01:04:48,476 --> 01:04:53,630
+They do not collide and they do not bump into each other.
+
+947
+01:04:53,711 --> 01:04:56,711
+In the same way, the whole thing should move.
+
+948
+01:04:56,791 --> 01:05:02,951
+See this Universe, see how beautifully God has created it, with so many
+
+949
+01:05:03,031 --> 01:05:08,280
+stars are moving, so many satellites are moving, and there’s no collision.
+
+950
+01:05:08,360 --> 01:05:13,160
+And this Earth is moving with tremendous speed and we are nicely settled
+
+951
+01:05:13,240 --> 01:05:18,680
+down here without feeling the speed or the noise of that moving mass.
+
+952
+01:05:19,284 --> 01:05:24,750
+How beautifully the whole thing is worked out and how delicately it is all placed.
+
+953
+01:05:24,830 --> 01:05:31,941
+In the same way, Sahaja Yoga is a tremendous Universe and that Universe you
+
+954
+01:05:32,021 --> 01:05:39,940
+have to move with that respect and love and understanding for each other.
+
+955
+01:05:40,020 --> 01:05:46,060
+Arrogance to each other or saying hurting things to others, or even disrespect,
+
+956
+01:05:46,140 --> 01:05:50,140
+even showing your tongue and things, you should not do that.
+
+957
+01:05:50,220 --> 01:05:52,820
+You are saints, you are matured people.
+
+958
+01:05:52,900 --> 01:05:57,300
+I mean, I have seen, even in the Parliament, the way people behave
+
+959
+01:05:57,380 --> 01:06:01,780
+towards each other is most surprising and shocking – how can they?
+
+960
+01:06:01,860 --> 01:06:04,670
+But you are the chosen ones by God,
+
+961
+01:06:04,750 --> 01:06:10,280
+you are all dignified just like all great sages.
+
+962
+01:06:10,820 --> 01:06:13,931
+Behave in that manner and respect each other!
+
+963
+01:06:14,011 --> 01:06:19,095
+And be very much thankful that you have so many like you here,
+
+964
+01:06:19,175 --> 01:06:22,841
+with whom you can share your ideas and can talk to each
+
+965
+01:06:22,921 --> 01:06:28,060
+other and can be kind to each other and can
+
+966
+01:06:28,140 --> 01:06:31,900
+also be absolutely one with each other,
+
+967
+01:06:31,980 --> 01:06:35,190
+absolutely one with each other.
+
+968
+01:06:35,270 --> 01:06:40,800
+It is a very special position you are into.
+
+969
+01:06:40,880 --> 01:06:48,430
+Because of this ego we really try to be very, very indignified and misidentified.
+
+970
+01:06:49,495 --> 01:06:54,161
+This you can bring about very carefully in the house, if you can write
+
+971
+01:06:54,241 --> 01:07:00,950
+in your rooms, “I am a realised soul.” It’s writ large on your forehead!
+
+972
+01:07:03,047 --> 01:07:04,980
+Absolutely I can see clearly.
+
+973
+01:07:05,060 --> 01:07:06,993
+It’s writ large in your eyes.
+
+974
+01:07:07,550 --> 01:07:12,690
+Anybody who goes to India, say, need not tell me that they are going,
+
+975
+01:07:13,300 --> 01:07:18,821
+Sahaja Yogis will find out who they are in no time.
+
+976
+01:07:18,901 --> 01:07:22,367
+Even looking at a person one can say, “Yah, you see,
+
+977
+01:07:22,447 --> 01:07:25,980
+he’s a realised soul.” It’s writ large on your faces.
+
+978
+01:07:26,060 --> 01:07:32,361
+So identified with your Self that you are and not that what you were,
+
+979
+01:07:32,441 --> 01:07:35,880
+it’s finished, you’ve got your Self-realisation.
+
+980
+01:07:35,960 --> 01:07:39,160
+So all the franticness the panic, the indignity,
+
+981
+01:07:39,240 --> 01:07:43,310
+the disturbances, all will gradually settle down now.
+
+982
+01:07:43,390 --> 01:07:49,040
+Just shake yourself, because now that’s like the leaves on the tree
+
+983
+01:07:49,120 --> 01:07:54,000
+which are dead now, will fall down, and the new leaves have to come out.
+
+984
+01:07:54,080 --> 01:07:59,546
+This is a thing I wanted to talk to you about your Self and about the Sahaja Yoga,
+
+985
+01:07:59,626 --> 01:08:02,561
+internal yoga. One is internal yoga here,
+
+986
+01:08:02,641 --> 01:08:06,787
+and another is a yoga between all of you – is very important.
+
+987
+01:08:06,867 --> 01:08:09,828
+Gradually you will be developing new and new
+
+988
+01:08:09,908 --> 01:08:13,374
+dimensions and new and new visions about each other.
+
+989
+01:08:13,454 --> 01:08:16,254
+When you will start seeing this on others,
+
+990
+01:08:16,334 --> 01:08:18,600
+you will start seeing in yourself.
+
+991
+01:08:18,680 --> 01:08:21,768
+Try to see good points of others and bad points of yours.
+
+992
+01:08:21,848 --> 01:08:26,149
+But don’t condemn it (yourself) because there’s another side to this,
+
+993
+01:08:26,229 --> 01:08:29,927
+is that this Left-Vishuddhi, is to feel guilty about it.
+
+994
+01:08:30,007 --> 01:08:31,394
+That’s not the point.
+
+995
+01:08:31,474 --> 01:08:36,474
+Guilty, feeling guilty is not done by a person who is in the Witness State.
+
+996
+01:08:36,554 --> 01:08:37,922
+He doesn’t take up anything as
+
+997
+01:08:38,002 --> 01:08:39,370
+bad because he can remove it.
+
+998
+01:08:39,450 --> 01:08:43,010
+So you remove that and remove this and be in the centre.
+
+999
+01:08:43,090 --> 01:08:47,370
+Just be in the centre where you receive the complete blessings.
+
+1000
+01:08:47,450 --> 01:08:50,291
+Sometimes, even if you lose vibrations, doesn’t matter.
+
+1001
+01:08:50,371 --> 01:08:53,570
+You are a realised soul and you will be a realised soul.
+
+1002
+01:08:53,650 --> 01:08:58,112
+Even if you are reborn you will be a realised soul no doubt about it.
+
+1003
+01:08:58,192 --> 01:08:59,373
+You are not going to lose it.
+
+1004
+01:08:59,453 --> 01:09:02,270
+And if anybody says anything to you [it] doesn’t matter,
+
+1005
+01:09:02,350 --> 01:09:03,911
+makes no difference, because
+
+1006
+01:09:03,991 --> 01:09:05,760
+you are a realised soul, you are above it,
+
+1007
+01:09:05,840 --> 01:09:07,351
+so let them say whatever they like.
+
+1008
+01:09:07,431 --> 01:09:10,535
+Whatever you are you are, they cannot change you.
+
+1009
+01:09:10,615 --> 01:09:15,145
+You can change them and they cannot change you. They cannot change you.
+
+1010
+01:09:15,225 --> 01:09:20,371
+So it’s something that is so much you own so why should you bother if others
+
+1011
+01:09:20,451 --> 01:09:21,796
+do not appreciate you? It doesn’t
+
+1012
+01:09:21,876 --> 01:09:24,156
+matter. But try to help them out.
+
+1013
+01:09:24,236 --> 01:09:27,500
+You are just doing it because you want to help them.
+
+1014
+01:09:27,580 --> 01:09:30,925
+If you think that way everything will be alright.
+
+1015
+01:09:31,005 --> 01:09:34,471
+And for doing it you have to be in meditation to see
+
+1016
+01:09:34,551 --> 01:09:37,964
+yourself [that’s] very important, to see yourself.
+
+1017
+01:09:38,044 --> 01:09:40,979
+And you have to try on others also, if they ask you.
+
+1018
+01:09:41,059 --> 01:09:45,744
+You should ask others to see you and watch and find out what’s the matter with you,
+
+1019
+01:09:45,824 --> 01:09:48,275
+where are we and what is happening to you.
+
+1020
+01:09:48,355 --> 01:09:52,101
+But there are now, lots of unanimous feelings among you
+
+1021
+01:09:52,181 --> 01:09:55,761
+which is surprising and good when there is an attack.
+
+1022
+01:09:55,841 --> 01:09:59,841
+This is the best part of the whole thing is that, when there is an attack,
+
+1023
+01:09:59,921 --> 01:10:02,468
+there’s a collectivity much more, in emergencies.
+
+1024
+01:10:02,548 --> 01:10:07,127
+Like there was an attack here and you felt much closer to each other.
+
+1025
+01:10:07,207 --> 01:10:11,873
+And there was quite an unanimous verdict on this that it was a horrid,
+
+1026
+01:10:11,953 --> 01:10:13,819
+horrid place we had come to.
+
+1027
+01:10:13,899 --> 01:10:18,032
+But the whole thing is transformed into a beautiful place now.
+
+1028
+01:10:18,112 --> 01:10:23,792
+Now even somebody coming here and sleeping might get his Kundalini awakened you see.
+
+1029
+01:10:23,872 --> 01:10:26,581
+You can transform. They’ll be a master,
+
+1030
+01:10:26,661 --> 01:10:32,141
+they’ll just laugh at these people like the elephant walking and the dogs barking
+
+1031
+01:10:32,221 --> 01:10:35,634
+like that, it makes no difference to the elephant,
+
+1032
+01:10:35,714 --> 01:10:39,327
+he just puts his ears just like this here (laughter).
+
+1033
+01:10:39,407 --> 01:10:44,740
+So, for the morning on this if you have any questions a little bit I don’t mind,
+
+1034
+01:10:44,820 --> 01:10:46,233
+but on this subject.
+
+1035
+01:10:47,052 --> 01:10:53,340
+Yogi: Some Sahaja Yogis have been getting colds.
+
+1036
+01:10:53,420 --> 01:11:00,750
+Now, if they are getting vibrations, should they be getting colds?
+
+1037
+01:11:00,830 --> 01:11:02,830
+And if they are getting colds,
+
+1038
+01:11:02,910 --> 01:11:09,540
+are they doing wrong things
+
+1039
+01:11:09,620 --> 01:11:13,135
+or eating wrong things? Shri Mataji:
+
+1040
+01:11:13,215 --> 01:11:17,829
+That is the ‘blessing’ of this country (laughter) that you get cold.
+
+1041
+01:11:17,909 --> 01:11:22,709
+I mean, this is also a human nature, you see. Just see the beauty of it.
+
+1042
+01:11:22,789 --> 01:11:25,989
+You see, in India, now, for example, my husband,
+
+1043
+01:11:26,069 --> 01:11:30,282
+at least, wears seven sweaters, you won’t believe it. See now,
+
+1044
+01:11:30,362 --> 01:11:35,095
+he’s (a yogi in the room) wearing a sweater which is covering his neck.
+
+1045
+01:11:35,175 --> 01:11:37,841
+Those who come from the hot country keep
+
+1046
+01:11:37,921 --> 01:11:41,054
+themselves much more protected than you people.
+
+1047
+01:11:42,620 --> 01:11:47,975
+I have always requested all of you to buy one scarf each of a very thick thing,
+
+1048
+01:11:48,555 --> 01:11:52,515
+that you should always keep your neck covered with a scarf.
+
+1049
+01:11:52,595 --> 01:11:56,261
+So, I have been requesting everybody that you bring it,
+
+1050
+01:11:56,341 --> 01:11:59,407
+I’ll vibrate it, I’ll give it to you, do that.
+
+1051
+01:11:59,487 --> 01:12:04,477
+And also you should know what it causes because of hot and cold you see.
+
+1052
+01:12:04,557 --> 01:12:06,890
+Never take anything cold after hot.
+
+1053
+01:12:06,970 --> 01:12:09,703
+Gradually you start from cold to the hot.
+
+1054
+01:12:10,600 --> 01:12:15,040
+Now, the another thing which catches Vishuddhi to begin with,
+
+1055
+01:12:15,740 --> 01:12:21,539
+is when you do not have consideration of the collectivity, in a subtler way.
+
+1056
+01:12:21,619 --> 01:12:24,085
+In a subtler way it starts like that.
+
+1057
+01:12:24,165 --> 01:12:29,298
+When you are aware of the collective being then the Vishuddhi is much better.
+
+1058
+01:12:29,378 --> 01:12:31,991
+Because of the ego problem here, also,
+
+1059
+01:12:32,071 --> 01:12:35,471
+the Vishuddhi catches because once the ego is there
+
+1060
+01:12:35,551 --> 01:12:38,284
+you are move individualistic, “I am this,
+
+1061
+01:12:38,364 --> 01:12:41,430
+I am that,” so it goes hand in hand with that.
+
+1062
+01:12:41,510 --> 01:12:46,570
+So one has to be more careful that we should keep our neck covered and
+
+1063
+01:12:46,650 --> 01:12:52,500
+use also some balm or something, just to give it some soothing thing.
+
+1064
+01:12:52,580 --> 01:12:56,180
+But, what is the best thing for your throats, is salt.
+
+1065
+01:12:56,260 --> 01:12:59,436
+You see, at this point you become the Viraat,
+
+1066
+01:13:00,346 --> 01:13:03,879
+the All-pervading, you can say, the Primordial Being.
+
+1067
+01:13:04,786 --> 01:13:08,332
+Now, pervading into everything is done through salt.
+
+1068
+01:13:09,452 --> 01:13:13,785
+Salt dissolves into all the solvent things. So salt is the thing,
+
+1069
+01:13:13,865 --> 01:13:15,131
+solution, for this.
+
+1070
+01:13:15,211 --> 01:13:20,671
+From the ocean you take out the salt which is clear cut and then you put it here.
+
+1071
+01:13:20,751 --> 01:13:23,171
+This is, also, is Viraata’s thing.
+
+1072
+01:13:23,251 --> 01:13:28,531
+Now, all these Gurus, in the stomach, have praised that Viraat,
+
+1073
+01:13:28,611 --> 01:13:33,030
+is the Akbar, is the Great Being, He’s the one here (Vishuddhi).
+
+1074
+01:13:33,110 --> 01:13:37,800
+So the salt, that they are, you have to use them here. It pleases.
+
+1075
+01:13:37,880 --> 01:13:40,693
+Salt is like the sages. You are the salt.
+
+1076
+01:13:41,795 --> 01:13:44,661
+Do you remember this? And you are the salt,
+
+1077
+01:13:44,741 --> 01:13:47,074
+all the Sahaja Yogis are the salts.
+
+1078
+01:13:47,154 --> 01:13:52,367
+And the salt is very pleasing to Shri Krishna, to your Primordial Being here.
+
+1079
+01:13:52,447 --> 01:13:57,387
+So when you take salt, in that way, is to gargle your throat, and to put a
+
+1080
+01:13:57,467 --> 01:13:59,600
+little salt if you want to here,
+
+1081
+01:13:59,680 --> 01:14:02,613
+with your fingers, with this finger is good.
+
+1082
+01:14:02,693 --> 01:14:04,734
+Use this finger for this thing.
+
+1083
+01:14:04,814 --> 01:14:09,347
+And look after that part because this is the demand of this country.
+
+1084
+01:14:09,427 --> 01:14:12,960
+We have demands of other troubles in other countries,
+
+1085
+01:14:13,040 --> 01:14:18,640
+like India is malaria, you have to protect yourself from malaria. Or maybe somewhere
+
+1086
+01:14:18,720 --> 01:14:23,586
+it is plague, I don’t know what countries even have, what sort of things.
+
+1087
+01:14:23,666 --> 01:14:27,866
+But here it is cold and catarrh and all these things are there.
+
+1088
+01:14:27,946 --> 01:14:29,679
+So a few things like that.
+
+1089
+01:14:29,759 --> 01:14:34,692
+And also inhalation and there are some things we know, very simple things,
+
+1090
+01:14:34,772 --> 01:14:40,305
+which cost nothing, is this ajwain ka dhuni, which they will tell you how to do it.
+
+1091
+01:14:40,385 --> 01:14:44,292
+All these things you must take and look after your throats.
+
+1092
+01:14:44,372 --> 01:14:47,505
+It’s very important to look after your throats.
+
+1093
+01:14:47,585 --> 01:14:49,065
+And that’s why people
+
+1094
+01:14:49,145 --> 01:14:53,840
+catch cold. But what is wrong in Sahaja Yoga is this,
+
+1095
+01:14:53,920 --> 01:14:58,090
+that you have not respected your Vishuddhi Chakra.
+
+1096
+01:14:58,170 --> 01:14:59,783
+You have to be careful.
+
+1097
+01:14:59,863 --> 01:15:02,996
+You catch from other people also so many times,
+
+1098
+01:15:03,076 --> 01:15:06,409
+so be careful as not to contact with other people.
+
+1099
+01:15:06,489 --> 01:15:10,289
+But it can be easily overcome if you develop your Witness
+
+1100
+01:15:10,369 --> 01:15:14,529
+State better and if you concentrate on your Vishuddhi Chakra.
+
+1101
+01:15:14,609 --> 01:15:17,142
+It can improved and it can be settled.
+
+1102
+01:15:24,039 --> 01:15:26,705
+What other trouble people have is liver.
+
+1103
+01:15:27,559 --> 01:15:29,159
+It’s common with people.
+
+1104
+01:15:29,239 --> 01:15:33,639
+Most of you have it because you are all the time thinking too much
+
+1105
+01:15:33,719 --> 01:15:38,319
+and the liver doesn’t get sufficient of energy so the liver is there.
+
+1106
+01:15:38,399 --> 01:15:41,532
+So, for liver also, we know what is to be done.
+
+1107
+01:15:41,612 --> 01:15:45,158
+And it’s more liver here than in India I think, yes.
+
+1108
+01:15:45,238 --> 01:15:49,438
+Extremes should be avoided, like sitting in the Sun and bathing
+
+1109
+01:15:49,518 --> 01:15:53,384
+yourself for hours together and all that is not necessary.
+
+1110
+01:15:53,464 --> 01:15:56,130
+And there’s no need to expose your body.
+
+1111
+01:15:56,210 --> 01:16:00,276
+You can cover your body and still the Sun’s rays go into you.
+
+1112
+01:16:00,356 --> 01:16:02,836
+There’s no need to expose your body.
+
+1113
+01:16:02,916 --> 01:16:08,182
+Actually the exposure of body is very dangerous for your nerves and everything,
+
+1114
+01:16:08,262 --> 01:16:11,928
+it’s very bad. You should not expose your body so much.
+
+1115
+01:16:12,008 --> 01:16:16,541
+Even in the water also, directly, you should never expose your body.
+
+1116
+01:16:16,621 --> 01:16:21,621
+You must cover your body in the water also, because water also attacks you.
+
+1117
+01:16:21,701 --> 01:16:27,034
+So exposure of body should be in a very limited space and in a very limited way.
+
+1118
+01:16:27,114 --> 01:16:30,648
+As far as possible body should not be exposed too much.
+
+1119
+01:16:30,728 --> 01:16:34,378
+It’s very dangerous because then you allow your chakras to be
+
+1120
+01:16:34,458 --> 01:16:38,804
+opened to these entities and a kind of a vulgarity walks in you.
+
+1121
+01:16:38,884 --> 01:16:42,350
+Now, this is another thing is that, in this country,
+
+1122
+01:16:42,430 --> 01:16:45,250
+people sleep without any clothes on them. I mean,
+
+1123
+01:16:45,330 --> 01:16:49,783
+this is the coldest country where people should cover up themselves and sleep.
+
+1124
+01:16:49,863 --> 01:16:53,974
+I sleep with the sweater on and everything on to be very frank, you see!
+
+1125
+01:16:54,054 --> 01:16:57,936
+Although we have the central heating on, but we all sleep like that.
+
+1126
+01:16:58,016 --> 01:17:00,813
+And here it is a very common thing that you find.
+
+1127
+01:17:00,893 --> 01:17:03,976
+And one Indian gentleman told me that’s the reason the
+
+1128
+01:17:04,056 --> 01:17:07,424
+children don’t sleep in the same room as the parents sleep.
+
+1129
+01:17:07,504 --> 01:17:11,672
+And we always had children with us because we don’t take out our clothes,
+
+1130
+01:17:11,752 --> 01:17:13,750
+we just sleep as we sleep normally.
+
+1131
+01:17:13,830 --> 01:17:18,455
+And there’s no need to be all the time in a perpetual nudity to enjoy your sleep.
+
+1132
+01:17:18,535 --> 01:17:22,360
+Or I don’t know what is the need to be nude in sleep because it’s a
+
+1133
+01:17:22,440 --> 01:17:26,322
+very bad thing is to expose yourself in the night especially because
+
+1134
+01:17:26,402 --> 01:17:30,430
+night time all these nocturnal people, all these spirits are hovering
+
+1135
+01:17:30,510 --> 01:17:34,976
+around and if they see anybody like that they might end up in them.
+
+1136
+01:17:35,056 --> 01:17:38,799
+So it’s a very dangerous thing. But this idea I think you
+
+1137
+01:17:38,879 --> 01:17:40,679
+have started very recently.
+
+1138
+01:17:40,759 --> 01:17:42,655
+Somebody must have given you ideas
+
+1139
+01:17:42,735 --> 01:17:44,112
+that to sleep without clothes
+
+1140
+01:17:44,192 --> 01:17:49,493
+is very good perhaps, which everybody starts doing that way. You see all these,
+
+1141
+01:17:49,573 --> 01:17:55,106
+also there are lots of spirits who are writing books so be careful if somebody says
+
+1142
+01:17:55,186 --> 01:17:58,119
+like that, “If you take out all your clothes
+
+1143
+01:17:58,199 --> 01:18:03,599
+you’ll behave different.” You’ll find anybody here who is all the time ?? nobody.
+
+1144
+01:18:03,679 --> 01:18:06,679
+Everybody has some sort of a ?? all the time.
+
+1145
+01:18:06,759 --> 01:18:08,639
+It’s very bad for the mind.
+
+1146
+01:18:08,719 --> 01:18:12,519
+You see the mind is never alright. Like, I would say now,
+
+1147
+01:18:12,599 --> 01:18:15,332
+I was coming and I saw a very nice church
+
+1148
+01:18:15,412 --> 01:18:17,563
+and with that all these graves,
+
+1149
+01:18:17,643 --> 01:18:19,935
+all the crosses and graves there.
+
+1150
+01:18:20,015 --> 01:18:23,881
+I said, now anybody going to the church will be possessed.
+
+1151
+01:18:23,961 --> 01:18:27,427
+But at least when you go to church there’s one thing
+
+1152
+01:18:27,507 --> 01:18:30,640
+you do is to wear a clean dress, go with a mark
+
+1153
+01:18:30,720 --> 01:18:34,320
+and all that, so that, if they see you clean and neat,
+
+1154
+01:18:34,400 --> 01:18:37,613
+then they are a little afraid to come into you.
+
+1155
+01:18:37,693 --> 01:18:42,506
+But if you go in the night without any dress there when you get in bed,
+
+1156
+01:18:42,586 --> 01:18:47,119
+you can become a booboo next morning (laughter). That’s what they do
+
+1157
+01:18:47,199 --> 01:18:52,132
+all these people, this ‘narayan’ and all that, all of them go do it there.
+
+1158
+01:18:52,212 --> 01:18:55,664
+And not only but they go to the temples where the Deities
+
+1159
+01:18:55,744 --> 01:18:59,105
+are and before them they become naked and do all kinds of
+
+1160
+01:18:59,185 --> 01:19:02,570
+dirty things and then get all the [dead] spirits to come
+
+1161
+01:19:02,650 --> 01:19:05,230
+down there because no more the God’s attention is there.
+
+1162
+01:19:05,310 --> 01:19:09,069
+And that’s how they work out with dead spirits, so it is like that.
+
+1163
+01:19:09,149 --> 01:19:11,618
+All these certain things you have to change.
+
+1164
+01:19:11,698 --> 01:19:15,401
+This is not your culture and do not insult your culture by saying,
+
+1165
+01:19:15,481 --> 01:19:18,342
+“This is our culture.” It’s absolutely nonsensical.
+
+1166
+01:19:18,422 --> 01:19:21,732
+This is not English culture, neither it is Western culture.
+
+1167
+01:19:21,812 --> 01:19:25,571
+They were all sensible people and they were never that nonsensical,
+
+1168
+01:19:25,651 --> 01:19:29,747
+the way we are now, and so we should not say this was our culture at all.
+
+1169
+01:19:29,827 --> 01:19:32,691
+I mean, this would be an insult to the culture.
+
+1170
+01:19:32,771 --> 01:19:38,371
+Only a few kings used to misbehave and everybody criticised them, nobody liked them.
+
+1171
+01:19:38,451 --> 01:19:41,784
+So, I mean that vice has become now, in democracy,
+
+1172
+01:19:41,864 --> 01:19:47,397
+everybody becomes a king as far as the vices are concerned, not in the good points.
+
+1173
+01:19:47,477 --> 01:19:50,010
+That kind of a democracy is of no use.
+
+1174
+01:19:50,090 --> 01:19:55,690
+And so, that sort of a thing it has happened but this was never your culture before.
+
+1175
+01:19:55,770 --> 01:19:59,570
+A very great, sensible people, and known for your wisdom.
+
+1176
+01:19:59,650 --> 01:20:04,916
+You know England is the Heart of the Universe and how could it be that foolish?
+
+1177
+01:20:04,996 --> 01:20:10,289
+Just think about it, it’s the Heart of the Universe, it is heart shaped also.
+
+1178
+01:20:10,369 --> 01:20:14,582
+It’s a very important thing and that’s why I am here with you.
+
+1179
+01:20:14,662 --> 01:20:17,695
+So try to respect it and
+
+1180
+01:20:17,775 --> 01:20:23,370
+respect it’s traditions. Yogi:
+
+1181
+01:20:23,450 --> 01:20:26,263
+Shri Mataji is it easier for evil spirits
+
+1182
+01:20:26,343 --> 01:20:28,756
+of bhoots to get into Sahaja Yogis?
+
+1183
+01:20:28,836 --> 01:20:32,836
+Shri Mataji: No, it is more difficult but you can feel them.
+
+1184
+01:20:32,916 --> 01:20:37,716
+You see the thing is, when you are not a Sahaja Yogi you cannot feel it.
+
+1185
+01:20:37,796 --> 01:20:42,996
+You can get possessed, you can get depressed, you can get all kinds of things,
+
+1186
+01:20:43,076 --> 01:20:46,276
+you might even become a lunatic person, you may.
+
+1187
+01:20:46,356 --> 01:20:49,156
+Whatever may happen but you won’t feel it.
+
+1188
+01:20:49,236 --> 01:20:52,169
+But as soon as you are a Sahaja Yogi you can
+
+1189
+01:20:52,249 --> 01:20:56,915
+feel it and that’s how you can guard yourselves. It is very difficult.
+
+1190
+01:20:56,995 --> 01:21:01,025
+And if you know all the methods of guarding then it’s even better.
+
+1191
+01:21:01,105 --> 01:21:03,890
+And actually Sahaja Yogis do not catch, as I said,
+
+1192
+01:21:03,970 --> 01:21:08,037
+but if you go on feeling, “I have caught, I have caught,” so you have it!
+
+1193
+01:21:08,117 --> 01:21:12,407
+Yogi: As far as I can really see that before one can really get in control of
+
+1194
+01:21:12,487 --> 01:21:16,888
+one’s body from the start one is especially vulnerable (to bhoots). is that so?
+
+1195
+01:21:16,968 --> 01:21:18,913
+Shri Mataji: No, no. You are much less
+
+1196
+01:21:18,993 --> 01:21:22,789
+vulnerable. But only you can feel it because you are sensitive.
+
+1197
+01:21:22,869 --> 01:21:27,949
+Like, if you have a pain, they may kill it with some sort of a numb effect.
+
+1198
+01:21:28,029 --> 01:21:29,859
+But when it goes out you feel it.
+
+1199
+01:21:29,939 --> 01:21:32,767
+In the same way, you are numbed before realisation,
+
+1200
+01:21:32,847 --> 01:21:35,047
+and after realisation you aren’t.
+
+1201
+01:21:35,127 --> 01:21:39,993
+And that’s what Sahaja Yogis think that, they all attack us and all that.
+
+1202
+01:21:40,073 --> 01:21:44,477
+They are literally frightened of you because you are much more powerful.
+
+1203
+01:21:44,557 --> 01:21:45,555
+It’s an idea that,
+
+1204
+01:21:45,635 --> 01:21:49,795
+“We are attacked because we are Sahaja Yogis.” (laughing) The idea is that.
+
+1205
+01:21:49,875 --> 01:21:54,275
+Nothing of the kind. On the contrary they run away, they run away.
+
+1206
+01:21:54,355 --> 01:21:58,688
+But you should be someone, in a beautiful way that they run away,
+
+1207
+01:21:58,768 --> 01:22:00,768
+they just don’t come near you.
+
+1208
+01:22:00,878 --> 01:22:06,291
+We have three of them in Rahuri and some of the possessed people they told that,
+
+1209
+01:22:06,371 --> 01:22:09,304
+“Please tell these three not to go together.
+
+1210
+01:22:09,384 --> 01:22:12,824
+Even if they have to go they can go single people.
+
+1211
+01:22:12,904 --> 01:22:17,837
+Because, after all, we have left the bodies but we have to live somewhere,
+
+1212
+01:22:17,917 --> 01:22:20,917
+and they go on their motorbikes,” so he said,
+
+1213
+01:22:20,997 --> 01:22:23,063
+“tell them not to go that fast.
+
+1214
+01:22:23,143 --> 01:22:28,023
+Give us some chance at least to get away from there.” So it’s like that!
+
+1215
+01:22:29,998 --> 01:22:32,664
+(laughing) So you are not attacked more.
+
+1216
+01:22:32,744 --> 01:22:38,990
+But they come more in
+
+1217
+01:22:39,070 --> 01:22:44,232
+your awareness you see.
+
+1218
+01:22:44,312 --> 01:22:47,192
+But there are certain ways of judging you.
+
+1219
+01:22:47,272 --> 01:22:51,472
+Like there was a girl in America, she used to run a shop of her
+
+1220
+01:22:51,552 --> 01:22:55,965
+own and what happened [was that] she was very good at remembering
+
+1221
+01:22:56,045 --> 01:23:00,511
+everything; this is this, this is this, that one is yellow coloured
+
+1222
+01:23:00,591 --> 01:23:02,724
+and this is pink colour and this
+
+1223
+01:23:02,804 --> 01:23:06,204
+price is so much and everything. She was very good.
+
+1224
+01:23:06,284 --> 01:23:11,017
+Once she got realisation she forgot all that, she couldn’t do that way.
+
+1225
+01:23:11,097 --> 01:23:13,830
+But the profits were four times [larger].
+
+1226
+01:23:13,910 --> 01:23:16,776
+And she was surprised, with all that thing,
+
+1227
+01:23:16,856 --> 01:23:21,456
+and she used to get a headache everyday. She could not sleep with the
+
+1228
+01:23:21,536 --> 01:23:24,936
+idea that she has put this here and she should have
+
+1229
+01:23:25,016 --> 01:23:29,682
+put it there and all that. She was [now] not doing anything like that.
+
+1230
+01:23:29,762 --> 01:23:35,242
+She was just doing spontaneously, just existing, and the profits were four times.
+
+1231
+01:23:35,322 --> 01:23:37,988
+She was so amazed. Because the attention
+
+1232
+01:23:38,068 --> 01:23:41,001
+you pay to [things] is very limited and with
+
+1233
+01:23:41,081 --> 01:23:45,561
+your limited idea. But after realisation you just become a vehicle
+
+1234
+01:23:45,641 --> 01:23:48,574
+of the dynamic attention which works it out.
+
+1235
+01:23:48,654 --> 01:23:51,254
+And it’s amazing how it works, amazing.
+
+1236
+01:23:52,364 --> 01:23:57,897
+Yogi: Mother, can one be too passive about witnessing one’s realisation? (laughter)
+
+1237
+01:23:57,977 --> 01:23:59,457
+Shri Mataji: You see,
+
+1238
+01:23:59,537 --> 01:24:03,207
+passive and active comes
+
+1239
+01:24:03,287 --> 01:24:08,743
+from the way we are either
+
+1240
+01:24:08,823 --> 01:24:13,404
+in the ego, the way we are acting, whether we are acting through ego.
+
+1241
+01:24:13,484 --> 01:24:18,350
+But in Sahaja Yoga you are neither passive nor active you are just there.
+
+1242
+01:24:18,430 --> 01:24:20,296
+This is the difference here.
+
+1243
+01:24:20,376 --> 01:24:30,655
+What are you saying to me? “Am I passive” or “active”? Shri Mataji:
+
+1244
+01:24:30,735 --> 01:24:34,287
+You are active?
+
+1245
+01:24:34,367 --> 01:24:38,594
+You are not.
+
+1246
+01:24:38,674 --> 01:24:40,140
+I am passively active.
+
+1247
+01:24:40,220 --> 01:24:44,424
+I am acting but I’m doing nothing but I am acting,
+
+1248
+01:24:44,504 --> 01:24:48,584
+you can say, in the same way that you have got powers to do.
+
+1249
+01:24:48,664 --> 01:24:52,610
+But if you think that you can do it just by sleeping over,
+
+1250
+01:24:52,690 --> 01:24:56,236
+that’s not the way it will work out. You have to be.
+
+1251
+01:24:56,316 --> 01:25:00,782
+Like I have told many people, “Why don’t you get up in the morning?
+
+1252
+01:25:00,862 --> 01:25:04,262
+If you do not have time in the evening to meditate,
+
+1253
+01:25:04,342 --> 01:25:07,742
+meditate in the morning” Because you have to do it.
+
+1254
+01:25:07,822 --> 01:25:12,288
+Still you are not there, that’s why you have to be active about it.
+
+1255
+01:25:12,368 --> 01:25:15,301
+First you become absolutely a Witness State,
+
+1256
+01:25:15,381 --> 01:25:17,714
+then you don’t have to do anything,
+
+1257
+01:25:17,794 --> 01:25:20,194
+you just sit down and you are in it.
+
+1258
+01:25:20,274 --> 01:25:24,074
+But still I have to travel, I have to go and meet people.
+
+1259
+01:25:24,154 --> 01:25:25,512
+I have to talk to you.
+
+1260
+01:25:25,592 --> 01:25:27,924
+I have to talk to you for hours together.
+
+1261
+01:25:28,004 --> 01:25:31,564
+Sometimes I have to sit in one place for ten hours continuously.
+
+1262
+01:25:31,644 --> 01:25:33,990
+So, I am quite active in that way.
+
+1263
+01:25:34,070 --> 01:25:38,670
+And I am also inactive because I am not doing anything, I am just watching it.
+
+1264
+01:25:38,750 --> 01:25:40,083
+If I see manifested…
+


### PR DESCRIPTION
English subtitles for the **Our-Understanding-of-SY** recording (the talk already has uk.srt).

## How
Force-aligned the corrected EN transcript to whisper words (`snap_srt_to_whisper`): **1227/1271 blocks anchor to exact whisper word timestamps**. The 44 unmatched blocks (whisper-garbled multi-speaker Q&A exchanges) are distributed in transcript order within the window between their nearest reliable whisper anchors.

## Result
- **1264 blocks**, text order preserved exactly, all structural checks **PASSED** (text / overlaps / range / numbering / CPL / gaps).
- Dense ~86-min Q&A seminar: **25 blocks (2%) read above 20 CPS** (max 26.4) — genuine fast speech plus non-spoken editorial parentheticals (e.g. `(A homosexual British MP accused…)`); validated with `--skip-cps-check`, same convention as other dense talks.
- No abridged opening here (unlike 1981-05-24) — transcript begins with real speech.

Intended as a base for fine-tuning the dense passages in the waveform timing editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)