### PR TITLE
fix(sync): scope transcript-diff patches to the edited paragraph's block

### DIFF
--- a/tests/test_sync_transcript.py
+++ b/tests/test_sync_transcript.py
@@ -467,26 +467,131 @@ class TestMismatchedBlockSplits:
         assert srt_blocks[1]["end_ms"] == 15000
 
 
+class TestFragmentScoping:
+    """The diff fragment must be applied inside the changed paragraph's own
+    blocks — a short fragment (e.g. the euphony edit « і » → « й ») almost
+    always occurs in other blocks too, and patching the first global match
+    corrupts an unrelated block while dropping the intended edit."""
+
+    @pytest.fixture
+    def two_para_talk(self, tmp_path):
+        talk = tmp_path / "talks" / "test"
+        video = talk / "Video" / "final"
+        video.mkdir(parents=True)
+        srt_content = """1
+00:00:01,000 --> 00:00:05,000
+Мати дала нам силу і любов.
+
+2
+00:00:05,100 --> 00:00:10,000
+Ми прийшли сюди і ми раді.
+"""
+        (video / "uk.srt").write_text(srt_content, encoding="utf-8")
+        old = HEADER + "Мати дала нам силу і любов.\n\nМи прийшли сюди і ми раді.\n"
+        (talk / "transcript_uk_old.txt").write_text(old, encoding="utf-8")
+        return talk
+
+    def test_short_fragment_patches_the_edited_paragraph_not_the_first_match(self, two_para_talk):
+        new = HEADER + "Мати дала нам силу і любов.\n\nМи прийшли сюди й ми раді.\n"
+        new_path = two_para_talk / "new.txt"
+        new_path.write_text(new, encoding="utf-8")
+
+        result = sync_transcript(
+            str(two_para_talk), "Video", str(two_para_talk / "transcript_uk_old.txt"), str(new_path)
+        )
+        assert not result.get("error")
+
+        from tools.srt_utils import parse_srt
+
+        srt = parse_srt(str(two_para_talk / "Video" / "final" / "uk.srt"))
+        assert srt[0]["text"] == "Мати дала нам силу і любов."  # untouched
+        assert srt[1]["text"] == "Ми прийшли сюди й ми раді."  # the actual edit
+
+    def test_drifted_srt_with_ambiguous_fragment_errors_instead_of_guessing(self, tmp_path):
+        """When SRT text has drifted from the transcript (word streams no longer
+        equal) and the fragment appears in several blocks, refuse loudly —
+        the caller falls back to the full pipeline."""
+        talk = tmp_path / "talks" / "test"
+        video = talk / "Video" / "final"
+        video.mkdir(parents=True)
+        # SRT drifted: «щось!» vs transcript «щось.»
+        srt_content = """1
+00:00:01,000 --> 00:00:05,000
+Так само і тут щось!
+
+2
+00:00:05,100 --> 00:00:10,000
+І знову і тут інше.
+"""
+        (video / "uk.srt").write_text(srt_content, encoding="utf-8")
+        old = HEADER + "Так само і тут щось.\n\nІ знову і тут інше.\n"
+        (talk / "transcript_uk_old.txt").write_text(old, encoding="utf-8")
+        new = HEADER + "Так само й тут щось.\n\nІ знову і тут інше.\n"
+        new_path = talk / "new.txt"
+        new_path.write_text(new, encoding="utf-8")
+
+        result = sync_transcript(str(talk), "Video", str(talk / "transcript_uk_old.txt"), str(new_path))
+        assert "error" in result
+
+        from tools.srt_utils import parse_srt
+
+        srt = parse_srt(str(talk / "Video" / "final" / "uk.srt"))
+        assert srt[0]["text"] == "Так само і тут щось!"  # nothing written
+        assert srt[1]["text"] == "І знову і тут інше."
+
+    def test_drifted_srt_with_unique_fragment_still_applies(self, tmp_path):
+        """Drifted SRT (whisper-shaped blocks) keeps working when the fragment
+        is unambiguous across the whole file."""
+        talk = tmp_path / "talks" / "test"
+        video = talk / "Video" / "final"
+        video.mkdir(parents=True)
+        srt_content = """1
+00:00:01,000 --> 00:00:05,000
+Так само і тут щось!
+
+2
+00:00:05,100 --> 00:00:10,000
+І знову і тут інше.
+"""
+        (video / "uk.srt").write_text(srt_content, encoding="utf-8")
+        old = HEADER + "Так само і тут щось.\n\nІ знову і тут інше.\n"
+        (talk / "transcript_uk_old.txt").write_text(old, encoding="utf-8")
+        new = HEADER + "Так само і тут дещо.\n\nІ знову і тут інше.\n"
+        new_path = talk / "new.txt"
+        new_path.write_text(new, encoding="utf-8")
+
+        result = sync_transcript(str(talk), "Video", str(talk / "transcript_uk_old.txt"), str(new_path))
+        assert not result.get("error")
+
+        from tools.srt_utils import parse_srt
+
+        srt = parse_srt(str(talk / "Video" / "final" / "uk.srt"))
+        assert srt[0]["text"] == "Так само і тут дещо!"
+        assert srt[1]["text"] == "І знову і тут інше."
+
+
 class TestFindDiff:
     """Unit tests for _find_diff helper."""
 
     def test_single_word_change(self):
-        old_f, new_f = _find_diff("Перше речення абзацу.", "Перше речення параграфу.")
+        old_f, new_f, offset = _find_diff("Перше речення абзацу.", "Перше речення параграфу.")
         # Prefix/suffix trimming: common suffix "у." is trimmed
         assert "абзац" in old_f
         assert "парагра" in new_f or "параграф" in new_f
+        assert "Перше речення абзацу."[offset : offset + len(old_f)] == old_f
 
     def test_empty_old_returns_empty(self):
-        old_f, _ = _find_diff("", "нове")
+        old_f, _, _ = _find_diff("", "нове")
         assert old_f == ""
 
     def test_multiple_changes(self):
-        old_f, new_f = _find_diff("AAAA. Текст. BBBB!", "CCCC. Текст. DDDD!")
+        old_f, new_f, offset = _find_diff("AAAA. Текст. BBBB!", "CCCC. Текст. DDDD!")
         # Both changes captured in one fragment
         assert "AAAA" in old_f
         assert "BBBB" in old_f
         assert "CCCC" in new_f
         assert "DDDD" in new_f
+        assert offset == 0
 
 
 class TestApplyDiffEdgeCases:

--- a/tools/sync_transcript_to_srt.py
+++ b/tools/sync_transcript_to_srt.py
@@ -133,18 +133,18 @@ def _apply_diff(old_para: str, new_para: str, srt_blocks: list, p_idx: int, loc:
     if not old_frag:
         return {"error": (f"P{p_idx + 1}: cannot determine changed text — run the full subtitle pipeline to rebuild")}
 
-    target = None
+    applied = False
     if loc is not None:
         block, offset = loc
         if offset >= 0 and block["text"][offset : offset + len(old_frag)] == old_frag:
             block["text"] = block["text"][:offset] + new_frag + block["text"][offset + len(old_frag) :]
-            target = block
+            applied = True
         elif old_frag in block["text"]:
             # offset arithmetic thrown off by whitespace variance — still the right block
             block["text"] = block["text"].replace(old_frag, new_frag, 1)
-            target = block
+            applied = True
 
-    if target is None:
+    if not applied:
         hits = [b for b in srt_blocks if old_frag in b["text"]]
         if not hits:
             return {"error": (f"P{p_idx + 1}: cannot find «{old_frag[:60]}» in SRT blocks")}
@@ -156,7 +156,6 @@ def _apply_diff(old_para: str, new_para: str, srt_blocks: list, p_idx: int, loc:
                 )
             }
         hits[0]["text"] = hits[0]["text"].replace(old_frag, new_frag, 1)
-        target = hits[0]
 
     print(
         f"  P{p_idx + 1}: «{old_frag[:60]}» → «{new_frag[:60]}»",

--- a/tools/sync_transcript_to_srt.py
+++ b/tools/sync_transcript_to_srt.py
@@ -16,6 +16,7 @@ Usage:
 """
 
 import argparse
+import re
 import sys
 from pathlib import Path
 
@@ -43,11 +44,12 @@ def find_paragraph_blocks(srt_blocks: list, para_blocks: list) -> list | None:
     return None
 
 
-def _find_diff(old_para: str, new_para: str) -> tuple[str, str]:
+def _find_diff(old_para: str, new_para: str) -> tuple[str, str, int]:
     """Find the changed region between old and new paragraph text.
 
-    Returns (old_fragment, new_fragment) — the minimal differing middle
-    with enough surrounding context for unique matching in SRT blocks.
+    Returns (old_fragment, new_fragment, offset) — the minimal differing
+    middle with enough surrounding context for matching in SRT blocks, and
+    the fragment's exact character offset within old_para.
     """
     # Common prefix
     prefix_len = 0
@@ -78,35 +80,88 @@ def _find_diff(old_para: str, new_para: str) -> tuple[str, str]:
         old_mid = old_para[prefix_len:old_end]
         new_mid = new_para[prefix_len:new_end]
 
-    return old_mid, new_mid
+    return old_mid, new_mid, prefix_len
 
 
-def _apply_diff(old_para: str, new_para: str, srt_blocks: list, p_idx: int) -> dict | None:
+def _locate_fragment(old_paras: list, p_idx: int, frag_lo: int, frag_hi: int, srt_blocks: list) -> tuple | None:
+    """(block_index, char_offset) of paragraph p_idx's fragment [frag_lo, frag_hi).
+
+    Maps by word-stream position: transcript paragraphs and SRT blocks carry
+    the same words in the same order even when segmented differently
+    (whisper-built SRTs combine sentences prepare_blocks would split).
+    Returns None when the streams have drifted or the fragment straddles a
+    block boundary — the caller must then fall back to a stricter search.
+    """
+    para_words = [list(re.finditer(r"\S+", p)) for p in old_paras]
+    block_words = [list(re.finditer(r"\S+", b["text"])) for b in srt_blocks]
+    if [m.group() for ms in para_words for m in ms] != [m.group() for ms in block_words for m in ms]:
+        return None
+
+    words = para_words[p_idx]
+    if not words:
+        return None
+    touched = [k for k, m in enumerate(words) if m.start() < frag_hi and m.end() > frag_lo]
+    if not touched:  # whitespace-only fragment: anchor to the next word
+        touched = [k for k, m in enumerate(words) if m.start() >= frag_lo][:1] or [len(words) - 1]
+
+    w0 = sum(len(ms) for ms in para_words[:p_idx])
+    g_lo, g_hi = w0 + touched[0], w0 + touched[-1]
+
+    pos = 0
+    for ms, block in zip(block_words, srt_blocks, strict=True):
+        if pos <= g_lo and g_hi < pos + len(ms):
+            anchor = ms[g_lo - pos]
+            offset = anchor.start() + (frag_lo - words[touched[0]].start())
+            return block, offset
+        pos += len(ms)
+    return None  # fragment straddles a block boundary
+
+
+def _apply_diff(old_para: str, new_para: str, srt_blocks: list, p_idx: int, loc: tuple | None = None) -> dict | None:
     """Apply text diff from old_para → new_para to SRT blocks.
 
-    Finds the changed region (prefix/suffix trimming), then searches
-    SRT blocks for the old fragment and replaces it in-place.
+    Finds the changed region (prefix/suffix trimming), then replaces the old
+    fragment at `loc` — the (block, offset) located by word-stream position.
+    Without a location (streams drifted, boundary straddle) the fragment is
+    applied only if it is unambiguous across the whole SRT; a short fragment
+    found in several blocks is an error, never a first-match guess.
 
     Returns an error dict on failure, or None on success.
     """
-    old_frag, new_frag = _find_diff(old_para, new_para)
+    old_frag, new_frag, _ = _find_diff(old_para, new_para)
 
     if not old_frag:
         return {"error": (f"P{p_idx + 1}: cannot determine changed text — run the full subtitle pipeline to rebuild")}
 
-    found = False
-    for block in srt_blocks:
-        if old_frag in block["text"]:
+    target = None
+    if loc is not None:
+        block, offset = loc
+        if offset >= 0 and block["text"][offset : offset + len(old_frag)] == old_frag:
+            block["text"] = block["text"][:offset] + new_frag + block["text"][offset + len(old_frag) :]
+            target = block
+        elif old_frag in block["text"]:
+            # offset arithmetic thrown off by whitespace variance — still the right block
             block["text"] = block["text"].replace(old_frag, new_frag, 1)
-            found = True
-            print(
-                f"  P{p_idx + 1}: «{old_frag[:60]}» → «{new_frag[:60]}»",
-                file=sys.stderr,
-            )
-            break
+            target = block
 
-    if not found:
-        return {"error": (f"P{p_idx + 1}: cannot find «{old_frag[:60]}» in SRT blocks")}
+    if target is None:
+        hits = [b for b in srt_blocks if old_frag in b["text"]]
+        if not hits:
+            return {"error": (f"P{p_idx + 1}: cannot find «{old_frag[:60]}» in SRT blocks")}
+        if len(hits) > 1:
+            return {
+                "error": (
+                    f"P{p_idx + 1}: «{old_frag[:60]}» is ambiguous ({len(hits)} blocks) — "
+                    "run the full subtitle pipeline to rebuild"
+                )
+            }
+        hits[0]["text"] = hits[0]["text"].replace(old_frag, new_frag, 1)
+        target = hits[0]
+
+    print(
+        f"  P{p_idx + 1}: «{old_frag[:60]}» → «{new_frag[:60]}»",
+        file=sys.stderr,
+    )
 
     # CPL check on all blocks after replacement
     for block in srt_blocks:
@@ -146,9 +201,17 @@ def sync_transcript(talk_dir: str, video_slug: str, old_transcript: str, new_tra
 
     print(f"Changed paragraphs: {len(changed_paras)}", file=sys.stderr)
 
+    # Locate every fragment against the pristine blocks before mutating any
+    # text — applied edits would desync the word streams for later paragraphs.
+    locs = {}
+    for p_idx in changed_paras:
+        old_frag, _new_frag, frag_lo = _find_diff(old_paras[p_idx], new_paras[p_idx])
+        if old_frag:
+            locs[p_idx] = _locate_fragment(old_paras, p_idx, frag_lo, frag_lo + len(old_frag), srt_blocks)
+
     total_updated = 0
     for p_idx in changed_paras:
-        err = _apply_diff(old_paras[p_idx], new_paras[p_idx], srt_blocks, p_idx)
+        err = _apply_diff(old_paras[p_idx], new_paras[p_idx], srt_blocks, p_idx, locs.get(p_idx))
         if err:
             return err
         total_updated += 1


### PR DESCRIPTION
HIGH from the 2026-07-02 multi-agent audit (adversarially verified, reproduced by execution).

## The bug

`sync_transcript_to_srt._apply_diff` searched the diff fragment — which `_find_diff` shrinks to as little as 3 characters — across **all** SRT blocks and patched the **first** match. The most common Ukrainian copy-edit, the euphony fix `« і » → « й »`, produces exactly such a fragment, and real SRTs contain `« і »` in dozens of blocks. Result: an unrelated earlier block got silently corrupted, the actually-edited block kept its old text, the CLI exited 0 — and for en-srt-mode primaries and secondaries (13 of 15 build manifests) `sync_pr`'s follow-up validation runs with `skip_text_check`, so the corruption shipped to the repo unflagged.

## The fix

- `_find_diff` now also returns the fragment's exact offset within the paragraph (known by construction from prefix trimming).
- New `_locate_fragment` maps that offset to the exact `(block, char offset)` by **word-stream position** — transcript paragraphs and SRT blocks carry the same words in the same order however they're segmented, so this works for whisper-shaped SRTs that combine sentences differently.
- All fragments are located against the pristine blocks **before** any mutation (earlier edits would desync the streams for later paragraphs).
- Fallback when streams have drifted or the fragment straddles a block boundary: apply only if the fragment is **unambiguous** across the whole SRT; multiple candidates → loud error with the existing full-pipeline-fallback wording. Never a first-match guess.

## Tests
- New `TestFragmentScoping` (3 tests, the two corruption scenarios watched failing first): ambiguous euphony edit patches the edited paragraph's block; drifted SRT + ambiguous fragment errors without writing; drifted SRT + unique fragment still applies.
- Full fast lane: 620 passed; sync suites (`test_sync_transcript`, `test_sync_pr`, `test_sync_srt`): 65 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)