### PR TITLE
test(cleanup): consolidate duplicated _write_srt helpers

### DIFF
--- a/tests/srt_helpers.py
+++ b/tests/srt_helpers.py
@@ -1,0 +1,44 @@
+"""Shared SRT-writing helpers for tests — single source for fixture SRTs.
+
+Two call styles, matching how tests already author SRTs:
+
+- ``write_srt_timecodes`` takes ``(idx, start, end, text)`` rows where start/end
+  are SRT timecode strings (``"00:00:01,000"``). Use when the test cares about
+  exact, hand-written timecodes.
+- ``write_srt_ms`` takes ``(start_ms, end_ms, text)`` rows and auto-numbers from
+  1, formatting milliseconds into timecodes. Use when the test works in ms.
+
+Both write byte-identical output to the per-file helpers they replaced.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _fmt_ms(ms: int) -> str:
+    h = ms // 3600000
+    ms %= 3600000
+    m = ms // 60000
+    ms %= 60000
+    s = ms // 1000
+    ms %= 1000
+    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+
+def write_srt_timecodes(path, rows: list[tuple[int, str, str, str]]) -> None:
+    """Write an SRT from ``(idx, start_timecode, end_timecode, text)`` rows."""
+    lines: list[str] = []
+    for idx, start, end, text in rows:
+        lines += [str(idx), f"{start} --> {end}", text, ""]
+    Path(path).write_text("\n".join(lines), encoding="utf-8")
+
+
+def write_srt_ms(path, blocks: list[tuple[int, int, str]]) -> None:
+    """Write an SRT from ``(start_ms, end_ms, text)`` blocks, numbered from 1."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = []
+    for i, (start_ms, end_ms, text) in enumerate(blocks, 1):
+        lines += [str(i), f"{_fmt_ms(start_ms)} --> {_fmt_ms(end_ms)}", text, ""]
+    p.write_text("\n".join(lines), encoding="utf-8")

--- a/tests/test_build_secondary_srts.py
+++ b/tests/test_build_secondary_srts.py
@@ -14,27 +14,9 @@ from pathlib import Path
 
 import yaml
 
+from tests.srt_helpers import write_srt_ms as _write_srt
 from tools.build_secondary_srts import build_secondary_srts
 from tools.srt_utils import parse_srt
-
-
-def _tc(ms: int) -> str:
-    h = ms // 3600000
-    ms %= 3600000
-    m = ms // 60000
-    ms %= 60000
-    s = ms // 1000
-    ms %= 1000
-    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
-
-
-def _write_srt(path: Path, blocks: list[tuple[int, int, str]]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    lines: list[str] = []
-    for i, (start, end, text) in enumerate(blocks, 1):
-        lines += [str(i), f"{_tc(start)} --> {_tc(end)}", text, ""]
-    path.write_text("\n".join(lines), encoding="utf-8")
-
 
 _EN_TEXT = [f"This is sentence number {i} of the talk today." for i in range(1, 13)]
 _UK_TEXT = [f"Це речення номер {i} сьогоднішньої промови." for i in range(1, 13)]

--- a/tests/test_offset_srt.py
+++ b/tests/test_offset_srt.py
@@ -1,29 +1,8 @@
 """Tests for offset_srt.py — detect and apply time offsets between SRT files."""
 
+from tests.srt_helpers import write_srt_ms as _write_srt
 from tools.offset_srt import apply_offset, detect_offset, normalize_text, text_similarity
 from tools.srt_utils import parse_srt
-
-
-def _write_srt(path, blocks):
-    """Helper: write a list of (start_ms, end_ms, text) tuples as an SRT file."""
-    lines = []
-    for i, (start_ms, end_ms, text) in enumerate(blocks, 1):
-
-        def _fmt(ms):
-            h = ms // 3600000
-            ms %= 3600000
-            m = ms // 60000
-            ms %= 60000
-            s = ms // 1000
-            ms %= 1000
-            return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
-
-        lines.append(str(i))
-        lines.append(f"{_fmt(start_ms)} --> {_fmt(end_ms)}")
-        lines.append(text)
-        lines.append("")
-    path.write_text("\n".join(lines), encoding="utf-8")
-
 
 # ---------------------------------------------------------------------------
 # Unit tests for helper functions

--- a/tests/test_resync_srt.py
+++ b/tests/test_resync_srt.py
@@ -2,26 +2,15 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
+from tests.srt_helpers import write_srt_timecodes as _write_srt
 from tools.resync_srt import _build_anchor_map, _remap, resync
 from tools.srt_utils import parse_srt
 
 
 def _ms(h: int, m: int, s: int, ms: int = 0) -> str:
     return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
-
-
-def _write_srt(path: Path, rows: list[tuple[int, str, str, str]]) -> None:
-    lines = []
-    for idx, start, end, text in rows:
-        lines.append(str(idx))
-        lines.append(f"{start} --> {end}")
-        lines.append(text)
-        lines.append("")
-    path.write_text("\n".join(lines), encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+from tests.srt_helpers import write_srt_timecodes as _write_srt
 from tools.config import OptimizeConfig
 from tools.validate_subtitles import (
     TimeAnchor,
@@ -69,20 +70,6 @@ def test_strip_header_header_beyond_10_lines():
 # ---------------------------------------------------------------------------
 #  Helpers for building test SRT / transcript files
 # ---------------------------------------------------------------------------
-
-
-def _write_srt(path, blocks):
-    """Write a minimal SRT file from a list of (idx, start, end, text) tuples.
-
-    *start* and *end* are SRT timecodes like ``"00:00:01,000"``.
-    """
-    lines = []
-    for idx, start, end, text in blocks:
-        lines.append(str(idx))
-        lines.append(f"{start} --> {end}")
-        lines.append(text)
-        lines.append("")
-    path.write_text("\n".join(lines), encoding="utf-8")
 
 
 def _write_transcript(path, text):


### PR DESCRIPTION
The audit found `_write_srt` copy-pasted across 4 test files in two signature
families. Extracted both into a single `tests/srt_helpers` module:

- `write_srt_timecodes(path, rows)` — `(idx, start_timecode, end_timecode, text)`
- `write_srt_ms(path, blocks)` — `(start_ms, end_ms, text)`, numbered from 1

`test_validate` / `test_resync_srt` use the timecode variant; `test_offset_srt`
/ `test_build_secondary_srts` use the ms variant — each aliased to the local
`_write_srt` name so **call sites are unchanged**. Output is byte-identical to
the helpers it replaces, so every test stays green (554 non-browser tests pass).

Removes ~50 lines of duplication plus the nested `_fmt` / `_tc` formatters.
Net −19 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)