### PR TITLE
pipeline: gate secondary-video build on en.srt presence (skip raw videos)

### DIFF
--- a/.github/workflows/subtitle-pipeline.yml
+++ b/.github/workflows/subtitle-pipeline.yml
@@ -805,67 +805,21 @@ jobs:
 
       - name: Build secondary-video SRTs
         # Secondary videos (same talk, different recording) get their uk.srt
-        # from primary's output — by simple time offset when the two en.srt
-        # files are identical-text-different-timing, or by word-level
-        # re-alignment (resync_srt) when the secondary covers a SUBSET of
-        # primary's content (e.g. only the English speech portion of a puja).
+        # from the primary's output — a simple time offset when the two en.srt
+        # files are identical-text-different-timing, or word-level re-alignment
+        # (resync_srt) when the secondary covers a SUBSET of the primary's
+        # content (e.g. only the English speech portion of a puja). This needs
+        # source/en.srt on BOTH the primary and the secondary; a secondary
+        # without en.srt (raw recording, no English subtitles) is skipped, not
+        # a failure. See tools/build_secondary_srts.py.
         env:
           TALK_ID: ${{ needs.prepare-build.outputs.talk_id }}
           VIDEO_SLUG: ${{ needs.prepare-build.outputs.video_slug }}
         run: |
-          TALK="talks/${TALK_ID}"
-          FIRST="${VIDEO_SLUG}"
-
-          python3 -c "
-          import yaml
-          with open('${TALK}/meta.yaml') as f:
-            meta = yaml.safe_load(f)
-          for v in meta['videos']:
-            if v['slug'] != '${FIRST}':
-              print(v['slug'])
-          " | while read slug; do
-            echo "=== Secondary video: $slug ==="
-            mkdir -p "${TALK}/${slug}/final"
-
-            OFFSET=$(python -m tools.offset_srt detect \
-              --srt1 "${TALK}/${FIRST}/source/en.srt" \
-              --srt2 "${TALK}/${slug}/source/en.srt" 2>/dev/null | grep -oE '[-0-9]+' | head -1)
-
-            if [ -n "$OFFSET" ]; then
-              echo "  offset match → offset_srt apply (${OFFSET}ms)"
-              python -m tools.offset_srt apply \
-                --srt "${TALK}/${FIRST}/final/uk.srt" \
-                --offset-ms "$OFFSET" \
-                --output "${TALK}/${slug}/final/uk.srt"
-              SUB_MODE="secondary-offset"
-            else
-              echo "  no offset → resync via EN SRT word alignment"
-              python -m tools.resync_srt \
-                --primary-uk "${TALK}/${FIRST}/final/uk.srt" \
-                --primary-en "${TALK}/${FIRST}/source/en.srt" \
-                --secondary-en "${TALK}/${slug}/source/en.srt" \
-                --output "${TALK}/${slug}/final/uk.srt"
-              SUB_MODE="secondary-resync"
-            fi
-
-            # Mirror the primary's build_manifest so golden tests know to
-            # apply secondary-relaxed validation (skip text/time/cps —
-            # derivative output from primary).
-            python3 <<PYEOF
-          import yaml
-          from datetime import datetime, timezone
-          manifest = {
-              "role": "secondary",
-              "mode": "${SUB_MODE}",
-              "primary_slug": "${FIRST}",
-              "built_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-              "run_id": ${{ github.run_id }},
-          }
-          with open("${TALK}/${slug}/final/build_manifest.yaml", "w") as f:
-              yaml.dump(manifest, f, default_flow_style=False, sort_keys=False)
-          print("  wrote ${TALK}/${slug}/final/build_manifest.yaml (mode=${SUB_MODE})")
-          PYEOF
-          done
+          python -m tools.build_secondary_srts \
+            --talk-dir "talks/${TALK_ID}" \
+            --primary-slug "${VIDEO_SLUG}" \
+            --run-id "${{ github.run_id }}"
 
       - name: Validate subtitles
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,10 @@ python -m tools.sync_pr --base SHA --paths "talks/.../transcript_uk.txt ..."
 python -m tools.resync_srt --primary-uk PATH --primary-en PATH \
   --secondary-en PATH --output PATH
 
+# Build UK SRTs for a talk's secondary videos (offset/resync from primary).
+# Needs source/en.srt on BOTH primary and secondary; skips videos without it.
+python -m tools.build_secondary_srts --talk-dir PATH --primary-slug SLUG [--run-id ID]
+
 # Validate artifact contracts at pipeline phase boundaries
 python -m tools.validate_artifacts [--whisper PATH | --meta PATH |
   --timecodes PATH | --talk-dir PATH]

--- a/tests/test_build_secondary_srts.py
+++ b/tests/test_build_secondary_srts.py
@@ -1,0 +1,227 @@
+"""Tests for tools.build_secondary_srts.
+
+Secondary videos of a multi-video talk derive their UK SRT from the primary's
+UK SRT. The derivation bridges the two timelines via en.srt word matching
+(offset when the shift is constant, resync otherwise), so it needs source/en.srt
+on BOTH the primary and the secondary — independent of the talk's timing_source.
+A secondary without en.srt (a raw recording, no English subtitles) is skipped,
+not a build failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from tools.build_secondary_srts import build_secondary_srts
+from tools.srt_utils import parse_srt
+
+
+def _tc(ms: int) -> str:
+    h = ms // 3600000
+    ms %= 3600000
+    m = ms // 60000
+    ms %= 60000
+    s = ms // 1000
+    ms %= 1000
+    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+
+def _write_srt(path: Path, blocks: list[tuple[int, int, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = []
+    for i, (start, end, text) in enumerate(blocks, 1):
+        lines += [str(i), f"{_tc(start)} --> {_tc(end)}", text, ""]
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+_EN_TEXT = [f"This is sentence number {i} of the talk today." for i in range(1, 13)]
+_UK_TEXT = [f"Це речення номер {i} сьогоднішньої промови." for i in range(1, 13)]
+
+
+def _blocks(texts: list[str], offset_ms: int = 0, jitter: int = 0, dur: int = 2000, gap: int = 1000):
+    out = []
+    t = offset_ms
+    for i, txt in enumerate(texts):
+        start = t + (jitter * i)
+        out.append((start, start + dur, txt))
+        t += dur + gap
+    return out
+
+
+def _setup_talk(tmp_path: Path, videos: dict[str, dict]) -> Path:
+    """Create a talk dir.
+
+    videos: ordered dict slug -> {"en": blocks|None, "uk": blocks|None}.
+    The first slug is treated as the primary by the caller.
+    """
+    talk = tmp_path / "talk"
+    talk.mkdir(parents=True)
+    meta = {
+        "title": "Test Talk",
+        "date": "1982-01-01",
+        "language": "en",
+        "videos": [{"slug": s, "title": s, "video_ref": "r1x"} for s in videos],
+    }
+    (talk / "meta.yaml").write_text(yaml.dump(meta, sort_keys=False), encoding="utf-8")
+    (talk / "transcript_uk.txt").write_text("Текст промови.", encoding="utf-8")
+    for slug, cfg in videos.items():
+        if cfg.get("en") is not None:
+            _write_srt(talk / slug / "source" / "en.srt", cfg["en"])
+        if cfg.get("uk") is not None:
+            _write_srt(talk / slug / "final" / "uk.srt", cfg["uk"])
+    return talk
+
+
+def _result_for(results: list[dict], slug: str) -> dict:
+    return next(r for r in results if r["slug"] == slug)
+
+
+# ---------------------------------------------------------------------------
+#  Regression for the #524/#525 crash: mixed secondaries, one without en.srt
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_secondaries_builds_with_ensrt_skips_without(tmp_path):
+    """A secondary with en.srt gets a uk.srt; a secondary without en.srt is
+    skipped — and the run does NOT crash (the bug that failed #524/#525)."""
+    talk = _setup_talk(
+        tmp_path,
+        {
+            "vid1": {"en": _blocks(_EN_TEXT), "uk": _blocks(_UK_TEXT)},  # primary
+            "vid2": {"en": _blocks(_EN_TEXT, offset_ms=5000)},  # constant offset
+            "vid3": {},  # raw recording, no en.srt
+        },
+    )
+
+    results = build_secondary_srts(talk, "vid1")
+
+    r2 = _result_for(results, "vid2")
+    r3 = _result_for(results, "vid3")
+    assert r2["status"] == "built"
+    assert r2["mode"] == "secondary-offset"
+    assert (talk / "vid2" / "final" / "uk.srt").exists()
+    assert len(parse_srt(str(talk / "vid2" / "final" / "uk.srt"))) > 0
+
+    assert r3["status"] == "skipped"
+    assert "en.srt" in (r3["reason"] or "")
+    assert not (talk / "vid3" / "final" / "uk.srt").exists()
+
+
+# ---------------------------------------------------------------------------
+#  offset vs resync selection
+# ---------------------------------------------------------------------------
+
+
+def test_constant_offset_uses_offset_mode(tmp_path):
+    talk = _setup_talk(
+        tmp_path,
+        {
+            "vid1": {"en": _blocks(_EN_TEXT), "uk": _blocks(_UK_TEXT)},
+            "vid2": {"en": _blocks(_EN_TEXT, offset_ms=7000)},
+        },
+    )
+    results = build_secondary_srts(talk, "vid1")
+    assert _result_for(results, "vid2")["mode"] == "secondary-offset"
+
+
+def test_inconsistent_offset_falls_back_to_resync(tmp_path):
+    """When the shift is not constant (per-block jitter beyond tolerance),
+    detect_offset returns None and the tool resyncs instead."""
+    talk = _setup_talk(
+        tmp_path,
+        {
+            "vid1": {"en": _blocks(_EN_TEXT), "uk": _blocks(_UK_TEXT)},
+            "vid2": {"en": _blocks(_EN_TEXT, offset_ms=5000, jitter=900)},
+        },
+    )
+    results = build_secondary_srts(talk, "vid1")
+    r2 = _result_for(results, "vid2")
+    assert r2["status"] == "built"
+    assert r2["mode"] == "secondary-resync"
+    assert (talk / "vid2" / "final" / "uk.srt").exists()
+
+
+# ---------------------------------------------------------------------------
+#  Gate is en.srt presence, independent of mode
+# ---------------------------------------------------------------------------
+
+
+def test_secondary_without_ensrt_is_skipped(tmp_path):
+    talk = _setup_talk(
+        tmp_path,
+        {
+            "vid1": {"en": _blocks(_EN_TEXT), "uk": _blocks(_UK_TEXT)},
+            "vid2": {},  # no en.srt
+        },
+    )
+    results = build_secondary_srts(talk, "vid1")
+    r2 = _result_for(results, "vid2")
+    assert r2["status"] == "skipped"
+    assert not (talk / "vid2" / "final" / "uk.srt").exists()
+
+
+def test_primary_without_ensrt_skips_all_secondaries(tmp_path):
+    """True whisper-mode talk (no en.srt anywhere): the en.srt bridge can't be
+    built from the primary, so every secondary is skipped — without crashing."""
+    talk = _setup_talk(
+        tmp_path,
+        {
+            "vid1": {"uk": _blocks(_UK_TEXT)},  # primary, no en.srt
+            "vid2": {"en": _blocks(_EN_TEXT, offset_ms=5000)},
+        },
+    )
+    results = build_secondary_srts(talk, "vid1")
+    r2 = _result_for(results, "vid2")
+    assert r2["status"] == "skipped"
+    assert "primary" in (r2["reason"] or "").lower()
+    assert not (talk / "vid2" / "final" / "uk.srt").exists()
+
+
+# ---------------------------------------------------------------------------
+#  build_manifest.yaml
+# ---------------------------------------------------------------------------
+
+
+def test_builds_secondary_manifest(tmp_path):
+    talk = _setup_talk(
+        tmp_path,
+        {
+            "vid1": {"en": _blocks(_EN_TEXT), "uk": _blocks(_UK_TEXT)},
+            "vid2": {"en": _blocks(_EN_TEXT, offset_ms=5000)},
+        },
+    )
+    build_secondary_srts(talk, "vid1", run_id=12345)
+    manifest_path = talk / "vid2" / "final" / "build_manifest.yaml"
+    assert manifest_path.exists()
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["role"] == "secondary"
+    assert manifest["mode"] == "secondary-offset"
+    assert manifest["primary_slug"] == "vid1"
+    assert manifest["run_id"] == 12345
+
+
+def test_no_manifest_for_skipped_secondary(tmp_path):
+    talk = _setup_talk(
+        tmp_path,
+        {
+            "vid1": {"en": _blocks(_EN_TEXT), "uk": _blocks(_UK_TEXT)},
+            "vid2": {},
+        },
+    )
+    build_secondary_srts(talk, "vid1")
+    assert not (talk / "vid2" / "final" / "build_manifest.yaml").exists()
+
+
+def test_returns_one_result_per_secondary(tmp_path):
+    talk = _setup_talk(
+        tmp_path,
+        {
+            "vid1": {"en": _blocks(_EN_TEXT), "uk": _blocks(_UK_TEXT)},
+            "vid2": {"en": _blocks(_EN_TEXT, offset_ms=5000)},
+            "vid3": {},
+        },
+    )
+    results = build_secondary_srts(talk, "vid1")
+    assert {r["slug"] for r in results} == {"vid2", "vid3"}

--- a/tools/build_secondary_srts.py
+++ b/tools/build_secondary_srts.py
@@ -1,0 +1,122 @@
+"""Build UK SRTs for the secondary videos of a multi-video talk.
+
+A talk can have several videos (different recordings of the same event). One is
+the *primary* (built by the LLM from the transcript); the others are *secondary*
+and derive their UK SRT from the primary's by re-timing it onto their own
+timeline. The bridge between the two timelines is built from matched words in
+the two ``source/en.srt`` files — a constant time offset when the recordings
+differ only by a head/tail shift (``offset_srt``), or a word-level warp when one
+covers a subset of the other (``resync_srt``).
+
+The derivation therefore needs ``source/en.srt`` on BOTH the primary and the
+secondary, regardless of the talk's ``timing_source``. A secondary without
+``en.srt`` (a raw recording with no English subtitles — e.g. a yogi-intro or a
+silent havan) simply has nothing to derive from and is **skipped**, not treated
+as a build failure. Likewise, if the primary has no ``en.srt`` (a true
+whisper-mode talk), there is no bridge to build and every secondary is skipped.
+
+Usage:
+    python -m tools.build_secondary_srts --talk-dir PATH --primary-slug SLUG \
+        [--run-id ID]
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import yaml
+
+from .offset_srt import apply_offset, detect_offset
+from .resync_srt import resync
+
+
+def _video_slugs(talk_dir: Path) -> list[str]:
+    with open(talk_dir / "meta.yaml", encoding="utf-8") as f:
+        meta = yaml.safe_load(f)
+    return [v["slug"] for v in (meta.get("videos") or [])]
+
+
+def _write_manifest(path: Path, mode: str, primary_slug: str, run_id) -> None:
+    manifest = {
+        "role": "secondary",
+        "mode": mode,
+        "primary_slug": primary_slug,
+        "built_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "run_id": run_id,
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.dump(manifest, f, default_flow_style=False, sort_keys=False)
+
+
+def build_secondary_srts(talk_dir, primary_slug: str, run_id=None) -> list[dict]:
+    """Derive a UK SRT for every secondary video that can have one.
+
+    Returns one result dict per non-primary video:
+        {"slug", "status": "built"|"skipped", "mode": str|None, "reason": str|None}
+    Skipping (missing en.srt) is a normal outcome, not an error.
+    """
+    talk_dir = Path(talk_dir)
+    primary_en = talk_dir / primary_slug / "source" / "en.srt"
+    primary_uk = talk_dir / primary_slug / "final" / "uk.srt"
+
+    results: list[dict] = []
+    for slug in _video_slugs(talk_dir):
+        if slug == primary_slug:
+            continue
+
+        secondary_en = talk_dir / slug / "source" / "en.srt"
+        final_dir = talk_dir / slug / "final"
+        out = final_dir / "uk.srt"
+
+        if not primary_en.exists():
+            reason = f"primary {primary_slug} has no source/en.srt — no bridge to derive from"
+            print(f"SKIP {slug}: {reason}", file=sys.stderr)
+            results.append({"slug": slug, "status": "skipped", "mode": None, "reason": reason})
+            continue
+        if not secondary_en.exists():
+            reason = "no source/en.srt (raw recording, no English subtitles)"
+            print(f"SKIP {slug}: {reason}", file=sys.stderr)
+            results.append({"slug": slug, "status": "skipped", "mode": None, "reason": reason})
+            continue
+
+        final_dir.mkdir(parents=True, exist_ok=True)
+        offset = detect_offset(str(primary_en), str(secondary_en))
+        if offset is not None:
+            print(f"=== {slug}: constant offset {offset}ms → offset_srt apply", file=sys.stderr)
+            apply_offset(str(primary_uk), offset, str(out))
+            mode = "secondary-offset"
+        else:
+            print(f"=== {slug}: no constant offset → resync via en.srt word alignment", file=sys.stderr)
+            resync(str(primary_uk), str(primary_en), str(secondary_en), str(out))
+            mode = "secondary-resync"
+
+        _write_manifest(final_dir / "build_manifest.yaml", mode, primary_slug, run_id)
+        results.append({"slug": slug, "status": "built", "mode": mode, "reason": None})
+
+    built = sum(1 for r in results if r["status"] == "built")
+    skipped = sum(1 for r in results if r["status"] == "skipped")
+    print(f"Secondary build: {built} built, {skipped} skipped", file=sys.stderr)
+    return results
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Build UK SRTs for secondary videos of a multi-video talk")
+    p.add_argument("--talk-dir", required=True, help="Path to the talk directory (contains meta.yaml)")
+    p.add_argument("--primary-slug", required=True, help="Slug of the primary video")
+    p.add_argument("--run-id", default=None, help="CI run id, recorded in build_manifest.yaml")
+    args = p.parse_args()
+
+    run_id = args.run_id
+    if run_id is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            run_id = int(run_id)
+
+    build_secondary_srts(args.talk_dir, args.primary_slug, run_id=run_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem
The **Build secondary-video SRTs** step derived every non-primary video's `uk.srt` via `offset`/`resync` — both of which need `source/en.srt` on the **primary AND the secondary**. A secondary without `en.srt` (a raw recording with no English subtitles — a yogi-intro, a silent havan) made the inline bash crash under `bash -e`, failing the whole build so the run committed **nothing**. This hit multi-video talks repeatedly: 1992 Sahasrara, and this week #524 (1982 Guru Puja) + #525 (1982 England-Jerusalem).

## Fix
Extract the logic into a tested tool — `tools/build_secondary_srts.py` — and gate each secondary on **en.srt presence**, independent of `timing_source` (a talk built in *manual* whisper mode can still have `en.srt` files on disk to offset against, so the gate is files, not mode):
- primary `en.srt` **+** secondary `en.srt` present → `offset` (constant shift) or `resync` (word warp), as before;
- secondary (or primary) missing `en.srt` → **skip** with a logged reason, not a failure.

So the only videos left without subtitles are those with no English source to derive from — exactly the intent. The whisper↔whisper bridge for a no-en.srt secondary is left as a future enhancement.

The workflow step now just calls the tool (removing a fragile inline bash block that grep-parsed tool stdout).

## Tests (TDD)
`tests/test_build_secondary_srts.py`:
- **regression** for the crash: mixed secondaries (one with `en.srt`, one without) → builds the first, skips the second, **no crash**;
- offset-vs-resync selection (constant vs jittered shift);
- secondary without `en.srt` skipped; primary without `en.srt` skips all;
- `build_manifest.yaml` contents (role/mode/primary_slug/run_id).

Full suite: **966 passed**. Integration-checked against the real 1982 England talk data: `v2` → secondary-offset, `v3` → secondary-resync, `yogi-intro` → skipped, **exit 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)