### PR TITLE
test: cover validate_artifacts error paths + extract_review CLI

### DIFF
--- a/tests/test_extract_review.py
+++ b/tests/test_extract_review.py
@@ -1,0 +1,40 @@
+"""Tests for tools.extract_review — SRT → '[N] text' review format."""
+
+from __future__ import annotations
+
+import sys
+
+from tools.extract_review import extract_review_text, main
+
+SAMPLE_SRT = "1\n00:00:01,000 --> 00:00:02,000\nHello there\n\n2\n00:00:03,000 --> 00:00:04,000\nsecond line\n\n"
+
+
+def test_extract_review_text_numbers_and_flattens():
+    blocks = [
+        {"idx": 1, "start_ms": 0, "end_ms": 1000, "text": "Hello there"},
+        {"idx": 2, "start_ms": 2000, "end_ms": 3000, "text": "wrapped\nover two"},
+    ]
+    assert extract_review_text(blocks) == "[1] Hello there\n[2] wrapped over two"
+
+
+def test_extract_review_text_empty_blocks():
+    assert extract_review_text([]) == ""
+
+
+def test_main_prints_to_stdout(tmp_path, monkeypatch, capsys):
+    srt = tmp_path / "in.srt"
+    srt.write_text(SAMPLE_SRT, encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["extract_review", "--srt", str(srt)])
+    main()
+    out = capsys.readouterr().out
+    assert "[1] Hello there" in out
+    assert "[2] second line" in out
+
+
+def test_main_writes_output_file(tmp_path, monkeypatch):
+    srt = tmp_path / "in.srt"
+    srt.write_text(SAMPLE_SRT, encoding="utf-8")
+    out = tmp_path / "review.txt"
+    monkeypatch.setattr(sys, "argv", ["extract_review", "--srt", str(srt), "--output", str(out)])
+    main()
+    assert out.read_text(encoding="utf-8") == "[1] Hello there\n[2] second line\n"

--- a/tests/test_validate_artifacts.py
+++ b/tests/test_validate_artifacts.py
@@ -8,11 +8,22 @@ to a maximum block count, instead of a strict 1..N sequence.
 
 from __future__ import annotations
 
+import json
+import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
-from tools.validate_artifacts import _check_timecodes
+from tools.validate_artifacts import (
+    _check_meta,
+    _check_talk_dir,
+    _check_timecodes,
+    _check_whisper,
+    main,
+)
+
+from .test_schemas import GOOD_META, GOOD_WHISPER
 
 
 def _write(path: Path, ids_with_times: list[tuple[int, str, str]]) -> Path:
@@ -121,3 +132,140 @@ def test_max_blocks_enforced(tmp_path):
     # Fail: over max
     with pytest.raises(SystemExit):
         _check_timecodes(str(p), allow_skipped_ids=True, max_blocks=3)
+
+
+# ---------------------------------------------------------------------------
+#  _check_timecodes structural failures (the safety net must reject bad output)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_timecodes_file_is_rejected(tmp_path):
+    with pytest.raises(SystemExit):
+        _check_timecodes(str(tmp_path / "absent.txt"))
+
+
+def test_malformed_timecode_line_is_rejected(tmp_path):
+    p = tmp_path / "tc.txt"
+    p.write_text("#1 | not-a-timestamp | also-not\n", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        _check_timecodes(str(p))
+
+
+def test_start_not_before_end_is_rejected(tmp_path):
+    # start == end is invalid (zero/negative duration block).
+    p = _write(tmp_path / "tc.txt", [(1, "00:00:05,000", "00:00:05,000")])
+    with pytest.raises(SystemExit):
+        _check_timecodes(str(p))
+
+
+def test_blank_only_timecodes_reports_no_blocks(tmp_path):
+    p = tmp_path / "tc.txt"
+    p.write_text("\n   \n\n", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        _check_timecodes(str(p))
+
+
+# ---------------------------------------------------------------------------
+#  Whisper / meta schema gates
+# ---------------------------------------------------------------------------
+
+
+def test_check_whisper_accepts_valid(tmp_path, capsys):
+    p = tmp_path / "whisper.json"
+    p.write_text(json.dumps(GOOD_WHISPER), encoding="utf-8")
+    _check_whisper(str(p))
+    assert "OK: whisper" in capsys.readouterr().out
+
+
+def test_check_whisper_rejects_missing_segments(tmp_path):
+    p = tmp_path / "whisper.json"
+    p.write_text(json.dumps({"language": "en"}), encoding="utf-8")
+    with pytest.raises(SystemExit):
+        _check_whisper(str(p))
+
+
+def test_check_meta_accepts_valid(tmp_path, capsys):
+    p = tmp_path / "meta.yaml"
+    p.write_text(yaml.safe_dump(GOOD_META, allow_unicode=True), encoding="utf-8")
+    _check_meta(str(p))
+    assert "OK: meta" in capsys.readouterr().out
+
+
+def test_check_meta_rejects_bad_date(tmp_path):
+    p = tmp_path / "meta.yaml"
+    p.write_text(yaml.safe_dump(dict(GOOD_META, date="not-a-date")), encoding="utf-8")
+    with pytest.raises(SystemExit):
+        _check_meta(str(p))
+
+
+# ---------------------------------------------------------------------------
+#  _check_talk_dir — whole-talk artifact sweep
+# ---------------------------------------------------------------------------
+
+
+def test_talk_dir_missing_meta_is_rejected(tmp_path):
+    with pytest.raises(SystemExit):
+        _check_talk_dir(str(tmp_path))
+
+
+def test_talk_dir_validates_meta_whisper_and_timecodes(tmp_path, capsys):
+    (tmp_path / "meta.yaml").write_text(yaml.safe_dump(GOOD_META, allow_unicode=True), encoding="utf-8")
+    video = tmp_path / "Some-Video"
+    (video / "source").mkdir(parents=True)
+    (video / "work").mkdir(parents=True)
+    (video / "source" / "whisper.json").write_text(json.dumps(GOOD_WHISPER), encoding="utf-8")
+    _write(video / "work" / "timecodes.txt", [(1, "00:00:01,000", "00:00:03,000")])
+    _check_talk_dir(str(tmp_path))
+    out = capsys.readouterr().out
+    assert "OK: meta" in out and "OK: whisper" in out and "OK: timecodes" in out
+
+
+# ---------------------------------------------------------------------------
+#  CLI entry point (argparse dispatch + exit codes)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_requires_at_least_one_input(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["validate_artifacts"])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 2  # argparse parser.error
+
+
+def test_cli_timecodes_ok_returns_cleanly(tmp_path, monkeypatch, capsys):
+    p = _write(tmp_path / "tc.txt", [(1, "00:00:01,000", "00:00:03,000")])
+    monkeypatch.setattr(sys, "argv", ["validate_artifacts", "--timecodes", str(p)])
+    main()  # must not raise
+    assert "OK: timecodes" in capsys.readouterr().out
+
+
+def test_cli_bad_timecodes_exits_nonzero(tmp_path, monkeypatch):
+    p = tmp_path / "tc.txt"
+    p.write_text("garbage line\n", encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["validate_artifacts", "--timecodes", str(p)])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1  # _fail()
+
+
+def test_cli_whisper_dispatch(tmp_path, monkeypatch, capsys):
+    p = tmp_path / "whisper.json"
+    p.write_text(json.dumps(GOOD_WHISPER), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["validate_artifacts", "--whisper", str(p)])
+    main()
+    assert "OK: whisper" in capsys.readouterr().out
+
+
+def test_cli_meta_dispatch(tmp_path, monkeypatch, capsys):
+    p = tmp_path / "meta.yaml"
+    p.write_text(yaml.safe_dump(GOOD_META, allow_unicode=True), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["validate_artifacts", "--meta", str(p)])
+    main()
+    assert "OK: meta" in capsys.readouterr().out
+
+
+def test_cli_talk_dir_dispatch(tmp_path, monkeypatch, capsys):
+    (tmp_path / "meta.yaml").write_text(yaml.safe_dump(GOOD_META, allow_unicode=True), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["validate_artifacts", "--talk-dir", str(tmp_path)])
+    main()
+    assert "OK: meta" in capsys.readouterr().out


### PR DESCRIPTION
Closes the two lowest-covered safety-net modules from the testing audit. Both
were happy-path-only (or untested); these prove the validators actually
**reject** bad artifacts and exercise the CLI entry points.

## Coverage
- `tools/validate_artifacts.py`: **47% → 99%**
- `tools/extract_review.py`: **0% → 96%**

## What
- validate_artifacts negative tests: `_check_timecodes` (missing file, malformed
  line, start≥end, no blocks); whisper/meta schema gates (valid + rejected);
  `_check_talk_dir` (missing meta + full sweep); `main()` CLI (no input → exit 2,
  bad timecodes → exit 1, all `--whisper/--meta/--timecodes/--talk-dir`
  dispatch). Reuses `GOOD_WHISPER`/`GOOD_META` from test_schemas.
- new `tests/test_extract_review.py`: formatter (numbering, newline flattening,
  empty input) + CLI (stdout and `--output`).

Additive only — no production or fixture changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)