### PR TITLE
SW offline: routing module + lifecycle/offline E2E + cache-first content + live offline badge

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -19,6 +19,7 @@
 <script src="js/preview_state.js"></script>
 <script src="js/index_url_state.js"></script>
 <script src="js/manifest_fetch.js"></script>
+<script src="js/offline_fallback.js"></script>
 <script src="js/talk_slug.js"></script>
 <script src="js/vimeo_codec.js"></script>
 <script src="js/add_talk_data.js"></script>
@@ -1913,6 +1914,7 @@ var I18N = {
 
     'add.link': '+ \u0414\u043E\u0434\u0430\u0442\u0438',
     'error.srt': '\u041F\u043E\u043C\u0438\u043B\u043A\u0430 \u0437\u0430\u0432\u0430\u043D\u0442\u0430\u0436\u0435\u043D\u043D\u044F \u0441\u0443\u0431\u0442\u0438\u0442\u0440\u0456\u0432',
+    'error.offline_content': '\u041D\u0435\u0434\u043E\u0441\u0442\u0443\u043F\u043D\u043E \u043E\u0444\u043B\u0430\u0439\u043D \u2014 \u0432\u0456\u0434\u043A\u0440\u0438\u0439\u0442\u0435 \u043E\u043D\u043B\u0430\u0439\u043D, \u0449\u043E\u0431 \u0437\u0431\u0435\u0440\u0435\u0433\u0442\u0438 \u0432 \u043A\u0435\u0448',
     'error.rate_limit': '\u041B\u0456\u043C\u0456\u0442 \u0437\u0430\u043F\u0438\u0442\u0456\u0432 GitHub. \u041F\u043E\u043A\u0430\u0437\u0430\u043D\u043E \u043A\u0435\u0448; \u043E\u043D\u043E\u0432\u043B\u0435\u043D\u043D\u044F \u0437\u0430 {min} \u0445\u0432',
     'error.rate_limit_nocache': '\u041B\u0456\u043C\u0456\u0442 \u0437\u0430\u043F\u0438\u0442\u0456\u0432 GitHub. \u0421\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0437\u0430 {min} \u0445\u0432',
     'error.stale_cache': '\u041D\u0435\u043C\u0430\u0454 \u0437\u0432\u02BC\u044F\u0437\u043A\u0443 \u2014 \u043F\u043E\u043A\u0430\u0437\u0430\u043D\u043E \u0437\u0431\u0435\u0440\u0435\u0436\u0435\u043D\u0443 \u0432\u0435\u0440\u0441\u0456\u044E',
@@ -2041,6 +2043,7 @@ var I18N = {
 
     'add.link': '+ Add Talk',
     'error.srt': 'Error loading subtitles',
+    'error.offline_content': 'Unavailable offline — open it online once to cache it',
     'error.rate_limit': 'GitHub rate limit reached. Showing cached data; refresh in {min} min',
     'error.rate_limit_nocache': 'GitHub rate limit reached. Try again in {min} min',
     'error.stale_cache': 'Offline — showing the cached version',
@@ -3008,7 +3011,10 @@ function loadSubtitleLang(lang) {
     })
     .catch(function(err) {
       console.warn('[SPA] SRT error:', err);
-      document.getElementById('subtitle-overlay').textContent = t('error.srt');
+      // Non-blocking: keep the page usable. Offline gets a clearer note than the
+      // generic load error; the freshness-bar offline badge is the global signal.
+      document.getElementById('subtitle-overlay').textContent =
+        isOfflineError(err, navigator.onLine) ? t('error.offline_content') : t('error.srt');
       return false;
     });
 }
@@ -4609,7 +4615,8 @@ function showReview(talkId) {
       SPA.openTranscriptVideo(savedSlug);
     }
   }).catch(function(err) {
-    statusEl.textContent = t('review.load_error').replace('{err}', err);
+    statusEl.textContent = isOfflineError(err, navigator.onLine)
+      ? t('error.offline_content') : t('review.load_error').replace('{err}', err);
     statusEl.classList.add('status-error');
   });
 }
@@ -4830,7 +4837,8 @@ SPA.switchReviewMode = function(mode, videoSlug) {
     statusEl.style.display = 'none';
     statusEl.classList.remove('status-error');
   }).catch(function(err) {
-    statusEl.textContent = t('review.srt_load_error').replace('{err}', err);
+    statusEl.textContent = isOfflineError(err, navigator.onLine)
+      ? t('error.offline_content') : t('review.srt_load_error').replace('{err}', err);
     statusEl.classList.add('status-error');
   });
 };
@@ -5419,15 +5427,36 @@ var _staleDismissed = false;
 function updateStaleIndicator() {
   var el = document.getElementById('stale-indicator');
   if (!el) return;
+  var txt = el.querySelector('.stale-text');
+  var x = el.querySelector('.stale-x');
+  // Live device offline takes priority over manifest staleness and is NOT
+  // dismissable — it is real connectivity state, refreshed by the online/offline
+  // listeners below. Visible on every view (the freshness bar is sticky), so the
+  // user always knows they are offline while they keep working with cached data.
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    if (txt) txt.textContent = t('freshness.offline');
+    // No dismiss × on a live offline state — it can't be dismissed; drop it and
+    // keep the padding symmetric. The × stays for the dismissable stale notice.
+    if (x) x.style.display = 'none';
+    el.style.paddingRight = '8px';
+    el.style.display = 'inline-flex';
+    return;
+  }
+  if (x) x.style.display = '';
+  el.style.paddingRight = '';
   var notice = staleNotice(manifest, Date.now());
   if (!notice) { _staleDismissed = false; el.style.display = 'none'; return; }
   if (_staleDismissed) { el.style.display = 'none'; return; }
   var msg = t(notice.key);
   if (notice.min != null) msg = msg.replace('{min}', notice.min);
-  var txt = el.querySelector('.stale-text');
   if (txt) txt.textContent = msg;
   el.style.display = 'inline-flex';
 }
+
+// Reflect real connectivity in the freshness-bar badge the moment it changes —
+// not only when a manifest refresh happens to detect staleness.
+window.addEventListener('online', updateStaleIndicator);
+window.addEventListener('offline', updateStaleIndicator);
 SPA.dismissStale = function() {
   _staleDismissed = true;
   updateStaleIndicator();
@@ -5800,11 +5829,22 @@ function applyExpertMode() {
 }
 applyExpertMode();
 
-// Service Worker registration (skip on localhost for dev/test)
-// Browser auto-detects sw.js changes by comparing byte-for-byte
-if ('serviceWorker' in navigator && location.hostname !== '127.0.0.1' && location.hostname !== 'localhost') {
-  navigator.serviceWorker.register('sw.js').catch(function() {});
-}
+// Reflect an offline-at-load state in the freshness bar immediately, before any
+// manifest fetch resolves.
+updateStaleIndicator();
+
+// Service Worker registration. Skipped on localhost by default (so dev edits are
+// never served from a stale SW cache), but ?sw=1 opts in locally to exercise the
+// real offline / cache-first flow that only the SW provides. Browser auto-detects
+// sw.js changes by comparing byte-for-byte.
+(function() {
+  if (!('serviceWorker' in navigator)) return;
+  var isLocal = location.hostname === '127.0.0.1' || location.hostname === 'localhost';
+  var swOptIn = /[?&]sw=1(&|$)/.test(location.search);
+  if (!isLocal || swOptIn) {
+    navigator.serviceWorker.register('sw.js').catch(function() {});
+  }
+})();
 </script>
 </body>
 </html>

--- a/site/js/offline_fallback.js
+++ b/site/js/offline_fallback.js
@@ -1,0 +1,22 @@
+// Decide whether a failed content (SRT/transcript) load is an offline situation
+// — so the SPA can show a friendly "available online only" screen instead of a
+// cryptic inline error. Single source: loaded by the browser via
+// <script src="js/offline_fallback.js"> in site/index.html AND required by the
+// Node test suite — no inline mirror.
+//
+// With sha-pinned content served cache-first by the service worker, a content
+// fetch only fails offline when that talk was never cached — exactly the case
+// this screen exists for.
+
+function isOfflineError(err, online) {
+  // The browser explicitly reports no connection — always offline.
+  if (online === false) return true;
+  // Online (or unknown) but fetch() rejected on its own: a network TypeError
+  // (dropped connection / DNS / CORS), with no HTTP status. An Error carrying a
+  // status, or any non-network throw (HTTP 404, a parse error), is NOT offline.
+  return !!err && err.name === 'TypeError' && err.status == null;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { isOfflineError: isOfflineError };
+}

--- a/site/js/sw_routing.js
+++ b/site/js/sw_routing.js
@@ -32,11 +32,29 @@ function isNavigation(url) {
   return url.endsWith('/') || url.endsWith('/index.html') || url.indexOf('sy-subtitles/#') !== -1;
 }
 
-// The single source of truth for the fetch handler's branch. Navigation + the
-// GitHub API/raw endpoints are network-first (always prefer fresh, fall back to
-// cache offline); truly-immutable assets are cache-first; everything else
-// (app js/css, the Vimeo iframe) is network-first.
+// Subtitle/transcript content is fetched with a ?v=<blob sha> cache-buster
+// (final/<lang>.srt, transcript_<lang>.txt, source/<lang>.srt, review-status.json):
+// the URL is content-addressed, so its bytes never change. A non-empty v param
+// marks such an immutable-by-URL resource. meta.yaml (no ?v=) and the Trees API
+// (?recursive=1) carry no v and stay network-first.
+function hasImmutableVersion(url) {
+  try {
+    return !!new URL(url).searchParams.get('v');
+  } catch (e) {
+    return false;
+  }
+}
+
+// The single source of truth for the fetch handler's branch.
+//  - sha-pinned content (?v=) → cache-first: instant offline + zero redundant
+//    refetch; a new build changes the sha → the URL, so a cache miss on the new
+//    key still fetches fresh. Checked FIRST so it wins over the raw network-first.
+//  - navigation + the GitHub API/raw endpoints → network-first (prefer fresh,
+//    fall back to cache offline).
+//  - truly-immutable CDN/static assets → cache-first.
+//  - everything else (app js/css, the Vimeo iframe) → network-first.
 function pickStrategy(url) {
+  if (hasImmutableVersion(url)) return 'cache-first';
   if (isNavigation(url) || isApiOrRaw(url)) return 'network-first';
   if (isImmutable(url)) return 'cache-first';
   return 'network-first';
@@ -48,6 +66,7 @@ if (typeof module !== 'undefined' && module.exports) {
     isImmutable: isImmutable,
     isApiOrRaw: isApiOrRaw,
     isNavigation: isNavigation,
+    hasImmutableVersion: hasImmutableVersion,
     pickStrategy: pickStrategy,
   };
 }

--- a/site/js/sw_routing.js
+++ b/site/js/sw_routing.js
@@ -1,0 +1,53 @@
+// Service-worker routing decision — which caching strategy a request gets.
+// Single source: loaded by the worker via importScripts('js/sw_routing.js') in
+// site/sw.js AND required by the Node test suite (tests/test_sw_routing.js) — no
+// inline mirror, so the worker and the tests can never drift.
+//
+// The strategy mechanics (networkFirst/cacheFirst, which touch caches+fetch) stay
+// in sw.js; only the pure decision lives here, because that is where the bugs are
+// (host-vs-substring matching, the navigation URL forms).
+
+// Versioned CDN bundles and static images — safe to serve cache-first.
+var IMMUTABLE_PATTERNS = ['cdn.jsdelivr.net', 'player.vimeo.com/api', '/icon.png'];
+
+function isImmutable(url) {
+  return IMMUTABLE_PATTERNS.some(function (p) { return url.indexOf(p) !== -1; });
+}
+
+function isApiOrRaw(url) {
+  // Match on the actual host, not a substring: "https://evil.com/?x=api.github.com"
+  // must not be treated as a GitHub API/raw request. Both hosts are used bare by
+  // the app and have no subdomain form in GitHub's infrastructure, so exact match
+  // is correct for both.
+  try {
+    var h = new URL(url).hostname;
+    return h === 'api.github.com' || h === 'raw.githubusercontent.com';
+  } catch (e) {
+    return false;
+  }
+}
+
+function isNavigation(url) {
+  // The HTML document: directory root, index.html, or a hash deep-link.
+  return url.endsWith('/') || url.endsWith('/index.html') || url.indexOf('sy-subtitles/#') !== -1;
+}
+
+// The single source of truth for the fetch handler's branch. Navigation + the
+// GitHub API/raw endpoints are network-first (always prefer fresh, fall back to
+// cache offline); truly-immutable assets are cache-first; everything else
+// (app js/css, the Vimeo iframe) is network-first.
+function pickStrategy(url) {
+  if (isNavigation(url) || isApiOrRaw(url)) return 'network-first';
+  if (isImmutable(url)) return 'cache-first';
+  return 'network-first';
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    IMMUTABLE_PATTERNS: IMMUTABLE_PATTERNS,
+    isImmutable: isImmutable,
+    isApiOrRaw: isApiOrRaw,
+    isNavigation: isNavigation,
+    pickStrategy: pickStrategy,
+  };
+}

--- a/site/sw.js
+++ b/site/sw.js
@@ -4,12 +4,18 @@
 var CACHE_VERSION = 3;
 var CACHE_NAME = 'sy-subtitles-c' + CACHE_VERSION;
 
-// Assets that are truly immutable (versioned CDN URLs, static images)
-var IMMUTABLE_PATTERNS = [
-  'cdn.jsdelivr.net',
-  'player.vimeo.com/api',
-  '/icon.png'
-];
+// Routing predicates (isImmutable / isApiOrRaw / isNavigation / pickStrategy) are
+// single-sourced in js/sw_routing.js so the Node suite can unit-test every branch
+// (tests/test_sw_routing.js). importScripts evaluates it in this worker's global
+// scope, exposing the functions here; the module's CommonJS export is a no-op in
+// the worker (no `module`). Path is relative to this script, so sw.js and js/ stay
+// siblings on GitHub Pages (/sy-subtitles/) and locally alike.
+//
+// The ?v= cache-buster matters because updateViaCache defaults to 'imports':
+// imported scripts may be served from the HTTP cache during an SW update, unlike
+// the top-level sw.js. Tying the query to CACHE_VERSION means a version bump
+// re-fetches fresh routing logic — so routing changes must bump CACHE_VERSION.
+importScripts('js/sw_routing.js?v=' + CACHE_VERSION);
 
 self.addEventListener('install', function(e) {
   // Skip waiting — activate immediately so new version takes effect
@@ -29,28 +35,6 @@ self.addEventListener('activate', function(e) {
   // Take control of all clients immediately
   self.clients.claim();
 });
-
-function isImmutable(url) {
-  return IMMUTABLE_PATTERNS.some(function(p) { return url.includes(p); });
-}
-
-function isApiOrRaw(url) {
-  // Match on the actual host, not a substring: "https://evil.com/?x=api.github.com"
-  // must not be treated as a GitHub API/raw request.
-  try {
-    var h = new URL(url).hostname;
-    // Both hosts are used bare by the app; no subdomain form exists in GitHub's
-    // infrastructure, so exact match (symmetric for both) is correct here.
-    return h === 'api.github.com' || h === 'raw.githubusercontent.com';
-  } catch (e) {
-    return false;
-  }
-}
-
-function isNavigation(url) {
-  // index.html or root path — always network-first
-  return url.endsWith('/') || url.endsWith('/index.html') || url.includes('sy-subtitles/#');
-}
 
 // Strategy: network-first with cache fallback
 function networkFirst(request) {
@@ -80,16 +64,11 @@ function cacheFirst(request) {
 }
 
 self.addEventListener('fetch', function(e) {
-  var url = e.request.url;
-
-  if (isNavigation(url) || isApiOrRaw(url)) {
-    // HTML page + API + raw content: always try network first
-    e.respondWith(networkFirst(e.request));
-  } else if (isImmutable(url)) {
+  if (pickStrategy(e.request.url) === 'cache-first') {
     // CDN libs, icon: cache-first (immutable, versioned)
     e.respondWith(cacheFirst(e.request));
   } else {
-    // Everything else (Vimeo player, etc): network-first
+    // HTML shell + API + raw + everything else: network-first
     e.respondWith(networkFirst(e.request));
   }
 });

--- a/site/sw.js
+++ b/site/sw.js
@@ -65,10 +65,10 @@ function cacheFirst(request) {
 
 self.addEventListener('fetch', function(e) {
   if (pickStrategy(e.request.url) === 'cache-first') {
-    // CDN libs, icon: cache-first (immutable, versioned)
+    // CDN libs, icon, and sha-pinned ?v= content (SRT/transcripts): cache-first
     e.respondWith(cacheFirst(e.request));
   } else {
-    // HTML shell + API + raw + everything else: network-first
+    // HTML shell + Trees API + meta.yaml + everything else: network-first
     e.respondWith(networkFirst(e.request));
   }
 });

--- a/tests/test_offline_fallback.js
+++ b/tests/test_offline_fallback.js
@@ -1,0 +1,44 @@
+// Unit coverage for the offline content-load classifier (site/js/offline_fallback.js).
+// Decides when a failed SRT/transcript fetch should show the friendly
+// "available online only" screen vs the existing inline error — single source,
+// loaded by site/index.html and required here.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { isOfflineError } = require('../site/js/offline_fallback');
+
+describe('isOfflineError', () => {
+  it('is true whenever the browser reports offline, regardless of the error', () => {
+    assert.strictEqual(isOfflineError(new Error('HTTP 404'), false), true);
+    assert.strictEqual(isOfflineError(null, false), true);
+  });
+
+  it('is true online when the fetch itself rejected (a network TypeError)', () => {
+    // fetch() rejects with a TypeError on a dropped connection / DNS / CORS;
+    // cache-first miss while offline surfaces exactly this.
+    const e = new TypeError('Failed to fetch');
+    assert.strictEqual(isOfflineError(e, true), true);
+  });
+
+  it('is false online for a real HTTP error (404 / rate-limit), not offline', () => {
+    // The preview loader throws `new Error('SRT fetch failed: HTTP 404')`.
+    assert.strictEqual(isOfflineError(new Error('SRT fetch failed: HTTP 404'), true), false);
+    // An error object carrying a status is an HTTP failure, never offline.
+    const httpErr = new TypeError('weird');
+    httpErr.status = 403;
+    assert.strictEqual(isOfflineError(httpErr, true), false);
+  });
+
+  it('is false online with no error and tolerates a missing/odd error', () => {
+    assert.strictEqual(isOfflineError(null, true), false);
+    assert.strictEqual(isOfflineError(undefined, true), false);
+    assert.strictEqual(isOfflineError('a string', true), false);
+  });
+
+  it('treats an undefined online flag as online (only a network error counts)', () => {
+    // navigator.onLine is normally boolean; if a caller passes undefined we must
+    // not falsely declare offline on a plain HTTP error.
+    assert.strictEqual(isOfflineError(new Error('HTTP 500'), undefined), false);
+    assert.strictEqual(isOfflineError(new TypeError('Failed to fetch'), undefined), true);
+  });
+});

--- a/tests/test_offline_indicator.py
+++ b/tests/test_offline_indicator.py
@@ -1,0 +1,84 @@
+"""E2E for the offline UX: the freshness-bar offline badge and non-blocking
+content failures. The user keeps working with cached data — no full-screen block.
+
+Reuses the server/page fixtures from test_preview_spa.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.test_preview_spa import (  # noqa: F401  — re-exported fixtures
+    browser,
+    mock_player_js,
+    page,
+    server,
+    spa_path,
+)
+
+pytestmark = [pytest.mark.e2e, pytest.mark.flaky(reruns=2, reruns_delay=2)]
+
+
+def _offline_text(locator):
+    txt = locator.inner_text().lower()
+    return "offline" in txt or "офлайн" in txt
+
+
+class TestOfflineIndicator:
+    def test_badge_tracks_connectivity_changes(self, server, page):  # noqa: F811
+        # The freshness-bar badge reflects REAL device connectivity via the
+        # online/offline listeners — not only a manifest-staleness check.
+        page.goto(f"{server}/index.html")
+        page.wait_for_function("() => !!document.getElementById('stale-indicator')")
+        # Online at load: badge hidden.
+        assert page.evaluate("() => document.getElementById('stale-indicator').style.display") == "none"
+        page.context.set_offline(True)
+        try:
+            ind = page.locator("#stale-indicator")
+            ind.wait_for(state="visible", timeout=5000)
+            assert _offline_text(ind), ind.inner_text()
+        finally:
+            page.context.set_offline(False)
+        # Back online with a fresh (mocked) manifest: badge clears again.
+        page.wait_for_function(
+            "() => document.getElementById('stale-indicator').style.display === 'none'",
+            timeout=5000,
+        )
+
+    def test_badge_visible_while_working_in_a_preview(self, server, page):  # noqa: F811
+        # The bar is sticky on every view, so going offline mid-work still surfaces
+        # the badge on the preview page (not just the index).
+        page.goto(f"{server}/index.html#/preview/2001-01-01_Test-Talk/Test-Video")
+        page.wait_for_function("() => !!document.getElementById('stale-indicator')")
+        page.context.set_offline(True)
+        try:
+            page.locator("#stale-indicator").wait_for(state="visible", timeout=5000)
+        finally:
+            page.context.set_offline(False)
+
+    def test_offline_subtitle_failure_is_non_blocking(self, server, page):  # noqa: F811
+        # An offline subtitle miss shows an inline note in the overlay and does NOT
+        # throw up a full-screen block — the page stays usable.
+        page.route(
+            "**/raw.githubusercontent.com/**/final/uk.srt**",
+            lambda route: route.abort("failed"),
+        )
+        page.goto(f"{server}/index.html#/preview/2001-01-01_Test-Talk/Test-Video")
+        page.wait_for_function(
+            "() => /offline|офлайн/i.test((document.getElementById('subtitle-overlay') || {}).textContent || '')",
+            timeout=8000,
+        )
+        # No blocking overlay was introduced; the page chrome stays present.
+        assert page.locator("#offline-screen").count() == 0
+        assert page.locator("#freshness-bar").count() == 1
+
+    def test_dismiss_cannot_hide_a_live_offline_badge(self, server, page):  # noqa: F811
+        # Real offline is live device state: it is shown regardless of the manifest
+        # dismiss flag (unlike a dismissable rate-limit notice).
+        page.goto(f"{server}/index.html")
+        page.evaluate("() => { _staleDismissed = true; }")
+        page.context.set_offline(True)
+        try:
+            page.locator("#stale-indicator").wait_for(state="visible", timeout=5000)
+        finally:
+            page.context.set_offline(False)

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -5006,12 +5006,25 @@ class TestSubtitleOverlaySize:
     # by every "set the handle to h, read the resulting font" probe so a
     # constant change in the production formula doesn't silently leave the
     # tests asserting against stale numbers.
+    #
+    # It must also PERSIST the height (localStorage keySubs), exactly as a real
+    # drag's onCommit does. Without that, the tuned state is unsaved: the resize
+    # that fires when this probe toggles native fullscreen re-runs
+    # ensurePreviewResizers, which — seeing no saved subs — wipes data-subs-tuned
+    # and --preview-subs-scale, dropping the fs-mode font back to the un-tuned
+    # baseline. That race is the long-standing `big == baseline` flake. Saving
+    # makes ensurePreviewResizers RE-APPLY the height (the real-usage path) so the
+    # scale survives the toggle deterministically. Key mirrors production:
+    # 'sy.preview_subs_h.' + previewTalkKey() where previewTalkKey = talk '.' video
+    # parsed from the #/preview/<talk>/<video> hash.
     _SET_HANDLE_JS = """
       (h) => {
         const scale = Math.max(0.5, Math.min(4, h / 120));
         document.documentElement.style.setProperty('--preview-subs-h', h + 'px');
         document.documentElement.style.setProperty('--preview-subs-scale', String(scale));
         document.getElementById('view-preview').setAttribute('data-subs-tuned', '1');
+        const m = (location.hash || '').match(/^#\\/preview\\/([^/]+)\\/([^/?#]+)/);
+        if (m) localStorage.setItem('sy.preview_subs_h.' + m[1] + '.' + m[2], String(h));
       }
     """
 

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -94,3 +94,166 @@ class TestServiceWorker:
             timeout=10000,
         )
         assert "sy-subtitles-c2" not in page.evaluate("() => caches.keys()")
+
+    def test_activate_keeps_current_version_cache(self, server, page):  # noqa: F811
+        # The purge must delete OTHER versions, never the current one. Seed c3
+        # with a sentinel before activation; it (and its entry) must survive.
+        page.goto(f"{server}/index.html")
+        page.evaluate(
+            "async () => { const c = await caches.open('sy-subtitles-c3');"
+            " await c.put(location.origin + '/keep', new Response('KEEP')); }"
+        )
+        page.evaluate("() => navigator.serviceWorker.register('sw.js')")
+        page.wait_for_function("() => !!navigator.serviceWorker.controller", timeout=SW_WAIT_MS)
+        assert CACHE in page.evaluate("() => caches.keys()")
+        survived = page.evaluate(
+            "async () => { const c = await caches.open('sy-subtitles-c3');"
+            " const r = await c.match(location.origin + '/keep'); return r ? await r.text() : null; }"
+        )
+        assert survived == "KEEP", "activate wrongly purged the current-version cache"
+
+    def test_claims_a_preexisting_uncontrolled_client(self, server, page):  # noqa: F811
+        # The page loads with no controller (registration happens after load);
+        # clients.claim() must take control of this already-open client without
+        # a reload — that is what lets the SW serve the current session offline.
+        page.goto(f"{server}/index.html")
+        assert page.evaluate("() => navigator.serviceWorker.controller") is None
+        page.evaluate("() => navigator.serviceWorker.register('sw.js')")
+        page.wait_for_function("() => !!navigator.serviceWorker.controller", timeout=SW_WAIT_MS)
+        assert page.evaluate("() => !!navigator.serviceWorker.controller") is True
+
+
+class TestServiceWorkerOffline:
+    """Offline fallback + the network-first/cache-first branches under a real
+    dropped connection (driven by CDP set_offline, so the assertions are
+    deterministic — only the worker scheduling is retried via the module mark)."""
+
+    def _go_offline(self, page):  # noqa: F811
+        page.context.set_offline(True)
+
+    def _go_online(self, page):  # noqa: F811
+        page.context.set_offline(False)
+
+    def test_cache_first_miss_goes_to_network_then_serves_offline(self, server, page):  # noqa: F811
+        # icon.png is immutable → cache-first. First fetch is a MISS, so it must
+        # fall through to the network and populate the cache; a later OFFLINE
+        # fetch must then be served from that cache.
+        _register_sw(page, server)
+        miss = page.evaluate(
+            "async () => { const c = await caches.open('sy-subtitles-c3');"
+            " return !!(await c.match(location.origin + '/icon.png')); }"
+        )
+        assert miss is False, "precondition: icon.png must not be cached yet"
+        page.evaluate("() => fetch('icon.png')")
+        page.wait_for_function(
+            "async () => { const c = await caches.open('sy-subtitles-c3');"
+            " return !!(await c.match(location.origin + '/icon.png')); }",
+            timeout=10000,
+        )
+        self._go_offline(page)
+        try:
+            ok = page.evaluate("async () => (await fetch('icon.png')).ok")
+            assert ok is True, "icon.png not served from cache while offline"
+        finally:
+            self._go_online(page)
+
+    def test_navigation_offline_falls_back_to_cached_shell(self, server, page):  # noqa: F811
+        # The key offline-reload guarantee: index.html is network-first, so once
+        # it has been fetched online (and cached) an OFFLINE request serves the
+        # cached shell instead of failing. Without this the app cannot load at
+        # all offline, and the localStorage degradation never gets a chance.
+        _register_sw(page, server)
+        page.evaluate("() => fetch('index.html')")
+        page.wait_for_function(
+            "async () => { const c = await caches.open('sy-subtitles-c3');"
+            " return !!(await c.match(location.origin + '/index.html')); }",
+            timeout=10000,
+        )
+        self._go_offline(page)
+        try:
+            body = page.evaluate("async () => (await (await fetch('index.html')).text())")
+            assert "<" in body, f"offline shell not served from cache: {body[:80]!r}"
+        finally:
+            self._go_online(page)
+
+    def test_network_first_miss_offline_rejects_gracefully(self, server, page):  # noqa: F811
+        # A never-cached request while offline: networkFirst's caches.match
+        # returns undefined → respondWith(undefined) → the page fetch rejects
+        # (a clean network error), and the worker keeps serving other requests.
+        _register_sw(page, server)
+        # Seed a cached asset so we can prove the SW is still alive afterwards.
+        page.evaluate("() => fetch('icon.png')")
+        page.wait_for_function(
+            "async () => { const c = await caches.open('sy-subtitles-c3');"
+            " return !!(await c.match(location.origin + '/icon.png')); }",
+            timeout=10000,
+        )
+        self._go_offline(page)
+        try:
+            outcome = page.evaluate(
+                "async () => { try { await fetch('never-cached-' + 'xyz.js'); return 'resolved'; }"
+                " catch (e) { return 'rejected'; } }"
+            )
+            assert outcome == "rejected", "uncached offline request should reject, not resolve"
+            # Worker still healthy: the cached immutable asset is still served.
+            still_ok = page.evaluate("async () => (await fetch('icon.png')).ok")
+            assert still_ok is True, "worker stopped serving cached assets after an offline miss"
+        finally:
+            self._go_online(page)
+
+    def test_non_ok_response_is_not_cached(self, server, page):  # noqa: F811
+        # networkFirst caches only response.ok — a 404 must never be stored
+        # (otherwise a transient miss would be served forever).
+        _register_sw(page, server)
+        status = page.evaluate("async () => (await fetch('definitely-missing-asset.js')).status")
+        assert status == 404, f"expected a 404 from the test server, got {status}"
+        cached = page.evaluate(
+            "async () => { const c = await caches.open('sy-subtitles-c3');"
+            " return !!(await c.match(location.origin + '/definitely-missing-asset.js')); }"
+        )
+        assert cached is False, "a 404 response was wrongly written to the cache"
+
+    def test_app_asset_is_network_first_with_offline_fallback(self, server, page):  # noqa: F811
+        # Same-origin non-immutable assets (js/css) take the "everything else"
+        # branch → network-first. Online caches them; offline serves the copy.
+        _register_sw(page, server)
+        page.evaluate("() => fetch('js/sw_routing.js')")
+        page.wait_for_function(
+            "async () => { const c = await caches.open('sy-subtitles-c3');"
+            " return !!(await c.match(location.origin + '/js/sw_routing.js')); }",
+            timeout=10000,
+        )
+        self._go_offline(page)
+        try:
+            body = page.evaluate("async () => (await (await fetch('js/sw_routing.js')).text())")
+            assert "pickStrategy" in body, "app js not served from cache while offline"
+        finally:
+            self._go_online(page)
+
+    def test_github_api_and_raw_are_network_first_with_cache_fallback(self, server, page):  # noqa: F811
+        # api.github.com + raw.githubusercontent.com are routed network-first, so
+        # an OFFLINE request falls back to whatever the SW previously cached. This
+        # is the "shadowing" mechanism: when the SW holds a cached API response,
+        # the app's own fetch resolves with it offline (never rejects), so the
+        # app-level stale banner does not fire. PR B intentionally inverts this.
+        _register_sw(page, server)
+        for url in (
+            "https://api.github.com/git/trees/main?recursive=1",
+            "https://raw.githubusercontent.com/o/r/main/review-status.json",
+        ):
+            page.evaluate(
+                "async (u) => { const c = await caches.open('sy-subtitles-c3');"
+                " await c.put(u, new Response('CACHED:' + u,"
+                " {status: 200, headers: {'content-type': 'application/json'}})); }",
+                url,
+            )
+        self._go_offline(page)
+        try:
+            for url in (
+                "https://api.github.com/git/trees/main?recursive=1",
+                "https://raw.githubusercontent.com/o/r/main/review-status.json",
+            ):
+                body = page.evaluate("async (u) => (await (await fetch(u)).text())", url)
+                assert body == "CACHED:" + url, f"{url} not served from SW cache offline: {body[:60]!r}"
+        finally:
+            self._go_online(page)

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -230,6 +230,23 @@ class TestServiceWorkerOffline:
         finally:
             self._go_online(page)
 
+    def test_sha_versioned_content_is_served_cache_first(self, server, page):  # noqa: F811
+        # Subtitle/transcript URLs carry a ?v=<blob sha> cache-buster, so they are
+        # immutable by URL → cache-first. Proof: seed a sentinel under the key and
+        # fetch it WHILE ONLINE — cache-first returns the cached copy without ever
+        # hitting the network (a network-first route would try the network first).
+        _register_sw(page, server)
+        srt_url = "https://raw.githubusercontent.com/o/r/main/talks/x/uk/final/uk.srt?v=ab12cd34"
+        page.evaluate(
+            "async (u) => { const c = await caches.open('sy-subtitles-c3');"
+            " await c.put(u, new Response('CACHED-SRT',"
+            " {status: 200, headers: {'content-type': 'text/plain'}})); }",
+            srt_url,
+        )
+        # Online (no set_offline): cache-first must still serve the cached bytes.
+        body = page.evaluate("async (u) => (await (await fetch(u)).text())", srt_url)
+        assert body == "CACHED-SRT", f"sha-versioned content not served cache-first: {body[:60]!r}"
+
     def test_github_api_and_raw_are_network_first_with_cache_fallback(self, server, page):  # noqa: F811
         # api.github.com + raw.githubusercontent.com are routed network-first, so
         # an OFFLINE request falls back to whatever the SW previously cached. This

--- a/tests/test_spa_cache.js
+++ b/tests/test_spa_cache.js
@@ -1242,75 +1242,14 @@ describe('refresh: no hardcoded colors in status messages', () => {
 // Tests: Service Worker caching strategy
 // ============================================================
 
-function swIsImmutable(url) {
-  var patterns = ['cdn.jsdelivr.net', 'player.vimeo.com/api', '/icon.png'];
-  return patterns.some(function(p) { return url.includes(p); });
-}
-// Exercise the REAL isApiOrRaw from site/sw.js (extracted + eval'd, like
-// extractI18N) instead of a hand-copied reimplementation that can silently
-// drift from production.
-function loadSwFn(name) {
-  var fs = require('fs');
-  var src = fs.readFileSync('site/sw.js', 'utf8');
-  // Grab the function body up to the first closing brace at column 0. This
-  // assumes top-level sw.js functions close on their own line and any inner
-  // braces stay indented (true today). It fails loud if violated — no match
-  // throws here, a truncated match throws on eval — never a wrong-but-passing
-  // function. Same extract-the-real-source approach as extractI18N below.
-  var m = src.match(new RegExp('function ' + name + '\\([\\s\\S]*?\\n\\}'));
-  assert.ok(m, name + '() not found in site/sw.js');
-  return eval('(' + m[0] + ')');
-}
-var swIsApiOrRaw = loadSwFn('isApiOrRaw');
-function swIsNavigation(url) {
-  return url.endsWith('/') || url.endsWith('/index.html') || url.includes('sy-subtitles/#');
-}
-function swGetStrategy(url) {
-  if (swIsNavigation(url) || swIsApiOrRaw(url)) return 'network-first';
-  if (swIsImmutable(url)) return 'cache-first';
-  return 'network-first';
-}
+// The SW routing predicates (isImmutable / isApiOrRaw / isNavigation /
+// pickStrategy) are now single-sourced in site/js/sw_routing.js — the module
+// site/sw.js loads via importScripts — and unit-tested there
+// (tests/test_sw_routing.js), so they can never drift from production. This file
+// keeps only the cache-name versioning helper used by the version-sync tests.
 function swCacheName(version) {
   return 'sy-subtitles-v' + (version || '0');
 }
-
-describe('SW: isImmutable', () => {
-  it('CDN js-yaml is immutable', () => assert.strictEqual(swIsImmutable('https://cdn.jsdelivr.net/npm/js-yaml@4/dist/js-yaml.min.js'), true));
-  it('Vimeo player API is immutable', () => assert.strictEqual(swIsImmutable('https://player.vimeo.com/api/player.js'), true));
-  it('icon.png is immutable', () => assert.strictEqual(swIsImmutable('https://site.github.io/sy-subtitles/icon.png'), true));
-  it('index.html is NOT immutable', () => assert.strictEqual(swIsImmutable('https://site.github.io/sy-subtitles/index.html'), false));
-  it('API is NOT immutable', () => assert.strictEqual(swIsImmutable('https://api.github.com/repos/foo'), false));
-  it('raw content is NOT immutable', () => assert.strictEqual(swIsImmutable('https://raw.githubusercontent.com/foo/uk.srt'), false));
-});
-
-describe('SW: isApiOrRaw', () => {
-  it('GitHub API', () => assert.strictEqual(swIsApiOrRaw('https://api.github.com/repos/foo'), true));
-  it('raw.githubusercontent', () => assert.strictEqual(swIsApiOrRaw('https://raw.githubusercontent.com/foo/file.srt'), true));
-  it('index.html is not API', () => assert.strictEqual(swIsApiOrRaw('https://site.github.io/sy-subtitles/'), false));
-  // Host must match, not merely appear as a substring of the URL.
-  it('attacker host with api.github.com in the query is not API', () => assert.strictEqual(swIsApiOrRaw('https://attacker.com/?x=api.github.com'), false));
-  it('attacker host with raw host in the fragment is not raw', () => assert.strictEqual(swIsApiOrRaw('https://attacker.com/#raw.githubusercontent.com'), false));
-  it('look-alike suffix host is not API', () => assert.strictEqual(swIsApiOrRaw('https://api.github.com.evil.com/x'), false));
-});
-
-describe('SW: isNavigation', () => {
-  it('root path', () => assert.strictEqual(swIsNavigation('https://site.github.io/sy-subtitles/'), true));
-  it('index.html', () => assert.strictEqual(swIsNavigation('https://site.github.io/sy-subtitles/index.html'), true));
-  it('hash route', () => assert.strictEqual(swIsNavigation('https://site.github.io/sy-subtitles/#/preview/talk/vid'), true));
-  it('icon is NOT navigation', () => assert.strictEqual(swIsNavigation('https://site.github.io/sy-subtitles/icon.png'), false));
-  it('CDN is NOT navigation', () => assert.strictEqual(swIsNavigation('https://cdn.jsdelivr.net/npm/js-yaml@4'), false));
-});
-
-describe('SW: caching strategy per URL', () => {
-  it('index.html → network-first', () => assert.strictEqual(swGetStrategy('https://site.github.io/sy-subtitles/index.html'), 'network-first'));
-  it('root → network-first', () => assert.strictEqual(swGetStrategy('https://site.github.io/sy-subtitles/'), 'network-first'));
-  it('API → network-first', () => assert.strictEqual(swGetStrategy('https://api.github.com/repos/foo/git/trees/main'), 'network-first'));
-  it('raw SRT → network-first', () => assert.strictEqual(swGetStrategy('https://raw.githubusercontent.com/foo/uk.srt'), 'network-first'));
-  it('CDN lib → cache-first', () => assert.strictEqual(swGetStrategy('https://cdn.jsdelivr.net/npm/js-yaml@4/dist/js-yaml.min.js'), 'cache-first'));
-  it('icon → cache-first', () => assert.strictEqual(swGetStrategy('https://site.github.io/sy-subtitles/icon.png'), 'cache-first'));
-  it('Vimeo embed → network-first', () => assert.strictEqual(swGetStrategy('https://player.vimeo.com/video/12345'), 'network-first'));
-  it('Vimeo player API → cache-first', () => assert.strictEqual(swGetStrategy('https://player.vimeo.com/api/player.js'), 'cache-first'));
-});
 
 describe('SW: cache name versioning', () => {
   it('derives from version param', () => assert.strictEqual(swCacheName('10'), 'sy-subtitles-v10'));

--- a/tests/test_sw_routing.js
+++ b/tests/test_sw_routing.js
@@ -13,6 +13,7 @@ const {
   isImmutable,
   isApiOrRaw,
   isNavigation,
+  hasImmutableVersion,
   pickStrategy,
 } = require('../site/js/sw_routing');
 
@@ -67,12 +68,36 @@ describe('isNavigation — the app shell / HTML document', () => {
   });
 });
 
+describe('hasImmutableVersion — sha-pinned (?v=) content is immutable by URL', () => {
+  it('detects a non-empty v query param', () => {
+    assert.strictEqual(hasImmutableVersion('https://raw.githubusercontent.com/o/r/main/talks/x/uk/final/uk.srt?v=ab12cd34'), true);
+    assert.strictEqual(hasImmutableVersion('https://raw.githubusercontent.com/o/r/main/talks/x/transcript_uk.txt?v=deadbee'), true);
+    assert.strictEqual(hasImmutableVersion('https://raw.githubusercontent.com/o/r/main/review-status.json?v=cafe123'), true);
+  });
+  it('is false when there is no v param (meta.yaml, the Trees API, the shell)', () => {
+    assert.strictEqual(hasImmutableVersion('https://raw.githubusercontent.com/o/r/main/talks/x/meta.yaml'), false);
+    // the Trees API uses ?recursive=1, never ?v= — must stay network-first
+    assert.strictEqual(hasImmutableVersion('https://api.github.com/git/trees/main?recursive=1'), false);
+    assert.strictEqual(hasImmutableVersion('https://sy-tools.github.io/sy-subtitles/index.html'), false);
+  });
+  it('is false for an empty v param and tolerates a malformed URL', () => {
+    assert.strictEqual(hasImmutableVersion('https://raw.githubusercontent.com/o/r/main/x.srt?v='), false);
+    assert.strictEqual(hasImmutableVersion('not a url'), false);
+  });
+});
+
 describe('pickStrategy — the routing the fetch handler applies', () => {
   it('navigation, API and raw are network-first', () => {
     assert.strictEqual(pickStrategy('https://sy-tools.github.io/sy-subtitles/'), 'network-first');
     assert.strictEqual(pickStrategy('https://sy-tools.github.io/sy-subtitles/index.html'), 'network-first');
     assert.strictEqual(pickStrategy('https://api.github.com/git/trees/main?recursive=1'), 'network-first');
-    assert.strictEqual(pickStrategy('https://raw.githubusercontent.com/o/r/main/review-status.json'), 'network-first');
+    // raw WITHOUT ?v= (meta.yaml) stays network-first
+    assert.strictEqual(pickStrategy('https://raw.githubusercontent.com/o/r/main/talks/x/meta.yaml'), 'network-first');
+  });
+  it('sha-pinned (?v=) raw content is cache-first — instant offline, no redundant refetch', () => {
+    assert.strictEqual(pickStrategy('https://raw.githubusercontent.com/o/r/main/talks/x/uk/final/uk.srt?v=ab12cd34'), 'cache-first');
+    assert.strictEqual(pickStrategy('https://raw.githubusercontent.com/o/r/main/talks/x/transcript_uk.txt?v=deadbee'), 'cache-first');
+    assert.strictEqual(pickStrategy('https://raw.githubusercontent.com/o/r/main/review-status.json?v=cafe123'), 'cache-first');
   });
   it('immutable assets are cache-first', () => {
     assert.strictEqual(pickStrategy('https://cdn.jsdelivr.net/npm/js-yaml@4/dist/js-yaml.min.js'), 'cache-first');

--- a/tests/test_sw_routing.js
+++ b/tests/test_sw_routing.js
@@ -1,0 +1,91 @@
+// Unit coverage for the service-worker routing decision (site/js/sw_routing.js).
+//
+// The predicates that decide which caching strategy a request gets used to live
+// inline in sw.js, where only the slow, flaky Playwright E2E could reach them —
+// yet that decision is exactly where the real bugs hide (the host-vs-substring
+// guard in isApiOrRaw, the navigation URL forms). Extracting them into a single-
+// source module lets the fast Node suite pin every branch deterministically;
+// sw.js loads the SAME file via importScripts.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const {
+  isImmutable,
+  isApiOrRaw,
+  isNavigation,
+  pickStrategy,
+} = require('../site/js/sw_routing');
+
+describe('isImmutable — versioned/static assets safe to cache-first', () => {
+  it('matches every immutable pattern', () => {
+    assert.strictEqual(isImmutable('https://cdn.jsdelivr.net/npm/js-yaml@4/dist/js-yaml.min.js'), true);
+    assert.strictEqual(isImmutable('https://player.vimeo.com/api/player.js'), true);
+    assert.strictEqual(isImmutable('https://sy-tools.github.io/sy-subtitles/icon.png'), true);
+  });
+  it('does NOT match Vimeo player iframe/video URLs (only /api is immutable)', () => {
+    assert.strictEqual(isImmutable('https://player.vimeo.com/video/123456'), false);
+  });
+  it('does NOT match the app shell or app assets', () => {
+    assert.strictEqual(isImmutable('https://sy-tools.github.io/sy-subtitles/js/app.js'), false);
+    assert.strictEqual(isImmutable('https://sy-tools.github.io/sy-subtitles/index.html'), false);
+  });
+});
+
+describe('isApiOrRaw — exact host match, never a substring', () => {
+  it('matches the GitHub API and raw hosts', () => {
+    assert.strictEqual(isApiOrRaw('https://api.github.com/git/trees/main?recursive=1'), true);
+    assert.strictEqual(isApiOrRaw('https://raw.githubusercontent.com/sy-tools/sy-subtitles/main/review-status.json'), true);
+  });
+  it('does NOT match github.com or other github subdomains', () => {
+    assert.strictEqual(isApiOrRaw('https://github.com/sy-tools/sy-subtitles'), false);
+    assert.strictEqual(isApiOrRaw('https://sub.api.github.com/x'), false);
+  });
+  it('SECURITY: a foreign host with the API host in its path/query is NOT matched', () => {
+    assert.strictEqual(isApiOrRaw('https://evil.com/?x=api.github.com'), false);
+    assert.strictEqual(isApiOrRaw('https://api.github.com.evil.com/git/trees'), false);
+  });
+  it('returns false for a malformed or empty URL without throwing', () => {
+    assert.strictEqual(isApiOrRaw('not a url'), false);
+    assert.strictEqual(isApiOrRaw(''), false);
+  });
+});
+
+describe('isNavigation — the app shell / HTML document', () => {
+  it('matches the directory root, index.html, and a hash deep-link', () => {
+    assert.strictEqual(isNavigation('https://sy-tools.github.io/sy-subtitles/'), true);
+    assert.strictEqual(isNavigation('https://sy-tools.github.io/sy-subtitles/index.html'), true);
+    assert.strictEqual(isNavigation('https://sy-tools.github.io/sy-subtitles/#/preview/1979-09-27_foo'), true);
+  });
+  it('does NOT match a plain asset path', () => {
+    assert.strictEqual(isNavigation('https://sy-tools.github.io/sy-subtitles/js/app.js'), false);
+  });
+  it('documents the current quirk: a root with a query string is not detected', () => {
+    // endsWith('/') is false once a ?query is appended; it still routes to
+    // network-first via the fallthrough, so behaviour is unaffected — pinned so
+    // a future change to isNavigation is a deliberate one.
+    assert.strictEqual(isNavigation('https://sy-tools.github.io/sy-subtitles/?branch=main'), false);
+  });
+});
+
+describe('pickStrategy — the routing the fetch handler applies', () => {
+  it('navigation, API and raw are network-first', () => {
+    assert.strictEqual(pickStrategy('https://sy-tools.github.io/sy-subtitles/'), 'network-first');
+    assert.strictEqual(pickStrategy('https://sy-tools.github.io/sy-subtitles/index.html'), 'network-first');
+    assert.strictEqual(pickStrategy('https://api.github.com/git/trees/main?recursive=1'), 'network-first');
+    assert.strictEqual(pickStrategy('https://raw.githubusercontent.com/o/r/main/review-status.json'), 'network-first');
+  });
+  it('immutable assets are cache-first', () => {
+    assert.strictEqual(pickStrategy('https://cdn.jsdelivr.net/npm/js-yaml@4/dist/js-yaml.min.js'), 'cache-first');
+    assert.strictEqual(pickStrategy('https://player.vimeo.com/api/player.js'), 'cache-first');
+    assert.strictEqual(pickStrategy('https://sy-tools.github.io/sy-subtitles/icon.png'), 'cache-first');
+  });
+  it('everything else (app js/css, vimeo iframe) is network-first', () => {
+    assert.strictEqual(pickStrategy('https://sy-tools.github.io/sy-subtitles/js/app.js'), 'network-first');
+    assert.strictEqual(pickStrategy('https://player.vimeo.com/video/123456'), 'network-first');
+  });
+  it('navigation precedence holds even for an icon under a hash route', () => {
+    // isNavigation wins before isImmutable: a hash deep-link is the shell, not an
+    // asset, so it must stay network-first.
+    assert.strictEqual(pickStrategy('https://sy-tools.github.io/sy-subtitles/#/icon.png'), 'network-first');
+  });
+});


### PR DESCRIPTION
Service-worker testing + a real offline content experience, in three commits.

## 1) Single-source SW routing module + full lifecycle/offline E2E
Extract the routing decision out of `sw.js` into **`site/js/sw_routing.js`**
(`isImmutable` / `isApiOrRaw` / `isNavigation` / `pickStrategy`), loaded by the
worker via `importScripts` and `require`d by the Node suite — same single-source
pattern as every other `site/js` module. **No behaviour change** here; the
original 5 E2E pass unchanged. `?v=CACHE_VERSION` on the import busts the HTTP
cache for the imported script (updateViaCache defaults to `'imports'`).

- Node unit `tests/test_sw_routing.js`: every predicate branch + the `isApiOrRaw`
  exact-host **security** cases + `pickStrategy` precedence.
- E2E `tests/test_service_worker.py` 5 → 14: activate keeps current cache /
  clients.claim / cache-first miss→network→offline / navigation offline → cached
  shell / network-first miss offline rejects gracefully / 404 not cached /
  app-asset offline fallback / api+raw network-first offline fallback.
- `tests/test_spa_cache.js`: drop the brittle `loadSwFn` regex + the now-duplicated
  routing describe blocks (canonical home is `test_sw_routing.js`).

## 2) Offline content — cache-first sha URLs + live offline badge
- **SW cache-first for sha-pinned content** (`?v=<blob sha>` on SRT/transcripts):
  immutable by URL → instant offline + zero redundant refetch; a new build changes
  the sha → the URL, so freshness is preserved. `meta.yaml`/Trees API stay
  network-first. New `hasImmutableVersion` + 4 unit tests + 1 E2E.
- **Live offline badge** in the freshness bar: reflects real connectivity via
  `window` online/offline + `navigator.onLine`, persistent and visible on every
  view (sticky bar). Not dismissable while truly offline (no × on the live state;
  the × stays for the dismissable rate-limit notice).
- **Non-blocking content failures**: the page stays usable and shows a friendly
  inline note (`isOfflineError` in `site/js/offline_fallback.js`, Node-tested)
  instead of a raw TypeError — no full-screen block.
- **SW opt-in on localhost via `?sw=1`** so the real cache-first offline flow can
  be exercised locally (registration still skipped on localhost by default).
- E2E `tests/test_offline_indicator.py`: badge tracks connectivity, visible in a
  preview, non-blocking failure, live badge not dismissable.

## 3) Fix the fs-mode font flake at root (not a marker)
`TestSubtitleOverlaySize` flaked (`big == baseline == 64px`, ~30% under `-n auto`)
because the test mirror set `--preview-subs-scale` + `data-subs-tuned` but never
**persisted** the height, unlike a real drag's `onCommit`. The resize from
toggling native fullscreen re-runs `ensurePreviewResizers`, which — seeing no
saved subs — wipes the tuning, dropping the fs-mode font to the un-tuned baseline.
Real users always save on commit, so the test modelled an impossible state. Fix
persists to `keySubs` exactly as `onCommit` does → deterministic. Verified 12/12
under load + full class 14/14.

## Test
- JS **595 pass** (`node --test tests/test_*.js`)
- Python preview SPA + SW + offline indicator: **351 pass**, no regression
- `ruff` clean

Note: the app↔SW bridge (preview reads SRT from the SW cache offline) is verified
manually via `?sw=1` — `page.route` mocks and the SW don't compose deterministically
in the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)