### PR TITLE
fix(sync-tools): four robustness bugs (double-space split, deleted-SRT crash, cursor drift, 0-block stats)

### DIFF
--- a/tests/test_srt_utils.py
+++ b/tests/test_srt_utils.py
@@ -141,3 +141,12 @@ def test_calc_stats_empty():
     assert stats["total_blocks"] == 0
     assert stats["avg_cps"] == 0
     assert stats["max_cps"] == 0
+
+
+def test_format_stats_empty_does_not_crash():
+    """A 0-block SRT must produce a report, not ZeroDivisionError — the
+    validator turns it into a FAILED report instead of a traceback."""
+    from tools.srt_utils import format_stats
+
+    report = format_stats(calc_stats([]), label="empty")
+    assert "Total blocks: 0" in report

--- a/tests/test_sync_pr.py
+++ b/tests/test_sync_pr.py
@@ -196,6 +196,28 @@ class TestSyncPrIntegration:
         assert "Перше речення першого абзацу." not in v2_after
         assert "Єдине речення другого абзацу." not in v2_after
 
+    def test_deleted_srt_is_skipped_not_crashing_the_driver(self, repo):
+        """A PR that deletes a final/uk.srt must not kill the whole driver
+        with FileNotFoundError — the deleted SRT is skipped and the rest of
+        the sync still runs."""
+        repo_path, base_sha = repo
+        talk = repo_path / "talks" / "test"
+        _git(repo_path, "rm", "-q", "talks/test/Video1/final/uk.srt")
+        transcript = talk / "transcript_uk.txt"
+        transcript.write_text(
+            BASE_TRANSCRIPT.replace("Єдине речення другого абзацу.", "Нове речення другого абзацу."),
+            encoding="utf-8",
+        )
+        _git(repo_path, "add", "talks")
+        _git(repo_path, "commit", "-q", "-m", "delete v1 srt + edit transcript")
+
+        exit_code = run(base_sha)
+        assert exit_code == 0
+
+        assert not (talk / "Video1" / "final" / "uk.srt").exists()  # stays deleted
+        v2_after = (talk / "Video2" / "final" / "uk.srt").read_text(encoding="utf-8")
+        assert "Нове речення другого абзацу." in v2_after  # Step B still ran
+
     def test_no_changes_returns_zero(self, repo):
         """Nothing changed in the PR — driver should noop and exit 0."""
         repo_path, base_sha = repo

--- a/tests/test_sync_srt.py
+++ b/tests/test_sync_srt.py
@@ -646,6 +646,55 @@ class TestSyncSrtToTranscript:
         assert result["changed"] == 1
         assert "Виправлене перше речення." in (talk / "transcript_uk.txt").read_text(encoding="utf-8")
 
+    def test_duplicate_delete_survives_case_drift_in_cursor_walk(self, tmp_path):
+        """Deleting a block whose text occurs earlier in the transcript must
+        remove the RIGHT occurrence even when a preceding unchanged block has
+        benign case drift (which used to stall the cursor walk, making the
+        deletion grab the earlier duplicate)."""
+        talk_dir = tmp_path / "talks" / "test"
+        video = talk_dir / "Video" / "final"
+        video.mkdir(parents=True)
+
+        old_srt = """1
+00:00:01,000 --> 00:00:05,000
+Вітаю всіх присутніх тут.
+
+2
+00:00:05,100 --> 00:00:07,000
+Так.
+
+3
+00:00:07,100 --> 00:00:10,000
+Дякую вам.
+"""
+        # user deletes block 2 («Так.»)
+        new_srt = """1
+00:00:01,000 --> 00:00:05,000
+Вітаю всіх присутніх тут.
+
+2
+00:00:07,100 --> 00:00:10,000
+Дякую вам.
+"""
+        (talk_dir / "uk_old.srt").write_text(old_srt, encoding="utf-8")
+        (video / "uk.srt").write_text(new_srt, encoding="utf-8")
+
+        # transcript has a leading «Так.» that belongs to no SRT block, and
+        # block 1 drifted in capitalization («вітаю» lowercase)
+        transcript = HEADER + "Так. вітаю всіх присутніх тут. Так. Дякую вам.\n"
+        (talk_dir / "transcript_uk.txt").write_text(transcript, encoding="utf-8")
+
+        result = sync_srt_to_transcript(
+            old_srt=str(talk_dir / "uk_old.srt"),
+            new_srt=str(video / "uk.srt"),
+            transcript=str(talk_dir / "transcript_uk.txt"),
+        )
+        assert result.get("removed") == 1
+
+        text = (talk_dir / "transcript_uk.txt").read_text(encoding="utf-8")
+        # the block-2 «Так.» (after «тут.») is gone, the leading one survives
+        assert "Так. вітаю всіх присутніх тут. Дякую вам." in text
+
     def test_cli_entrypoint_writes_file(self, talk):
         """The module CLI should run end-to-end and update the transcript."""
         import subprocess

--- a/tests/test_text_segmentation.py
+++ b/tests/test_text_segmentation.py
@@ -69,6 +69,20 @@ def test_split_text_to_lines_enforces_cpl() -> None:
         assert len(line) <= MAX_CPL, line
 
 
+def test_split_text_double_space_never_cuts_mid_word() -> None:
+    # A run of extra whitespace must not skew split positions: every produced
+    # line has to consist of whole words of the original text.
+    text = (
+        "Це  дуже довге речення яке містить подвійний пробіл на початку і має бути "
+        "розділене на частини без розривів посередині слова."
+    )
+    assert len(text) > MAX_CPL
+    lines = split_text_to_lines(text)
+    for line in lines:
+        assert len(line) <= MAX_CPL, line
+    assert " ".join(lines).split() == text.split()
+
+
 def test_split_text_prefers_punctuation() -> None:
     # A comma should be a preferred break point — if any line ends right
     # after the comma, the splitter honoured punctuation priority.

--- a/tools/srt_utils.py
+++ b/tools/srt_utils.py
@@ -168,9 +168,7 @@ def format_stats(stats, label=""):
     lines.append(f"  CPS > hard max: {stats['cps_over_hard']} ({stats['cps_over_hard'] / n * 100:.1f}%)")
     lines.append(f"  CPL: avg={stats['avg_cpl']:.1f}, max={stats['max_cpl']}")
     lines.append(f"  CPL > max: {stats['cpl_over_max']} ({stats['cpl_over_max'] / n * 100:.1f}%)")
-    lines.append(
-        f"  Chars > max block: {stats['chars_over_max']} ({stats['chars_over_max'] / stats['total_blocks'] * 100:.1f}%)"
-    )
+    lines.append(f"  Chars > max block: {stats['chars_over_max']} ({stats['chars_over_max'] / n * 100:.1f}%)")
     lines.append(f"  Lines > max: {stats['lines_over_max']}")
     lines.append(f"  Duration < min: {stats['duration_under_min']}")
     lines.append(f"  Duration > max: {stats['duration_over_max']}")

--- a/tools/sync_common.py
+++ b/tools/sync_common.py
@@ -37,6 +37,19 @@ def find_in_text(text: str, needle: str, cursor: int) -> int:
     return text.find(needle, cursor)
 
 
+def find_in_text_lenient(text: str, needle: str, cursor: int) -> int:
+    """find_in_text, falling back to a case-insensitive search.
+
+    Used for cursor tracking across blocks with benign case drift
+    (manual capitalization edits) — a stalled cursor makes later
+    duplicate-text operations pick the wrong occurrence.
+    """
+    pos = text.find(needle, cursor)
+    if pos != -1:
+        return pos
+    return text.lower().find(needle.lower(), cursor)
+
+
 def delete_from_text(text: str, cursor: int, needle: str) -> dict:
     """Remove the first occurrence of `needle` in `text` at/after `cursor`.
 

--- a/tools/sync_pr.py
+++ b/tools/sync_pr.py
@@ -137,6 +137,10 @@ def _process_talk(
     step_a_failed = False
     for srt in srt_paths:
         video_slug = srt.split("/")[2]
+        if not Path(srt).exists():
+            # `git diff --name-only` also lists deletions — nothing to sync
+            print(f"  [{talk_id}/{video_slug}] SRT deleted in this PR — skip", file=sys.stderr)
+            continue
         base_srt = tmp / f"{talk_id}__{video_slug}.base.srt"
         if not _show_base(base_sha, srt, base_srt):
             print(f"  [{talk_id}/{video_slug}] SRT is new in this PR — skip", file=sys.stderr)

--- a/tools/sync_srt_to_transcript.py
+++ b/tools/sync_srt_to_transcript.py
@@ -29,7 +29,7 @@ import difflib
 import sys
 
 from .srt_utils import parse_srt, write_srt
-from .sync_common import delete_from_text, find_in_text
+from .sync_common import delete_from_text, find_in_text, find_in_text_lenient
 
 # Thin aliases kept for in-file readability (and to not churn call sites).
 _find_in_transcript = find_in_text
@@ -95,7 +95,10 @@ def sync_srt_to_transcript(old_srt: str, new_srt: str, transcript: str) -> dict:
             # cursor doesn't matter and the workflow still does the right
             # thing.
             for k in range(i1, i2):
-                pos = _find_in_transcript(text, old_texts[k], cursor)
+                # Lenient (case-insensitive) fallback: benign capitalization
+                # drift must not stall the cursor, or a later deletion of
+                # duplicated text grabs an earlier occurrence.
+                pos = find_in_text_lenient(text, old_texts[k], cursor)
                 if pos == -1:
                     drifted += 1
                     continue

--- a/tools/text_segmentation.py
+++ b/tools/text_segmentation.py
@@ -150,18 +150,18 @@ def _split_once(text: str) -> list[str]:
 
     Returns two parts, or [text] if can't split.
     """
-    words = text.split()
+    words = list(re.finditer(r"\S+", text))
     if len(words) <= 1:
         return [text]
 
     mid = len(text) // 2
     candidates: list[tuple[int, int, int]] = []  # (char_pos, priority, distance_from_mid)
-    char_pos = 0
 
-    for i, word in enumerate(words[:-1]):
-        char_pos += len(word)
-        next_word = words[i + 1]
-        next_clean = next_word.lower().rstrip(".,;:!?—»\"'")
+    for i, m in enumerate(words[:-1]):
+        word = m.group()
+        char_pos = m.end()
+        next_m = words[i + 1]
+        next_clean = next_m.group().lower().rstrip(".,;:!?—»\"'")
 
         if word[-1] in ".!?":
             priority = 1
@@ -175,19 +175,14 @@ def _split_once(text: str) -> list[str]:
             priority = 5
 
         left_len = char_pos
-        right_len = len(text) - char_pos - 1
+        right_len = len(text) - next_m.start()
 
         if left_len <= MAX_CPL and right_len <= MAX_CPL:
             candidates.append((char_pos, priority, abs(char_pos - mid)))
 
-        char_pos += 1  # space
-
     if not candidates:
-        char_pos = 0
-        for word in words[:-1]:
-            char_pos += len(word)
-            candidates.append((char_pos, 5, abs(char_pos - mid)))
-            char_pos += 1
+        for m in words[:-1]:
+            candidates.append((m.end(), 5, abs(m.end() - mid)))
 
     if not candidates:
         return [text]


### PR DESCRIPTION
Four MEDIUM/LOW findings from the 2026-07-02 multi-agent audit (each adversarially verified), fixed test-first in the sync toolchain.

1. **`text_segmentation._split_once` — double space cuts words in half.** Split positions were accumulated as `len(word)+1` per word after `text.split()`, so every whitespace run longer than one space skewed all candidate positions and `text[:split_at]` cut mid-word (`«на початк» / «у і має…»`). Positions now come from `re.finditer(r"\S+")` spans over the original text; the CPL/priority logic is unchanged.

2. **`sync_pr` — a PR deleting a `final/uk.srt` killed the whole driver.** `git diff --name-only` lists deletions, `_classify` fed the dead path into Step A, and `parse_srt` raised an uncaught `FileNotFoundError` — remaining talks never got processed. Deleted SRTs are now skipped with a log note; the rest of the sync (including Step B for surviving videos) proceeds.

3. **`sync_srt_to_transcript` — wrong duplicate deleted after case drift.** The equal-block cursor walk left the cursor behind whenever a preceding block wasn't found verbatim (e.g. manual capitalization edits); a later deletion of duplicated text («Так.») then removed the *first* occurrence after the stale cursor — silently corrupting the transcript while reporting success. The walk now uses a case-insensitive fallback (`sync_common.find_in_text_lenient`) so benign drift no longer stalls the cursor.

4. **`srt_utils.format_stats` — ZeroDivisionError on a 0-block SRT.** One report row divided by raw `total_blocks` instead of the zero-guarded `n` used by every other row, so validate/optimize died with a traceback instead of a FAILED report on empty/corrupt input.

## Tests
4 new tests, each watched failing first for the audited reason. Full fast lane: 621 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)