### PR TITLE
docs: fix drift — no Validate workflow, single-pass builder, current site/ layout

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -123,7 +123,10 @@ Triggered manually via `workflow_dispatch`. Full pipeline:
 6. **Commit** — pushes results + creates review tracking Issue
 
 ### sync-subtitles.yml
-Triggered on PRs that modify `transcript_uk.txt`. Does text-only swap in SRT blocks (no re-timing), then validates.
+Triggered on PRs that modify `transcript_uk.txt` **or** `*/final/uk.srt`.
+Runs the two-pass driver (`tools/sync_pr.py`): SRT edits are first synced
+back into the transcript (reverse), then the transcript is synced out to
+every video's SRT (forward) — text-only swaps, no re-timing — and validates.
 
 ### sync-review-status.yml
 Triggered on Issue label/assign changes. Syncs GitHub Issues → `review-status.json`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,7 +16,7 @@
                             │                        │              │
                             │                        ▼              │
                             │  ┌──────────────────────────────────┐ │
-                            │  │ build (prepare → chunks → assemble)│
+                            │  │ build (prepare → LLM → assemble)  │ │
                             │  │  Python splits ──► LLM timecodes  │ │
                             │  │  Python assembles ──► uk.srt      │ │
                             │  └──────────────────────────────────┘ │
@@ -89,7 +89,11 @@ sy-subtitles/
 │   ├── sync_common.py              # Shared sync helpers
 │   └── config.py                   # Threshold constants
 ├── site/                           # GitHub Pages SPA
-│   ├── index.html                  # Preview + Review app
+│   ├── index.html                  # Preview + Review app shell
+│   ├── js/                         # Plain-JS modules (single source, shared with node --test)
+│   ├── css/                        # Design tokens + components (tokens.css, components.css)
+│   ├── styleguide.html             # Live design-system catalog
+│   ├── sw.js                       # Service worker (offline shell precache)
 │   └── icon.png                    # Mahayantra favicon
 ├── review-status.json              # Review tracking (synced from Issues)
 ├── templates/                      # Prompt templates
@@ -114,7 +118,7 @@ Triggered manually via `workflow_dispatch`. Full pipeline:
 1. **Discover** — finds videos and determines what needs processing
 2. **Whisper** — calls `whisper.yml` for word-level speech timestamps
 3. **Translate + Review** — Claude Opus translates EN→UK, then 2+1 review
-4. **Build** — `build_map.py prepare` → parallel LLM chunks → `build_map.py assemble` → `build_srt.py`
+4. **Build** — `build_map.py prepare` → single-pass LLM timecodes (`build-timecodes` job) → `build_map.py assemble` → `build_srt.py`
 5. **Validate** — text preservation, CPS, timing checks
 6. **Commit** — pushes results + creates review tracking Issue
 
@@ -154,15 +158,19 @@ the build/sync stack without burning Claude calls.
 ## Subtitle Builder (V2)
 
 Three-phase architecture:
-1. **Prepare** (Python, deterministic) — splits Ukrainian text into subtitle-sized blocks, finds paragraph boundaries, creates LLM prompt chunks
-2. **Matrix chunks** (LLM, parallel) — each chunk receives UK blocks + EN transcript context + whisper timestamps. LLM returns ONLY timecodes, never modifies text
-3. **Assemble** (Python, deterministic) — collects chunk results, builds mapping table, generates SRT via `build_srt.py`
+1. **Prepare** (Python, deterministic) — splits Ukrainian text into subtitle-sized blocks and prepares timing data (`build_map.py prepare` / `prepare-timing`)
+2. **Build timecodes** (LLM, single pass) — one Opus 4.8 agent receives the UK blocks + EN transcript + timing source (whisper words or en.srt) and writes `timecodes.txt` (`#N | start | end` per block). The LLM returns ONLY timecodes, never modifies text
+3. **Assemble** (Python, deterministic) — merges `timecodes.txt` with `uk_blocks.json` in memory and generates SRT via `build_srt.py`
 
 Key principle: **LLM determines timing, Python guarantees text integrity.**
 
 ## SPA (GitHub Pages)
 
-Single-file app at `site/index.html`:
+App shell at `site/index.html` plus plain-JS modules under `site/js/`
+(shared single-source with the Node test suite), the token/component CSS
+under `site/css/` (`tokens.css` + `components.css`, catalogued live in
+`site/styleguide.html`), and a service worker (`site/sw.js` +
+`site/js/sw_routing.js`) that precaches the shell for offline use:
 - **Index** — talk list with search/filter, review status badges (from `review-status.json`)
 - **Preview** — Vimeo player + subtitle overlay + markers
 - **Review** — side-by-side EN/UK transcript editor

--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ gh workflow run subtitle-pipeline.yml -f talk_id={date}_{slug}
 
 The pipeline runs all steps automatically and commits results back to the repo.
 
-### 3. Automatic validation
+### 3. Validation
 
-Pushing to `final/*.srt` triggers the **Validate** workflow:
-- Checks for overlaps, gaps, CPS limits, structural issues
-- Posts results as check annotations
+Validation runs inside the pipeline itself (the **Validate** step checks
+text preservation, overlaps, gaps, CPS limits and structural issues before
+anything is committed) and again in `sync-subtitles.yml` for PR edits.
+There is no separate push-triggered Validate workflow; to re-check an SRT
+by hand run `python -m tools.validate_subtitles`.
 
 ## PR-based Edits
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ tools/                          Python modules (see ARCHITECTURE.md for full lis
   optimize_srt.py               SRT timing optimizer (run from main pipeline)
   sync_*.py                     Transcript ↔ SRT sync (PR workflow)
 
-templates/                      Agent templates (builder, review)
+templates/                      Agent templates (language review)
 glossary/                       SY terminology dictionary (EN → UK, see glossary/README.md)
 ```
 
@@ -103,8 +103,9 @@ by hand run `python -m tools.validate_subtitles`.
 
 To fix Ukrainian text after the pipeline ships subtitles, edit
 `transcript_uk.txt` (or `final/uk.srt`) on a branch and open a PR.
-`sync-subtitles.yml` runs the reverse-then-forward sync, optimizes,
-and validates automatically.
+`sync-subtitles.yml` runs the reverse-then-forward sync and validates
+automatically (text-only swaps — edits that change block structure
+need a full pipeline rebuild; approximate re-timing is banned).
 
 ## Batch Download
 
@@ -126,8 +127,8 @@ Run: `python -m tools.download --manifest queue.yaml`
 | CPS (chars/sec) | ≤15 | ≤20 |
 | CPL (chars/line) | – | ≤84 |
 | Lines per block | 1 (single-line mode) | 1 |
-| Min duration | ≥1.2s | ≥1.0s |
-| Max duration | ≤15s | ≤21s |
+| Min duration | ≥1.2s | ≥1.2s |
+| Max duration | ≤7s (optimizer CLI) | ≤21s |
 | Min gap | ≥80ms (2 frames @24fps) | ≥80ms |
 
 ## License

--- a/TESTING.md
+++ b/TESTING.md
@@ -116,7 +116,6 @@ responses in `tests/fixtures/pipeline_snapshots/`, then `tools.verify_snapshot`
 checks the output (text preservation, block-count tolerance, CPS, validation).
 
 > ⚠️ **Known gap:** the generator `tools/bootstrap_snapshot.py` was removed in
-> `c72e1b53` ("drop uk.map … legacy cleanup") but is still referenced by
-> `test_dryrun_matrix.py` and `tools/verify_snapshot.py`. Until it is restored
-> and modernised, snapshots cannot be regenerated from the documented
-> `python -m tools.bootstrap_snapshot --all`.
+> `c72e1b53` ("drop uk.map … legacy cleanup"). Until it is restored and
+> modernised, the checked-in snapshot fixtures cannot be regenerated —
+> `python -m tools.bootstrap_snapshot --all` no longer exists.


### PR DESCRIPTION
Documentation-drift findings from the 2026-07-02 multi-agent audit (verified against the actual workflows and site/ tree):

- **README §"Automatic validation"** promised a push-triggered **Validate** workflow that no longer exists (removed 2026-04; no workflow watches `final/*.srt` on push). Rewritten to describe where validation actually happens: the pipeline's Validate step and `sync-subtitles.yml`, plus the manual `tools.validate_subtitles` CLI.
- **ARCHITECTURE "Subtitle Builder (V2)"** (and the ASCII diagram + pipeline step 4) described parallel LLM matrix chunks; the real pipeline runs a single-pass Opus 4.8 `build-timecodes` job that writes `timecodes.txt`, merged with `uk_blocks.json` by Python.
- **ARCHITECTURE "SPA"** called it a "single-file app" and listed `site/` as `index.html` + `icon.png`; documented the actual layout (13 `js/` modules single-sourced with the Node tests, `css/tokens.css` + `components.css`, `styleguide.html`, `sw.js`).

Docs-only change — no runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)