### PR TITLE
test(infra): coverage in CI, pytest markers, faster/deterministic CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+          cache: 'pip'
       - run: pip install ruff==0.15.18
       - run: ruff check tools/ tests/
       - run: ruff format --check tools/ tests/
@@ -53,9 +54,12 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+          cache: 'pip'
       - run: pip install -r requirements.txt -r requirements-dev.txt
       - run: playwright install chromium --with-deps
-      - run: pytest tests/ -n auto --tb=short
+        # Coverage is report-only (no enforced floor yet) — surfaces the tools/
+        # coverage trend in the job log; see TESTING.md for local usage.
+      - run: pytest tests/ -n auto --tb=short --cov=tools --cov-report=term-missing
 
   test-js:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,12 @@ dist/
 build/
 .hypothesis/
 
+# Coverage artifacts
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+
 # IDE
 .idea/
 .vscode/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,15 @@ See `ARCHITECTURE.md` for full descriptions. In short:
 pip install -r requirements.txt
 pip install -r requirements-dev.txt                  # for tests
 python -m pytest tests/                              # run Python tests
+python -m pytest tests/ -m "not e2e"                 # fast lane (skip browser E2E)
 python -m pytest tests/test_offset_srt.py -k detect  # run a single test
+python -m pytest tests/ --cov=tools --cov-report=term-missing  # coverage
 GOLDEN_TALKS_SCOPE=all pytest tests/test_golden_talks.py  # full-corpus golden
 node --test tests/test_*.js                          # run JS (SPA) tests
 ```
+
+See `TESTING.md` for the full guide: markers, golden corpus, property tests,
+snapshots, and the `SY_E2E_REAL_VIMEO` network gate.
 
 ## Development (TDD required)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,101 @@
+# Testing Guide
+
+How the test suite is organised and how to run the parts you need. The
+project is **test-first** (see `CLAUDE.md` → Development) — every behaviour
+change starts with a failing test.
+
+## Layout
+
+| Suite | Runner | Files | What it covers |
+|-------|--------|-------|----------------|
+| Python | `pytest` | `tests/test_*.py` | `tools/*` — pipeline logic, validation, sync, build |
+| JavaScript | `node --test` | `tests/test_*.js` | `site/js/*` — SPA parsing/state, XSS guards, bookmarklet |
+
+Shared Python fixtures live in `tests/conftest.py`; data fixtures in
+`tests/fixtures/` (sample SRT/whisper/transcripts, parsed-HTML vectors,
+`pipeline_snapshots/`).
+
+## Running
+
+```bash
+# Everything (Python, parallel)
+pytest tests/ -n auto
+
+# JavaScript
+node --test tests/test_*.js
+
+# A single file / test
+pytest tests/test_optimize.py
+pytest tests/test_offset_srt.py -k detect
+```
+
+### Markers (run subsets)
+
+Markers are registered in `pyproject.toml`. The big lever is `e2e`, which
+tags the Playwright/browser tests (~410 of them):
+
+```bash
+# Fast lane — skip browser E2E (no chromium needed)
+pytest tests/ -n auto -m "not e2e"
+
+# Only the browser E2E
+pytest tests/ -n auto -m e2e
+```
+
+| Marker | Meaning |
+|--------|---------|
+| `e2e` | Browser/Playwright tests — slow, need `playwright install chromium`. |
+| `integration` | Multi-component / subprocess tests (e.g. dry-run matrix). |
+| `golden` | Regression over shipped talk corpora. |
+| `slow` | Wall-clock heavy (>1s). |
+| `flaky` | Retried via `pytest-rerunfailures` (browser timing under `-n auto`). |
+
+### Golden corpus
+
+```bash
+# Curated set (CI default)
+pytest tests/test_golden_talks.py
+# Full corpus (has known-broken xfails — see KNOWN_BROKEN_VALIDATION)
+GOLDEN_TALKS_SCOPE=all pytest tests/test_golden_talks.py
+```
+
+### Property-based tests (Hypothesis)
+
+`tests/test_property_invariants.py` proves invariants that must hold for *any*
+input (no overlaps, text preservation, monotonic timing, idempotent
+`optimize()`, …). These catch the failure modes that only surface at playback.
+
+### Coverage
+
+```bash
+pytest tests/ -n auto --cov=tools --cov-report=term-missing
+```
+
+CI runs the same flags **report-only** (no enforced floor yet); the trend
+shows in the `test` job log. JS coverage is not wired up yet (Node's
+`--experimental-test-coverage` is the intended path).
+
+## Determinism
+
+`tests/test_sync_player_integration.py` hits the **real** Vimeo SDK. It runs
+by default (including in CI — Vimeo is stable, and the class retries twice to
+absorb a transient blip). Opt out in offline/restricted environments with:
+
+```bash
+SY_E2E_REAL_VIMEO=0 pytest tests/test_sync_player_integration.py
+```
+
+Every other test runs against mocked fixtures (GitHub API, meta.yaml, SRTs)
+and makes no outbound calls.
+
+## Dry-run snapshots
+
+`tests/test_dryrun_matrix.py` replays the full pipeline against canned LLM
+responses in `tests/fixtures/pipeline_snapshots/`, then `tools.verify_snapshot`
+checks the output (text preservation, block-count tolerance, CPS, validation).
+
+> ⚠️ **Known gap:** the generator `tools/bootstrap_snapshot.py` was removed in
+> `c72e1b53` ("drop uk.map … legacy cleanup") but is still referenced by
+> `test_dryrun_matrix.py` and `tools/verify_snapshot.py`. Until it is restored
+> and modernised, snapshots cannot be regenerated from the documented
+> `python -m tools.bootstrap_snapshot --all`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.pytest.ini_options]
+# Project lint/format config lives in ruff.toml (authoritative); this file only
+# carries pytest settings. Markers are registered here so `-m` selection works
+# and unknown-marker warnings stay quiet. See TESTING.md for how to run subsets.
+testpaths = ["tests"]
+addopts = "--tb=short"
+markers = [
+    "e2e: browser/Playwright end-to-end tests — slow, need chromium. Deselect with -m 'not e2e'.",
+    "integration: multi-component or subprocess tests, slower than a unit test.",
+    "golden: regression checks over shipped talk corpora (see GOLDEN_TALKS_SCOPE).",
+    "slow: wall-clock heavy (>1s) tests.",
+    "flaky: known-flaky tests retried via pytest-rerunfailures.",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,8 @@
 pytest>=9.1.1
 pytest-xdist>=3.8
 pytest-rerunfailures>=16.3
+pytest-cov>=7.1
+coverage>=7.13
 ruff>=0.15.18
 pre-commit>=4.6.0
 playwright>=1.60.0

--- a/tests/test_dryrun_matrix.py
+++ b/tests/test_dryrun_matrix.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 ROOT = Path(__file__).resolve().parent.parent
 SNAPSHOT_ROOT = ROOT / "tests" / "fixtures" / "pipeline_snapshots"
 

--- a/tests/test_golden_talks.py
+++ b/tests/test_golden_talks.py
@@ -26,6 +26,8 @@ from tools.srt_utils import parse_srt
 from tools.validate_subtitles import manifest_validate_flags as _mode_flags
 from tools.validate_subtitles import validate
 
+pytestmark = pytest.mark.golden
+
 ROOT = Path(__file__).resolve().parent.parent
 TALKS = ROOT / "talks"
 

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -13,6 +13,8 @@ import yaml
 
 from tools.vimeo_codec import decode_video_ref
 
+pytestmark = pytest.mark.e2e
+
 SAMPLE_META = """title: 'Test Talk: Subtitle Preview'
 date: '2001-01-01'
 location: Test Location

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -25,7 +25,7 @@ from tests.test_preview_spa import (  # noqa: F401  — re-exported fixtures
 # SW install/activate/claim and the fetch chain are timing-sensitive under
 # `pytest -n auto` on a 2-core CI runner. The assertions are deterministic;
 # only the scheduling is not — so retry rather than widen the timeout forever.
-pytestmark = pytest.mark.flaky(reruns=2, reruns_delay=2)
+pytestmark = [pytest.mark.e2e, pytest.mark.flaky(reruns=2, reruns_delay=2)]
 
 CACHE = "sy-subtitles-c3"  # CACHE_NAME in sw.js (CACHE_VERSION = 3)
 SW_WAIT_MS = 15000

--- a/tests/test_sync_player.py
+++ b/tests/test_sync_player.py
@@ -29,7 +29,7 @@ from tests.test_preview_spa import (  # noqa: F401  — re-exported fixtures
 # even the widened 20s budget. Widening the timeout alone did not fully fix it,
 # so retry the (idempotent, read-only) tests; a genuine logic regression still
 # fails all attempts. Scoped to this module so it cannot mask flakes elsewhere.
-pytestmark = pytest.mark.flaky(reruns=2, reruns_delay=2)
+pytestmark = [pytest.mark.e2e, pytest.mark.flaky(reruns=2, reruns_delay=2)]
 
 # Single timeout budget for "wait for an SPA-rendered element" probes. The
 # click→mount chain that produces #mock-player is synchronous once the page has

--- a/tests/test_sync_player_integration.py
+++ b/tests/test_sync_player_integration.py
@@ -49,6 +49,8 @@ TEST_VIMEO_URL = decode_video_ref(TEST_VIDEO_REF)
 _SKIP_REAL = os.environ.get("SY_E2E_REAL_VIMEO", "1") == "0"
 _SKIP_REASON = "SY_E2E_REAL_VIMEO=0 — real Vimeo network access disabled"
 
+pytestmark = pytest.mark.e2e
+
 REAL_VIMEO_META = f"""title: 'Test Talk: Subtitle Preview'
 date: '2001-01-01'
 location: Test Location
@@ -158,6 +160,10 @@ def _goto_review_srt_real(page, server):  # noqa: F811
     page.wait_for_selector(".cell.uk", timeout=15000)
 
 
+# These run live in CI (Vimeo is a stable platform). reruns absorbs a rare
+# transient network blip so it cannot red-fail an unrelated PR — a genuine
+# Vimeo SDK/embed breakage still fails all attempts.
+@pytest.mark.flaky(reruns=2, reruns_delay=2)
 @pytest.mark.skipif(_SKIP_REAL, reason=_SKIP_REASON)
 class TestRealVimeoIntegration:
     def test_real_vimeo_sdk_loads(self, server, real_vimeo_page):  # noqa: F811


### PR DESCRIPTION
Infrastructure and ergonomics for the test suite — **no reduction in CI scope**.

## What
- **pyproject.toml**: register markers (`e2e`, `integration`, `golden`, `slow`,
  `flaky`). `pytest -m "not e2e"` runs the 554 fast tests locally and skips the
  ~410 browser/Playwright tests (no chromium needed). **CI still runs the FULL
  suite** — the marker is a local convenience only.
- Mark browser E2E files (`test_preview_spa`, `test_sync_player[_integration]`,
  `test_service_worker`) `e2e`; `test_dryrun_matrix` `integration`;
  `test_golden_talks` `golden`.
- **requirements-dev.txt**: add `pytest-cov` + `coverage`.
- **ci.yml**: cache pip; run pytest with `--cov=tools --cov-report=term-missing`
  (report-only, no floor yet).
- **Real-Vimeo integration tests keep running in CI** (Vimeo is stable). The
  class gains `flaky(reruns=2)` so a transient network blip can't red-fail an
  unrelated PR, while a genuine SDK/embed breakage still fails. The
  `SY_E2E_REAL_VIMEO=0` gate stays as an opt-out for offline/restricted envs.
- **TESTING.md**: new guide (layout, markers, golden corpus, property tests,
  coverage, the `SY_E2E_REAL_VIMEO` opt-out, and the missing `bootstrap_snapshot`).
- **CLAUDE.md**: link TESTING.md + fast-lane / coverage commands.
- **.gitignore**: ignore coverage artifacts.

Local `tools/` coverage baseline today is **69%** (966 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)