### PR TITLE
fix(timing): adjacent-gap slack in _extend_block, forced-gap invariant, unmatched-block rebalance

### DIFF
--- a/tests/test_build_srt.py
+++ b/tests/test_build_srt.py
@@ -1,6 +1,7 @@
 """Tests for tools.build_srt (internal timing passes)."""
 
 from tools.build_srt import (
+    _extend_block,
     apply_padding,
     balance_cps,
     enforce_duration,
@@ -37,6 +38,21 @@ def test_enforce_gaps_shrinks_previous():
     config = OptimizeConfig(min_gap_ms=80)
     result = enforce_gaps(blocks, config)
     assert result[0]["end_ms"] == 2060 - 80  # shrunk to create 80ms gap
+
+
+def test_enforce_gaps_forced_gap_keeps_start_before_end():
+    # Block 2 nested inside block 1 (LLM mapping error): the forced-gap
+    # fallback moves block 2's start forward and must not leave start > end.
+    blocks = [
+        _make_block(1, 1000, 5000, "A"),
+        _make_block(2, 1010, 1500, "B"),
+    ]
+    config = OptimizeConfig(min_gap_ms=80, min_duration_ms=1200)
+    result = enforce_gaps(blocks, config)
+    for b in result:
+        assert b["start_ms"] < b["end_ms"], f"block #{b['idx']} start >= end"
+    # gap invariant still holds
+    assert result[1]["start_ms"] - result[0]["end_ms"] >= 80
 
 
 # ---------------------------------------------------------------------------
@@ -84,6 +100,73 @@ def test_enforce_duration_extends_short_block():
 
 
 # ---------------------------------------------------------------------------
+# _extend_block
+# ---------------------------------------------------------------------------
+
+
+def test_extend_block_consumes_adjacent_right_gap_without_shifting():
+    # 5080ms silence right after block 1 — the deficit fits entirely there.
+    blocks = [
+        _make_block(1, 0, 1000, "A"),
+        _make_block(2, 6080, 8000, "B"),
+        _make_block(3, 8080, 9000, "C"),
+    ]
+    config = OptimizeConfig(min_gap_ms=80)
+    remaining = _extend_block(blocks, 0, 5000, config)
+    assert remaining == 0
+    assert blocks[0]["end_ms"] == 6000  # ate the silence, left min_gap
+    assert blocks[1]["start_ms"] == 6080  # neighbors stay on their audio
+    assert blocks[1]["end_ms"] == 8000
+    assert blocks[2]["start_ms"] == 8080
+    assert blocks[2]["end_ms"] == 9000
+
+
+def test_extend_block_consumes_adjacent_left_gap_without_shifting():
+    blocks = [
+        _make_block(1, 2000, 3000, "A"),
+        _make_block(2, 8080, 9000, "B"),
+    ]
+    config = OptimizeConfig(min_gap_ms=80)
+    remaining = _extend_block(blocks, 1, 5000, config)
+    assert remaining == 0
+    assert blocks[1]["start_ms"] == 3080  # ate the silence, left min_gap
+    assert blocks[0]["start_ms"] == 2000  # left neighbor untouched
+    assert blocks[0]["end_ms"] == 3000
+
+
+def test_extend_block_cascades_only_for_remainder():
+    # Adjacent gap holds 1000ms of slack; the other 2000ms must come from
+    # shifting block 2 into the 6000ms silence behind it.
+    blocks = [
+        _make_block(1, 0, 1000, "A"),
+        _make_block(2, 2080, 3000, "B"),
+        _make_block(3, 9000, 10000, "C"),
+    ]
+    config = OptimizeConfig(min_gap_ms=80)
+    remaining = _extend_block(blocks, 0, 3000, config)
+    assert remaining == 0
+    assert blocks[0]["end_ms"] == 4000
+    # Block 2 shifted wholesale (duration preserved), min gap kept
+    assert blocks[1]["start_ms"] == 4080
+    assert blocks[1]["end_ms"] == 5000
+    # Block 3 never needed to move
+    assert blocks[2]["start_ms"] == 9000
+
+
+def test_extend_block_reports_unfixable_remainder_without_moving_neighbors():
+    blocks = [
+        _make_block(1, 0, 1000, "A"),
+        _make_block(2, 1160, 2000, "B"),  # only 80ms of slack anywhere
+    ]
+    config = OptimizeConfig(min_gap_ms=80)
+    remaining = _extend_block(blocks, 0, 500, config)
+    assert remaining == 420
+    assert blocks[0]["end_ms"] == 1080
+    assert blocks[1]["start_ms"] == 1160  # not shifted on a false promise
+    assert blocks[1]["end_ms"] == 2000
+
+
+# ---------------------------------------------------------------------------
 # balance_cps
 # ---------------------------------------------------------------------------
 
@@ -99,3 +182,16 @@ def test_balance_cps_extends_high_cps_block():
     # Block 1 should have been extended
     dur = result[0]["end_ms"] - result[0]["start_ms"]
     assert dur > 1000
+
+
+def test_balance_cps_does_not_shift_neighbor_when_adjacent_silence_suffices():
+    # 9s of silence sits right after the high-CPS block; the neighbor's
+    # timing is audio-anchored and must not move.
+    blocks = [
+        _make_block(1, 0, 1000, "x" * 40),
+        _make_block(2, 10000, 15000, "Normal text."),
+    ]
+    config = OptimizeConfig()
+    result = balance_cps(blocks, config, threshold=20)
+    assert result[1]["start_ms"] == 10000
+    assert result[1]["end_ms"] == 15000

--- a/tests/test_snap_srt_to_whisper.py
+++ b/tests/test_snap_srt_to_whisper.py
@@ -30,6 +30,35 @@ def test_block_with_no_whisper_match_is_kept_and_flagged():
     assert out[1]["start_ms"] == 5000 and out[1]["end_ms"] == 7000
 
 
+def test_rebalance_never_moves_unmatched_block():
+    """A dense matched block must not steal its boundary rebalance from an
+    unmatched neighbour: the unmatched block's stale timing is not a valid
+    balance window, and the contract says unmatched blocks stay untouched."""
+    segs = _segs(
+        [
+            ("aaaa", 1000, 1250),
+            ("bbbb", 1250, 1500),
+            ("cccc", 1500, 1750),
+            ("dddd", 1750, 2000),
+            # unrelated speech (belongs to neither block)
+            ("xxxx", 3000, 3400),
+            ("yyyy", 3500, 3900),
+        ]
+    )
+    blocks = [
+        # 19 chars over 1s once snapped -> CPS 19, above target
+        {"idx": 1, "start_ms": 900, "end_ms": 2100, "text": "aaaa bbbb cccc dddd"},
+        # no whisper match; keeps its original SRT timing
+        {"idx": 2, "start_ms": 2080, "end_ms": 5000, "text": "zzzz qqqq"},
+    ]
+    out, unmatched = snap_to_whisper(blocks, segs, min_gap_ms=80, min_duration_ms=0)
+    assert unmatched == [2]
+    assert out[1]["start_ms"] == 2080
+    assert out[1]["end_ms"] == 5000
+    # and the matched block is not re-timed against the stale window either
+    assert out[0]["end_ms"] == 2000
+
+
 def test_min_duration_extends_into_silence_only():
     """A too-short block grows into the following pause, never over the next block's speech."""
     segs = _segs([("hi", 1000, 1300), ("there", 5000, 6000)])

--- a/tools/build_srt.py
+++ b/tools/build_srt.py
@@ -77,6 +77,10 @@ def enforce_gaps(blocks, config=None):
                 # Can't fix by shrinking prev — move current start forward instead
                 result[i - 1]["end_ms"] = result[i - 1]["start_ms"] + config.min_duration_ms
                 result[i]["start_ms"] = result[i - 1]["end_ms"] + config.min_gap_ms
+                # Moving start forward can pass the block's own end (nested
+                # mapping error) — keep start < end invariant
+                if result[i]["end_ms"] <= result[i]["start_ms"]:
+                    result[i]["end_ms"] = result[i]["start_ms"] + config.min_duration_ms
                 warnings.append(
                     f"  Forced gap: #{result[i - 1]['idx']}→#{result[i]['idx']} "
                     f"(moved block #{result[i]['idx']} start forward)"
@@ -97,42 +101,62 @@ def _cps(block):
 
 
 def _extend_block(blocks, i, deficit, config, max_cascade=10):
-    """Extend block i by deficit ms using cascade shifting.
+    """Extend block i by deficit ms into nearby silence.
 
-    Shifts neighbors wholesale into nearby silence gaps (up to max_cascade
-    blocks in each direction). Tries rightward first, then leftward.
+    The gap adjacent to block i is consumed directly (no shifting); any
+    remainder is opened by shifting neighbors wholesale into their own
+    downstream gaps (up to max_cascade blocks in each direction).
+    Tries rightward first, then leftward.
     Returns remaining deficit (0 = fully resolved).
     """
+    # === Extend END: eat the adjacent gap directly ===
+    if i + 1 < len(blocks):
+        gap = blocks[i + 1]["start_ms"] - blocks[i]["end_ms"]
+        take = min(deficit, max(0, gap - config.min_gap_ms))
+        blocks[i]["end_ms"] += take
+        deficit -= take
+
     # === Extend END: shift blocks to the right into gaps ===
-    right_slack = 0
-    for j in range(i, min(i + max_cascade, len(blocks) - 1)):
-        gap = blocks[j + 1]["start_ms"] - blocks[j]["end_ms"]
-        right_slack += max(0, gap - config.min_gap_ms)
+    if deficit > 0:
+        right_slack = 0
+        for j in range(i + 1, min(i + 1 + max_cascade, len(blocks) - 1)):
+            gap = blocks[j + 1]["start_ms"] - blocks[j]["end_ms"]
+            right_slack += max(0, gap - config.min_gap_ms)
 
-    extend_right = min(deficit, right_slack)
-    if extend_right > 0:
-        shift = extend_right
-        for j in range(i + 1, min(i + 1 + max_cascade, len(blocks))):
-            if shift <= 0:
-                break
-            blocks[j]["start_ms"] += shift
-            blocks[j]["end_ms"] += shift
-            if j + 1 < len(blocks):
-                gap = blocks[j + 1]["start_ms"] - blocks[j]["end_ms"]
-                if gap >= config.min_gap_ms:
+        extend_right = min(deficit, right_slack)
+        if extend_right > 0:
+            shift = extend_right
+            for j in range(i + 1, min(i + 1 + max_cascade, len(blocks))):
+                if shift <= 0:
                     break
-                shift = config.min_gap_ms - gap
+                blocks[j]["start_ms"] += shift
+                blocks[j]["end_ms"] += shift
+                if j + 1 < len(blocks):
+                    gap = blocks[j + 1]["start_ms"] - blocks[j]["end_ms"]
+                    if gap >= config.min_gap_ms:
+                        break
+                    shift = config.min_gap_ms - gap
 
-        blocks[i]["end_ms"] += extend_right
-        deficit -= extend_right
+            blocks[i]["end_ms"] += extend_right
+            deficit -= extend_right
+
+    # === Extend START: eat the adjacent gap (or lead-in silence) directly ===
+    if deficit > 0:
+        if i > 0:
+            gap = blocks[i]["start_ms"] - blocks[i - 1]["end_ms"]
+            take = min(deficit, max(0, gap - config.min_gap_ms))
+        else:
+            take = min(deficit, blocks[0]["start_ms"])
+        blocks[i]["start_ms"] -= take
+        deficit -= take
 
     # === Extend START: shift blocks to the left into gaps ===
-    if deficit > 0:
+    if deficit > 0 and i > 0:
         left_slack = 0
-        for j in range(i, max(i - max_cascade, 0), -1):
+        for j in range(i - 1, max(i - 1 - max_cascade, 0), -1):
             gap = blocks[j]["start_ms"] - blocks[j - 1]["end_ms"]
             left_slack += max(0, gap - config.min_gap_ms)
-        if i - max_cascade <= 0 and blocks[0]["start_ms"] > 0:
+        if i - 1 - max_cascade <= 0 and blocks[0]["start_ms"] > 0:
             left_slack += blocks[0]["start_ms"]
 
         extend_left = min(deficit, left_slack)

--- a/tools/snap_srt_to_whisper.py
+++ b/tools/snap_srt_to_whisper.py
@@ -167,19 +167,25 @@ def _word_gaps(wwords, min_sil_ms=150):
     return out
 
 
-def rebalance_short_blocks(blocks, wwords, target_cps=15, min_gap_ms=80, min_dur_ms=700):
+def rebalance_short_blocks(blocks, wwords, target_cps=15, min_gap_ms=80, min_dur_ms=700, matched_idx=None):
     """When a block reads too fast (CPS above target), move its boundary with the
     next block to even out the reading rate, so the next subtitle doesn't flash
     up while the dense phrase is still being heard. The boundary lands on a real
     whisper word edge (preferring an actual pause), never mid-silence guessing,
     and only when it lowers the pair's worst CPS. The two blocks' outer edges
     (this block's first word, the next block's last word) stay put, so neither
-    is pushed off its own speech — only the shared hand-off moves."""
+    is pushed off its own speech — only the shared hand-off moves.
+
+    Pairs where either block is unmatched (idx not in matched_idx) are skipped:
+    an unmatched block keeps its stale SRT timing, which is neither a valid
+    balance window nor allowed to move (contract: untouched, reviewed by hand)."""
     # candidate boundaries = every whisper word edge; pauses are naturally included
     edges = sorted({w[0] for w in wwords} | {w[1] for w in wwords})
     pauses = {ge for _gs, ge in _word_gaps(wwords)} | {gs for gs, _ge in _word_gaps(wwords)}
     for i in range(len(blocks) - 1):
         b, n = blocks[i], blocks[i + 1]
+        if matched_idx is not None and (b["idx"] not in matched_idx or n["idx"] not in matched_idx):
+            continue
         cb = len(b["text"].replace("\n", ""))
         cn = len(n["text"].replace("\n", ""))
         dur_b = b["end_ms"] - b["start_ms"]
@@ -235,7 +241,7 @@ def snap_to_whisper(blocks, segments, min_gap_ms=80, min_duration_ms=1000, targe
     # 2) where speech is continuous (no pause) but a block still reads too fast,
     #    even out the shared boundary with the next block at a real word edge.
     distribute_pauses(blocks, matched_idx, target_cps, min_gap_ms)
-    rebalance_short_blocks(blocks, wwords, target_cps=target_cps, min_gap_ms=min_gap_ms)
+    rebalance_short_blocks(blocks, wwords, target_cps=target_cps, min_gap_ms=min_gap_ms, matched_idx=matched_idx)
 
     # Floor: keep any block at least min_duration_ms, borrowing only from a
     # following pause (never over the next block's speech).


### PR DESCRIPTION
Three timing-core defects from the 2026-07-02 multi-agent audit (each adversarially verified and reproduced by execution), fixed test-first.

## 1. `build_srt._extend_block` — counted adjacent gap as slack but never consumed it (HIGH)

The slack window started at the gap between block *i* and *i+1*, but the shift mechanism moves `blocks[i].end_ms` and `blocks[i+1].start_ms` together, so that gap is arithmetically invariant — its slack was promised but never delivered. When the only real silence sat right next to the block, the cascade shifted up to `max_cascade` downstream blocks wholesale off their audio (audit repro: +1667 ms drift on blocks 2–11 while the build report printed `Overlaps: 0`), and could leave a large overlap at the cascade boundary that a later `enforce_gaps` silently "healed". Mirrored defect on the left side.

**Fix:** consume the adjacent gap directly (no shifting) first; cascade only for the remainder, with the slack window aligned to the gaps the shift loop can actually eat. Verified against the audit's end-to-end geometry: the +1667 ms wholesale desync is gone and audio-anchored neighbours stay put when adjacent silence suffices.

## 2. `build_srt.enforce_gaps` — forced-gap fallback could emit `start > end` (MEDIUM)

When a block is nested inside its predecessor (LLM mapping error, which `cmd_assemble` does not reject cross-block), the fallback moved the block's start past its own end. Now clamps the end to preserve `start < end`.

## 3. `snap_srt_to_whisper.rebalance_short_blocks` — re-timed unmatched blocks (MEDIUM)

`snap_to_whisper` gates `distribute_pauses` and the min-duration floor on `matched_idx`, but the rebalance pass received no matched info: it moved unmatched blocks (whose stale SRT timing the module contract explicitly promises to leave untouched for hand review) and used that stale timing as the balance window. Now pairs involving an unmatched block are skipped.

## Tests
- 7 new tests (all watched failing first for the right reason): 5 for `_extend_block`/`balance_cps` neighbour anchoring, 1 for the forced-gap invariant, 1 for unmatched-block immutability through the public `snap_to_whisper` API.
- Full fast lane: `624 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)