### PR TITLE
test: cover align_uk LLM orchestrator + optimize_srt CLI

### DIFF
--- a/tests/test_align_uk.py
+++ b/tests/test_align_uk.py
@@ -1,11 +1,22 @@
 """Tests for tools.align_uk."""
 
+import json
+import subprocess
+import sys
+from types import SimpleNamespace
+
 from tools.align_uk import (
+    align,
+    align_words,
+    build_word_alignment_prompt,
+    call_claude_for_alignment,
     distribute_text_to_segments,
     group_whisper_by_pauses,
     load_transcript,
+    main,
     map_paragraphs_to_segments,
     validate_segments,
+    write_uk_whisper,
 )
 
 # --- load_transcript ---
@@ -200,3 +211,170 @@ def test_validate_non_monotonic():
     ]
     warnings = validate_segments(segments)
     assert any("non-monotonic" in w for w in warnings)
+
+
+# --- build_word_alignment_prompt ---
+
+
+def test_build_prompt_contains_segment_words_and_format():
+    batch = [
+        {
+            "id": 3,
+            "start": 1.0,
+            "end": 2.0,
+            "uk_text": "привіт світ",
+            "en_words": [{"start": 1.0, "end": 2.0, "word": "hello"}],
+        }
+    ]
+    prompt = build_word_alignment_prompt(batch)
+    assert "Segment 3" in prompt
+    assert "привіт світ" in prompt
+    assert "hello" in prompt
+    assert "JSON" in prompt  # output-format instruction present
+
+
+# --- call_claude_for_alignment (subprocess boundary mocked) ---
+
+
+def _fake_run(stdout="", returncode=0, stderr=""):
+    return lambda *a, **k: SimpleNamespace(stdout=stdout, returncode=returncode, stderr=stderr)
+
+
+def test_call_claude_parses_json_array(monkeypatch):
+    monkeypatch.setattr(
+        "tools.align_uk.subprocess.run",
+        _fake_run(stdout='preamble [{"id": 1, "words": []}] trailing'),
+    )
+    assert call_claude_for_alignment("p") == [{"id": 1, "words": []}]
+
+
+def test_call_claude_nonzero_returns_none(monkeypatch):
+    monkeypatch.setattr("tools.align_uk.subprocess.run", _fake_run(returncode=1, stderr="boom"))
+    assert call_claude_for_alignment("p") is None
+
+
+def test_call_claude_no_json_returns_none(monkeypatch):
+    monkeypatch.setattr("tools.align_uk.subprocess.run", _fake_run(stdout="no json here"))
+    assert call_claude_for_alignment("p") is None
+
+
+def test_call_claude_timeout_returns_none(monkeypatch):
+    def _boom(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="claude", timeout=120)
+
+    monkeypatch.setattr("tools.align_uk.subprocess.run", _boom)
+    assert call_claude_for_alignment("p") is None
+
+
+def test_call_claude_missing_cli_returns_none(monkeypatch):
+    def _boom(*a, **k):
+        raise FileNotFoundError("claude")
+
+    monkeypatch.setattr("tools.align_uk.subprocess.run", _boom)
+    assert call_claude_for_alignment("p") is None
+
+
+# --- align_words (Claude call mocked) ---
+
+
+def test_align_words_uniform_when_segment_has_no_en_words():
+    segs = [{"id": 1, "start": 0.0, "end": 2.0, "text": "слово два", "words": []}]
+    whisper = [{"id": 1, "start": 0.0, "end": 2.0, "words": []}]
+    out = align_words(segs, whisper)
+    assert [w["word"] for w in out[0]["words"]] == ["слово", "два"]
+    assert out[0]["words"][0]["start"] == 0.0
+    assert out[0]["words"][-1]["end"] == 2.0
+
+
+def test_align_words_skips_empty_text_segment(monkeypatch):
+    segs = [{"id": 1, "start": 0.0, "end": 2.0, "text": "", "words": []}]
+    whisper = [{"id": 1, "start": 0.0, "end": 2.0, "words": []}]
+    monkeypatch.setattr("tools.align_uk.call_claude_for_alignment", lambda prompt: None)
+    out = align_words(segs, whisper)
+    assert out[0]["words"] == []  # untouched — nothing to align
+
+
+def test_align_words_applies_claude_result(monkeypatch):
+    segs = [{"id": 1, "start": 0.0, "end": 2.0, "text": "aa bb", "words": []}]
+    whisper = [
+        {"id": 1, "start": 0.0, "end": 2.0, "words": [{"start": 0.0, "end": 2.0, "word": "x"}]},
+    ]
+    canned = [{"id": 1, "words": [{"start": 0.0, "end": 1.0, "word": "aa"}, {"start": 1.0, "end": 2.0, "word": "bb"}]}]
+    monkeypatch.setattr("tools.align_uk.call_claude_for_alignment", lambda prompt: canned)
+    out = align_words(segs, whisper)
+    assert out[0]["words"] == canned[0]["words"]
+
+
+def test_align_words_falls_back_to_uniform_on_claude_failure(monkeypatch):
+    segs = [{"id": 1, "start": 0.0, "end": 2.0, "text": "aa bb", "words": []}]
+    whisper = [{"id": 1, "start": 0.0, "end": 2.0, "words": [{"start": 0.0, "end": 2.0, "word": "x"}]}]
+    monkeypatch.setattr("tools.align_uk.call_claude_for_alignment", lambda prompt: None)
+    out = align_words(segs, whisper)
+    assert [w["word"] for w in out[0]["words"]] == ["aa", "bb"]  # uniform fallback
+
+
+# --- write_uk_whisper ---
+
+
+def test_write_uk_whisper_writes_language_and_segments(tmp_path):
+    segs = [{"id": 1, "start": 0.0, "end": 1.0, "text": "x", "words": []}]
+    out = tmp_path / "uk_whisper.json"
+    write_uk_whisper(segs, str(out))
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["language"] == "uk"
+    assert data["segments"] == segs
+
+
+# --- align() + main() end-to-end (no Claude: --skip-word-align) ---
+
+
+def test_align_skip_word_align_writes_output(tmp_path, sample_transcript_uk_path, sample_whisper_path):
+    out = tmp_path / "uk_whisper.json"
+    segments = align(
+        str(sample_transcript_uk_path),
+        str(sample_whisper_path),
+        str(out),
+        skip_word_align=True,
+    )
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["language"] == "uk"
+    assert len(data["segments"]) == len(segments)
+    # uniform word timestamps were assigned for non-empty segments
+    assert any(seg.get("words") for seg in data["segments"])
+
+
+def test_align_runs_word_alignment_when_not_skipped(
+    tmp_path, monkeypatch, sample_transcript_uk_path, sample_whisper_path
+):
+    # Mock the Claude boundary so the word-alignment path runs without a CLI.
+    monkeypatch.setattr("tools.align_uk.call_claude_for_alignment", lambda prompt: None)
+    out = tmp_path / "uk_whisper.json"
+    segments = align(
+        str(sample_transcript_uk_path),
+        str(sample_whisper_path),
+        str(out),
+        skip_word_align=False,
+    )
+    assert out.is_file()
+    assert len(segments) > 0
+
+
+def test_main_cli_skip_word_align(tmp_path, monkeypatch, sample_transcript_uk_path, sample_whisper_path):
+    out = tmp_path / "uk_whisper.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "align_uk",
+            "--transcript",
+            str(sample_transcript_uk_path),
+            "--whisper-json",
+            str(sample_whisper_path),
+            "--output",
+            str(out),
+            "--skip-word-align",
+        ],
+    )
+    main()
+    assert out.is_file()
+    assert json.loads(out.read_text(encoding="utf-8"))["language"] == "uk"

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,6 +1,9 @@
 """Tests for tools.optimize_srt."""
 
 import json
+import sys
+
+import pytest
 
 from tools.config import OptimizeConfig
 from tools.optimize_srt import (
@@ -8,11 +11,13 @@ from tools.optimize_srt import (
     cascade_redistribute,
     find_best_split_point,
     find_block_split_point,
+    main,
     merge_short_blocks,
     optimize,
     split_blocks_by_duration,
     split_blocks_by_size,
 )
+from tools.srt_utils import parse_srt
 
 # --- find_best_split_point ---
 
@@ -264,3 +269,28 @@ def test_cascade_redistribute_leaves_soft_blocks_untouched():
     before = [(b["start_ms"], b["end_ms"]) for b in blocks]
     result = cascade_redistribute(blocks, config, [])
     assert [(b["start_ms"], b["end_ms"]) for b in result] == before
+
+
+# --- CLI entry point ---
+
+
+def test_main_requires_srt_or_uk_json(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "argv", ["optimize_srt", "--output", str(tmp_path / "o.srt")])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 2  # argparse parser.error
+
+
+def test_main_optimizes_srt_file(monkeypatch, tmp_path):
+    src = tmp_path / "in.srt"
+    src.write_text(
+        "1\n00:00:01,000 --> 00:00:05,000\nHello world this is a sample subtitle line\n\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "out.srt"
+    monkeypatch.setattr(sys, "argv", ["optimize_srt", "--srt", str(src), "--output", str(out)])
+    main()
+    assert out.is_file()
+    blocks = parse_srt(str(out))
+    assert len(blocks) >= 1
+    assert all(b["start_ms"] < b["end_ms"] for b in blocks)


### PR DESCRIPTION
Lifts the worst-covered core module and closes two untested CLI entry points.
Additive only — no production changes.

## Coverage
- `tools/align_uk.py`: **45% → 95%**
- `tools/optimize_srt.py`: `main()` CLI now covered

## What
- **align_uk**: mocks the Claude boundary (`call_claude_for_alignment` /
  `subprocess.run`) to exercise `align_words` — Claude success, uniform fallback
  on failure, no-en-words uniform path, empty-text skip — without a CLI. Pure
  tests for `build_word_alignment_prompt` and `write_uk_whisper`; the
  `call_claude` error branches (non-zero, no-JSON, timeout, missing CLI); and
  `align()`/`main()` end-to-end via `--skip-word-align` + a mocked word-align run.
- **optimize_srt**: `main()` requires `--srt`/`--uk-json` (exit 2) and a full
  `--srt → --output` run producing a valid SRT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)