### PR TITLE
fix(io): slug allowlist path-safety, tuple-type SchemaError, retryable empty extraction

### DIFF
--- a/tests/test_fetch_transcripts.py
+++ b/tests/test_fetch_transcripts.py
@@ -1,0 +1,54 @@
+"""Tests for tools.fetch_transcripts (sentinel semantics)."""
+
+import os
+
+from tools.fetch_transcripts import fetch_and_save
+
+
+class _StubDownloader:
+    """Downloader stub: page fetches fine but yields the given transcript."""
+
+    def __init__(self, text):
+        self._text = text
+
+    def fetch_talk_page(self, url):
+        return "<soup>"
+
+    def extract_transcript(self, soup):
+        return self._text
+
+
+class _Stub404Downloader:
+    def fetch_talk_page(self, url):
+        raise RuntimeError("HTTP 404 Not Found")
+
+    def extract_transcript(self, soup):  # pragma: no cover — never reached
+        raise AssertionError
+
+
+def test_empty_extraction_writes_no_sentinel(tmp_path):
+    """A page that loads but yields no transcript (expired cookie, stub page,
+    layout change) must NOT be stamped complete forever — no sentinel file,
+    so the next run retries."""
+    out = tmp_path / "corpus" / "slug" / "en.txt"
+    status = fetch_and_save(_StubDownloader(None), "https://x", str(out), "en")
+    assert status == "empty"
+    assert not out.exists()
+
+
+def test_real_404_still_writes_sentinel(tmp_path):
+    """A genuine 404 keeps the empty-sentinel behavior (never refetched)."""
+    out = tmp_path / "corpus" / "slug" / "en.txt"
+    status = fetch_and_save(_Stub404Downloader(), "https://x", str(out), "en")
+    assert status == "404"
+    assert out.exists()
+    assert out.read_text(encoding="utf-8") == ""
+
+
+def test_ok_extraction_written(tmp_path):
+    out = tmp_path / "corpus" / "slug" / "en.txt"
+    text = "Перший абзац. " * 20
+    status = fetch_and_save(_StubDownloader(text), "https://x", str(out), "en")
+    assert status == "ok"
+    assert out.read_text(encoding="utf-8") == text
+    assert os.path.getsize(out) > 0

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -107,6 +107,17 @@ def test_whisper_small_overlap_accepted(tmp_path: Path) -> None:
     validate_whisper_json(_w(tmp_path, "whisper.json", ok))
 
 
+def test_whisper_wrong_typed_start_raises_schema_error(tmp_path: Path) -> None:
+    """A string start/end (hand-edited whisper.json) must surface as a
+    SchemaError with a readable message — not AttributeError from formatting
+    a tuple of expected types."""
+    bad = json.loads(json.dumps(GOOD_WHISPER))
+    bad["segments"][0]["start"] = "1.5"
+    path = _w(tmp_path, "whisper.json", bad)
+    with pytest.raises(SchemaError, match="expected int/float, got str"):
+        validate_whisper_json(path)
+
+
 def test_whisper_bad_json(tmp_path: Path) -> None:
     p = tmp_path / "whisper.json"
     p.write_text("{not json", encoding="utf-8")

--- a/tests/test_workflow_validation.py
+++ b/tests/test_workflow_validation.py
@@ -65,6 +65,13 @@ def test_video_slug_accepts(value: str) -> None:
         "a/b",
         "x" * 200,
         'slug";curl x;"',
+        # path-safety: dot-only and option-like values defeat the allowlist
+        ".",
+        "..",
+        "...",
+        "-rf",
+        "--help",
+        ".hidden",
     ],
 )
 def test_video_slug_rejects(value: str) -> None:

--- a/tools/fetch_transcripts.py
+++ b/tools/fetch_transcripts.py
@@ -57,14 +57,16 @@ def fetch_and_save(downloader, url, output_path, label):
         return "error"
 
     text = downloader.extract_transcript(soup)
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
     if not text:
-        with open(output_path, "w", encoding="utf-8") as f:
-            f.write(SENTINEL_CONTENT)
-        print(f"    {label}: no transcript found (sentinel written)")
+        # No sentinel: an empty extraction usually means an expired cookie or
+        # a layout change, not a missing transcript — stamping the slug
+        # complete would skip it on every future run. Only a real 404 above
+        # writes the sentinel.
+        print(f"    {label}: no transcript found (will retry next run)")
         return "empty"
 
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
     with open(output_path, "w", encoding="utf-8") as f:
         f.write(text)
 

--- a/tools/schemas.py
+++ b/tools/schemas.py
@@ -43,10 +43,13 @@ def _require(obj: Any, key: str, expected_type: type, source: str, path: str) ->
         raise SchemaError(source, path, f"missing required field '{key}'")
     value = obj[key]
     if not isinstance(value, expected_type):
+        expected = (
+            "/".join(t.__name__ for t in expected_type) if isinstance(expected_type, tuple) else expected_type.__name__
+        )
         raise SchemaError(
             source,
             f"{path}.{key}",
-            f"expected {expected_type.__name__}, got {type(value).__name__}",
+            f"expected {expected}, got {type(value).__name__}",
         )
     return value
 

--- a/tools/workflow_validation.py
+++ b/tools/workflow_validation.py
@@ -10,7 +10,9 @@ import re
 import sys
 
 TALK_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}_[A-Za-z0-9_.-]{1,80}$")
-VIDEO_SLUG_RE = re.compile(r"^[A-Za-z0-9_.-]{1,64}$")
+# First char alphanumeric/underscore: rejects dot-only values (".", "..")
+# and option-like values ("-rf", "--help") that defeat path safety.
+VIDEO_SLUG_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.-]{0,63}$")
 VIMEO_URL_RE = re.compile(r"^https://(?:www\.)?(?:vimeo\.com|player\.vimeo\.com/video)/\d+(?:/[0-9a-f]+)?/?$")
 
 


### PR DESCRIPTION
Three LOW findings from the 2026-07-02 multi-agent audit (adversarially verified, proven by execution), fixed test-first.

1. **`workflow_validation.VIDEO_SLUG_RE` accepts `.` / `..` / option-like values.** The allowlist `[A-Za-z0-9_.-]{1,64}` matches pure dots and leading-dash strings, defeating the module's own path-safety contract (its tests already reject `a/b` and `../escape`). First char must now be `[A-Za-z0-9_]`; existing valid slugs (`morning`, `talk-01`, `v.1`) unaffected.

2. **`schemas._require` raises AttributeError on tuple types.** `validate_whisper_json` passes `(int, float)` for `start`/`end`; on a wrong-typed value the error formatter did `expected_type.__name__` — tuples have none. The guard step still failed closed, but with a stack trace instead of the contracted `SchemaError`. Now formats `expected int/float, got str`.

3. **`fetch_transcripts` marks talks complete forever on empty extraction.** Any `extract_transcript() → None` (expired `AMRUTA_SESSION_COOKIE`, stub page, layout change) wrote the empty sentinel that `is_complete` treats as done — permanently skipping the slug on all future runs. Sentinel now written only for genuine 404s; empty extractions retry next run.

## Tests
New `tests/test_fetch_transcripts.py` (3 tests) + 6 rejection cases + wrong-typed-start schema test; each watched failing first. Full fast lane: 627 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)