### PR TITLE
refactor(spa): migrate action buttons to the .btn system

### DIFF
--- a/site/css/components.css
+++ b/site/css/components.css
@@ -21,10 +21,8 @@ a:hover { text-decoration: underline; }
   position: sticky; top: var(--freshness-h); z-index: 20; }
 .header h1 { font-size: 16px; font-weight: normal; color: var(--fg4); }
 .header-actions { display: flex; gap: 8px; }
-.header-actions button { background: var(--bg4); color: var(--fg); border: 1px solid var(--border3); border-radius: 6px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
-.header-actions button.primary { background: var(--primary-bg); border-color: var(--primary-border); color: var(--primary-fg); }
-.header-actions button.issue { background: var(--issue-bg); border-color: var(--issue-border); color: var(--issue-fg); }
-.header-actions button:active { opacity: 0.7; }
+/* Header action buttons use the .btn system (class="btn btn--issue|primary|danger").
+   Only the mobile touch-target rule for .header-actions button remains (below). */
 button:focus-visible, a:focus-visible,
 input:focus-visible, select:focus-visible, textarea:focus-visible,
 [contenteditable="true"]:focus-visible { outline: 2px solid var(--link); outline-offset: 2px; }
@@ -174,7 +172,6 @@ textarea.input { resize: vertical; font-family: monospace; font-size: 13px; }
 #time-display { color: var(--fg6); font-size: 13px; font-family: monospace; }
 .preview-list { max-width: 960px; margin: 0 auto; padding: 0 8px; }
 .preview-list summary { color: var(--fg5); cursor: pointer; padding: 8px; font-size: 14px; }
-.header-actions button.danger { background: var(--danger-bg); color: var(--danger-fg); border-color: var(--danger-border); }
 .preview-mode-toggle { display: inline-flex; border: 1px solid var(--border3); border-radius: 6px; overflow: hidden; }
 .preview-mode-toggle button { background: var(--bg4); color: var(--fg5); border: 0; padding: 6px 12px; font-size: 13px; cursor: pointer; border-radius: 0; }
 .preview-mode-toggle button + button { border-left: 1px solid var(--border3); }
@@ -473,14 +470,14 @@ body {
 }
 #search-input:not(:placeholder-shown) { font-style: normal; }
 
-/* Buttons / chips — square corners, quiet weight */
-.header-actions button, .controls button, .chip, .select-chip, .branch-btn,
+/* Chips / segmented controls — square corners, quiet weight. (Header action
+   buttons get this from .btn now; only the still-bespoke controls are listed.) */
+.controls button, .chip, .select-chip, .branch-btn,
 .preview-mode-toggle button {
   border-radius: 2px;
   font-family: var(--f-sans);
   letter-spacing: 0.01em;
 }
-.header-actions button.primary { letter-spacing: 0.02em; }
 
 /* Links — warm terracotta, no underline by default */
 a { text-decoration: none; }

--- a/site/index.html
+++ b/site/index.html
@@ -331,10 +331,10 @@
       <button type="button" data-mode="marker" class="chip active" onclick="SPA.setPreviewMode('marker')" data-i18n="preview.mode_marker">&#x1F4CC; Marker</button><button type="button" data-mode="edit" class="chip" onclick="SPA.setPreviewMode('edit')" data-i18n="preview.mode_edit">&#x270E; Edit</button>
     </div>
     <div class="header-actions">
-      <button id="btn-copy-all" onclick="SPA.copyMarkers()" data-i18n="btn.copy_all">Copy all</button>
-      <button id="btn-preview-issue" class="issue" onclick="SPA.createPreviewIssue()" data-i18n="btn.create_issue">Create issue</button>
-      <button id="btn-preview-editor" class="primary" style="display:none" onclick="SPA.openPreviewEditor()" data-i18n="btn.open_editor">Open in GitHub Editor</button>
-      <button id="btn-clear-all" class="danger" style="display:none" onclick="SPA.clearAll()" data-i18n="btn.clear_all">Clear all</button>
+      <button id="btn-copy-all" class="btn" onclick="SPA.copyMarkers()" data-i18n="btn.copy_all">Copy all</button>
+      <button id="btn-preview-issue" class="btn btn--issue" onclick="SPA.createPreviewIssue()" data-i18n="btn.create_issue">Create issue</button>
+      <button id="btn-preview-editor" class="btn btn--primary" style="display:none" onclick="SPA.openPreviewEditor()" data-i18n="btn.open_editor">Open in GitHub Editor</button>
+      <button id="btn-clear-all" class="btn btn--danger" style="display:none" onclick="SPA.clearAll()" data-i18n="btn.clear_all">Clear all</button>
     </div>
   </div>
   <div class="player-container">
@@ -365,15 +365,15 @@
     </h1>
     <div class="header-actions">
       <span class="video-picker">
-        <button id="btn-sync-player" class="chip" style="display:none"
+        <button id="btn-sync-player" class="btn" style="display:none"
                 onclick="SPA.onSyncBtnClick()"
                 data-i18n-title="title.show_video"
                 data-i18n="btn.show_video">&#x25B6; Show video</button>
         <div id="video-picker-dropdown" class="video-dropdown" role="listbox"></div>
       </span>
-      <button class="issue" onclick="SPA.createReviewIssue()" data-i18n="btn.create_review_issue">Create Issue</button>
-      <button class="primary" onclick="SPA.openEditor()" data-i18n="btn.open_editor">Open in GitHub Editor</button>
-      <button onclick="SPA.revertAllEdits()" id="btn-revert-all" class="danger" style="display:none" data-i18n="btn.revert_all">Revert all</button>
+      <button class="btn btn--issue" onclick="SPA.createReviewIssue()" data-i18n="btn.create_review_issue">Create Issue</button>
+      <button class="btn btn--primary" onclick="SPA.openEditor()" data-i18n="btn.open_editor">Open in GitHub Editor</button>
+      <button onclick="SPA.revertAllEdits()" id="btn-revert-all" class="btn btn--danger" style="display:none" data-i18n="btn.revert_all">Revert all</button>
     </div>
   </div>
   <div id="sync-player-bar" class="sync-player-bar" hidden>
@@ -457,7 +457,7 @@
         <span style="color:var(--fg5);font-size:12px;" data-i18n="add.preview_label">meta.yaml preview:</span>
         <pre id="add-preview" style="margin-top:8px;color:var(--fg3);font-size:12px;font-family:monospace;white-space:pre-wrap;max-height:20em;overflow-y:auto;"></pre>
       </div>
-      <button type="submit" style="padding:10px 24px;background:var(--primary-bg);color:var(--primary-fg);border:1px solid var(--primary-border);border-radius:6px;font-size:15px;cursor:pointer;" data-i18n="add.submit">Create PR</button>
+      <button type="submit" class="btn btn--primary btn--lg" data-i18n="add.submit">Create PR</button>
     </form>
   </div>
 </div>

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -740,7 +740,7 @@ class TestMarkers:
         page.click("#btn-mark")
         page.click("#btn-mark")
         assert page.locator("#marker-count").text_content() == "2"
-        page.click("button.danger")
+        page.click("#btn-clear-all")
         spa_confirm_accept(page)
         assert page.locator("#marker-count").text_content() == "0"
         assert page.locator(".marker-item").count() == 0
@@ -752,7 +752,7 @@ class TestMarkers:
         page.wait_for_timeout(200)
         page.click("#btn-mark")
         assert page.locator("#marker-count").text_content() == "1"
-        page.click("button.danger")
+        page.click("#btn-clear-all")
         spa_confirm_dismiss(page)
         assert page.locator("#marker-count").text_content() == "1"
         assert page.locator(".marker-item").count() == 1
@@ -767,7 +767,7 @@ class TestMarkers:
             "JSON.parse(localStorage.getItem('preview_2001-01-01_Test-Talk_Test-Video') || '{}').markers || []"
         )
         assert len(data) == 1
-        page.click("button.danger")
+        page.click("#btn-clear-all")
         spa_confirm_accept(page)
         data = page.evaluate(
             "JSON.parse(localStorage.getItem('preview_2001-01-01_Test-Talk_Test-Video') || '{}').markers || []"


### PR DESCRIPTION
Follow-up to the design-system PR (#656): migrate the app's action buttons onto the
`.btn` system so there's **one** button system instead of two.

## What changed
The header/review action buttons — **Copy all, Create issue, Open editor, Clear all,
Revert all, Show video** — and the **Add-talk submit** now use `class="btn btn--*"`
instead of the ad-hoc `.header-actions button` + `.primary/.issue/.danger` rules.
Removed the redundant CSS (kept the mobile 44px touch-target rule). Buttons adopt the
`.btn` standard size (8px 16px, up from 6px 14px) — a small, deliberate size bump;
verified in light + dark + a review view.

## Deliberately left as distinct components
Not everything is a "reinvented button". These stay as-is: the segmented mode-toggle
(`.chip`), the player controls (`.controls button`), the branch/expert chips, the
freshness-bar icon buttons, the per-cell revert, and the **modal buttons**
(`.sy-modal-btn` keeps its intentional *inverted strong-CTA* primary — `.btn--primary`
would be a softer, weaker confirm button, a UX regression).

## Why (the point)
Before this, `.btn` existed but only the styleguide used it → two parallel systems and
the "which do I copy?" ambiguity the design-system work was meant to remove. Now the
app uses `.btn`, the styleguide reflects reality, and new buttons match existing ones.

## Tests
- Fixed 3 e2e tests that clicked Clear-all by its old `.danger` class → now target the
  stable `#btn-clear-all` id (won't break on future class changes).
- JS 609/609 · boot smoke ✓ · e2e button-interaction suite (clear/create-issue/revert/
  fullscreen/loads) 40/40 after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
