### PR TITLE
fix(spa): stale-fetch guards, error paths, dead preview conditionals, token colors

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -17,6 +17,7 @@
      app script below runs. -->
 <script src="js/preview_srt_parser.js"></script>
 <script src="js/preview_state.js"></script>
+<script src="js/load_token.js"></script>
 <script src="js/index_url_state.js"></script>
 <script src="js/manifest_fetch.js"></script>
 <script src="js/offline_fallback.js"></script>
@@ -802,6 +803,7 @@ var I18N = {
 
     'add.link': '+ \u0414\u043E\u0434\u0430\u0442\u0438',
     'error.srt': '\u041F\u043E\u043C\u0438\u043B\u043A\u0430 \u0437\u0430\u0432\u0430\u043D\u0442\u0430\u0436\u0435\u043D\u043D\u044F \u0441\u0443\u0431\u0442\u0438\u0442\u0440\u0456\u0432',
+    'error.clipboard': '\u041D\u0435 \u0432\u0434\u0430\u043B\u043E\u0441\u044F \u0441\u043A\u043E\u043F\u0456\u044E\u0432\u0430\u0442\u0438 \u0432 \u0431\u0443\u0444\u0435\u0440 \u2014 \u043A\u043B\u0430\u0446\u043D\u0456\u0442\u044C \u043D\u0430 \u0441\u0442\u043E\u0440\u0456\u043D\u0446\u0456 \u0442\u0430 \u0441\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0449\u0435 \u0440\u0430\u0437',
     'error.offline_content': '\u041D\u0435\u0434\u043E\u0441\u0442\u0443\u043F\u043D\u043E \u043E\u0444\u043B\u0430\u0439\u043D \u2014 \u0432\u0456\u0434\u043A\u0440\u0438\u0439\u0442\u0435 \u043E\u043D\u043B\u0430\u0439\u043D, \u0449\u043E\u0431 \u0437\u0431\u0435\u0440\u0435\u0433\u0442\u0438 \u0432 \u043A\u0435\u0448',
     'error.rate_limit': '\u041B\u0456\u043C\u0456\u0442 \u0437\u0430\u043F\u0438\u0442\u0456\u0432 GitHub. \u041F\u043E\u043A\u0430\u0437\u0430\u043D\u043E \u043A\u0435\u0448; \u043E\u043D\u043E\u0432\u043B\u0435\u043D\u043D\u044F \u0437\u0430 {min} \u0445\u0432',
     'error.rate_limit_nocache': '\u041B\u0456\u043C\u0456\u0442 \u0437\u0430\u043F\u0438\u0442\u0456\u0432 GitHub. \u0421\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0437\u0430 {min} \u0445\u0432',
@@ -930,6 +932,7 @@ var I18N = {
 
     'add.link': '+ Add Talk',
     'error.srt': 'Error loading subtitles',
+    'error.clipboard': 'Could not copy to clipboard — click the page and try again',
     'error.offline_content': 'Unavailable offline — open it online once to cache it',
     'error.rate_limit': 'GitHub rate limit reached. Showing cached data; refresh in {min} min',
     'error.rate_limit_nocache': 'GitHub rate limit reached. Try again in {min} min',
@@ -2235,7 +2238,7 @@ function renderStats() {
   bar.innerHTML = '';
   cards.forEach(function(c) {
     var active = activeFilter === c.filter ? ' active' : '';
-    var num = hasSearch ? c.f + '<span style="font-size:12px;color:#666">/' + c.t + '</span>' : '' + c.t;
+    var num = hasSearch ? c.f + '<span style="font-size:12px;color:var(--fg5)">/' + c.t + '</span>' : '' + c.t;
     bar.innerHTML += '<div class="stat-card ' + c.cls + active + '" data-filter="' + c.filter + '" onclick="SPA.filterTalks(\'' + c.filter + '\')">' +
       '<div class="num">' + num + '</div><div class="label">' + c.label + '</div></div>';
   });
@@ -2658,7 +2661,7 @@ function showPreview(talkId, videoSlug) {
     iframe.allow = 'autoplay; fullscreen';
     iframe.allowFullscreen = true;
     iframe.style.cssText = oldIframe.style.cssText || 'position:absolute;top:0;left:0;width:100%;height:100%;border:0;';
-    if (embedUrl) iframe.src = embedUrl + '&texttrack=false';
+    if (embedUrl) iframe.src = withQueryParam(embedUrl, 'texttrack=false');
     oldIframe.parentNode.replaceChild(iframe, oldIframe);
   }
 
@@ -2674,10 +2677,14 @@ function showPreview(talkId, videoSlug) {
     previewState.mode = persisted.mode;
     previewState.markers = persisted.markers;
     previewState.edits = persisted.edits;
+    previewState.talk = talk;
+    previewState.video = video;
   } else {
     previewState = {
       talkId: talkId,
       videoSlug: videoSlug,
+      talk: talk,
+      video: video,
       subtitles: [],
       mode: persisted.mode,
       markers: persisted.markers,
@@ -2925,13 +2932,21 @@ function applyPreviewMode() {
   if (markBtn) {
     markBtn.textContent = mode === 'edit' ? t('btn.edit') : t('btn.mark');
     markBtn.title = mode === 'edit' ? t('btn.edit_title') : t('btn.mark_title');
+    // Keep the i18n keys in sync with the mode — translatePage() rewrites
+    // every [data-i18n] element, so stale keys would flip the button back
+    // to Marker-mode text on a UI-language toggle.
+    markBtn.setAttribute('data-i18n', mode === 'edit' ? 'btn.edit' : 'btn.mark');
+    markBtn.setAttribute('data-i18n-title', mode === 'edit' ? 'btn.edit_title' : 'btn.mark_title');
   }
   var copyBtn = document.getElementById('btn-copy-all');
   if (copyBtn) copyBtn.style.display = mode === 'marker' ? 'inline-block' : 'none';
   var editorBtn = document.getElementById('btn-preview-editor');
   if (editorBtn) editorBtn.style.display = mode === 'edit' ? 'inline-block' : 'none';
   var label = document.getElementById('preview-list-label');
-  if (label) label.textContent = mode === 'edit' ? t('edits.summary') : t('markers.summary');
+  if (label) {
+    label.textContent = mode === 'edit' ? t('edits.summary') : t('markers.summary');
+    label.setAttribute('data-i18n', mode === 'edit' ? 'edits.summary' : 'markers.summary');
+  }
   var markerList = document.getElementById('marker-list');
   var editList = document.getElementById('edit-list');
   if (markerList) markerList.style.display = mode === 'marker' ? '' : 'none';
@@ -3483,10 +3498,15 @@ function showReview(talkId) {
   var leftUrl = RAW + '/talks/' + talkId + '/transcript_' + reviewState.leftLang + '.txt' + (leftSha ? '?v=' + leftSha.substring(0, 8) : '');
   var rightUrl = RAW + '/talks/' + talkId + '/transcript_' + reviewState.rightLang + '.txt' + (rightSha ? '?v=' + rightSha.substring(0, 8) : '');
 
+  // Stale-fetch guard: navigating away (or switching mode/lang) before this
+  // resolves must not let the late response render into the new view or save
+  // edits under the wrong localStorage key.
+  var loadToken = bumpLoadToken(reviewState);
   Promise.all([
     fetch(leftUrl).then(function(r) { return r.ok ? r.text() : ''; }),
     fetch(rightUrl).then(function(r) { return r.ok ? r.text() : ''; })
   ]).then(function(texts) {
+    if (!isCurrentLoad(reviewState, loadToken)) return;
     var left = parseTranscript(texts[0]);
     var right = parseTranscript(texts[1]);
     reviewState.leftParas = left.paragraphs;
@@ -3502,6 +3522,7 @@ function showReview(talkId) {
       SPA.openTranscriptVideo(savedSlug);
     }
   }).catch(function(err) {
+    if (!isCurrentLoad(reviewState, loadToken)) return;
     statusEl.textContent = isOfflineError(err, navigator.onLine)
       ? t('error.offline_content') : t('review.load_error').replace('{err}', err);
     statusEl.classList.add('status-error');
@@ -3583,7 +3604,9 @@ SPA.openTranscriptVideo = function(videoSlug) {
   var sha = (talk._srtSha && talk._srtSha[videoSlug + '/' + srtLang]) || '';
   var url = RAW + '/talks/' + reviewState.talkId + '/' + videoSlug + '/final/' + srtLang + '.srt' +
     (sha ? '?v=' + sha.substring(0, 8) : '');
+  var loadToken = bumpLoadToken(reviewState);
   fetch(url).then(function(r) { return r.ok ? r.text() : ''; }).then(function(text) {
+    if (!isCurrentLoad(reviewState, loadToken)) return;
     if (!text) { showToast(t('review.srt_load_error').replace('{err}', 'SRT not found')); return; }
     var blocks = parseSRT(text);
     var timings = matchParagraphsToSrt(reviewState.rightParas, blocks);
@@ -3593,6 +3616,10 @@ SPA.openTranscriptVideo = function(videoSlug) {
     localStorage.setItem(transcriptVideoStorageKey(reviewState.talkId), videoSlug);
     SyncPlayer.init(reviewState.talkId, videoSlug);
     SyncPlayer.show();
+  }).catch(function(err) {
+    if (!isCurrentLoad(reviewState, loadToken)) return;
+    showToast(isOfflineError(err, navigator.onLine)
+      ? t('error.offline_content') : t('review.srt_load_error').replace('{err}', err));
   });
 };
 
@@ -3657,10 +3684,12 @@ SPA.switchReviewMode = function(mode, videoSlug) {
     var rightSha = (talk && talk._transcriptSha && talk._transcriptSha[reviewState.rightLang]) || '';
     var leftUrl = RAW + '/talks/' + talkId + '/transcript_' + reviewState.leftLang + '.txt' + (leftSha ? '?v=' + leftSha.substring(0, 8) : '');
     var rightUrl = RAW + '/talks/' + talkId + '/transcript_' + reviewState.rightLang + '.txt' + (rightSha ? '?v=' + rightSha.substring(0, 8) : '');
+    var tToken = bumpLoadToken(reviewState);
     Promise.all([
       fetch(leftUrl).then(function(r) { return r.ok ? r.text() : ''; }),
       fetch(rightUrl).then(function(r) { return r.ok ? r.text() : ''; })
     ]).then(function(texts) {
+      if (!isCurrentLoad(reviewState, tToken)) return;
       var left = parseTranscript(texts[0]);
       var right = parseTranscript(texts[1]);
       reviewState.leftParas = left.paragraphs;
@@ -3668,6 +3697,7 @@ SPA.switchReviewMode = function(mode, videoSlug) {
       reviewState.rightParsed = right;
       renderReview();
       statusEl.style.display = 'none';
+      statusEl.classList.remove('status-error');
       updateTranscriptSyncBtn();
       // Re-open the last-chosen video so leaving and returning to the
       // same talk restores the player (memory). Skipped when no saved
@@ -3678,6 +3708,11 @@ SPA.switchReviewMode = function(mode, videoSlug) {
       if (savedSlug && videos.some(function(v) { return v.slug === savedSlug; })) {
         SPA.openTranscriptVideo(savedSlug);
       }
+    }).catch(function(err) {
+      if (!isCurrentLoad(reviewState, tToken)) return;
+      statusEl.textContent = isOfflineError(err, navigator.onLine)
+        ? t('error.offline_content') : t('review.load_error').replace('{err}', err);
+      statusEl.classList.add('status-error');
     });
     return;
   }
@@ -3707,10 +3742,12 @@ SPA.switchReviewMode = function(mode, videoSlug) {
   var enUrl = RAW + '/talks/' + talkId + '/' + videoSlug + '/source/' + leftLang + '.srt' + (leftSha ? '?v=' + leftSha.substring(0, 8) : '');
   var ukUrl = RAW + '/talks/' + talkId + '/' + videoSlug + '/final/' + rightLang + '.srt' + (rightSha ? '?v=' + rightSha.substring(0, 8) : '');
 
+  var srtToken = bumpLoadToken(reviewState);
   Promise.all([
     fetch(enUrl).then(function(r) { return r.ok ? r.text() : ''; }),
     fetch(ukUrl).then(function(r) { return r.ok ? r.text() : ''; })
   ]).then(function(texts) {
+    if (!isCurrentLoad(reviewState, srtToken)) return;
     var enBlocks = parseSRT(texts[0]);
     var ukBlocks = parseSRT(texts[1]);
     var aligned = alignSubtitlesByTime(enBlocks, ukBlocks);
@@ -3724,6 +3761,7 @@ SPA.switchReviewMode = function(mode, videoSlug) {
     statusEl.style.display = 'none';
     statusEl.classList.remove('status-error');
   }).catch(function(err) {
+    if (!isCurrentLoad(reviewState, srtToken)) return;
     statusEl.textContent = isOfflineError(err, navigator.onLine)
       ? t('error.offline_content') : t('review.srt_load_error').replace('{err}', err);
     statusEl.classList.add('status-error');
@@ -4116,6 +4154,10 @@ SPA.openEditor = function() {
         confirmLabel: t('modal.open_github'),
         singleButton: true
       }).then(function() { window.open(url); });
+    }).catch(function() {
+      // Clipboard can reject (document not focused, permission denied) —
+      // the edits are NOT exported then; say so instead of a dead button.
+      showToast(t('error.clipboard'));
     });
   } else {
     window.open(url);
@@ -4206,10 +4248,12 @@ SPA.switchSrtLang = function(side, lang) {
   var enUrl = RAW + '/talks/' + talkId + '/' + videoSlug + '/source/' + leftLang + '.srt' + (leftSha ? '?v=' + leftSha.substring(0, 8) : '');
   var ukUrl = RAW + '/talks/' + talkId + '/' + videoSlug + '/final/' + rightLang + '.srt' + (rightSha ? '?v=' + rightSha.substring(0, 8) : '');
 
+  var loadToken = bumpLoadToken(reviewState);
   Promise.all([
     fetch(enUrl).then(function(r) { return r.ok ? r.text() : ''; }),
     fetch(ukUrl).then(function(r) { return r.ok ? r.text() : ''; })
   ]).then(function(texts) {
+    if (!isCurrentLoad(reviewState, loadToken)) return;
     var enBlocks = parseSRT(texts[0]);
     var ukBlocks = parseSRT(texts[1]);
     var aligned = alignSubtitlesByTime(enBlocks, ukBlocks);
@@ -4220,6 +4264,12 @@ SPA.switchSrtLang = function(side, lang) {
     renderReview();
     updateColHeaders();
     statusEl.style.display = 'none';
+    statusEl.classList.remove('status-error');
+  }).catch(function(err) {
+    if (!isCurrentLoad(reviewState, loadToken)) return;
+    statusEl.textContent = isOfflineError(err, navigator.onLine)
+      ? t('error.offline_content') : t('review.srt_load_error').replace('{err}', err);
+    statusEl.classList.add('status-error');
   });
 };
 
@@ -4414,7 +4464,7 @@ SPA.toggleBranches = function() {
   var dd = document.getElementById('branch-dropdown');
   if (!dd) return;
   if (dd.classList.contains('open')) { dd.classList.remove('open'); return; }
-  dd.innerHTML = '<div style="color:#888;padding:8px 12px">Loading...</div>';
+  dd.innerHTML = '<div style="color:var(--fg4);padding:8px 12px">Loading...</div>';
   dd.classList.add('open');
   fetch(API + '/branches?per_page=100')
     .then(function(r) { return r.ok ? r.json() : Promise.reject('HTTP ' + r.status); })
@@ -4429,7 +4479,7 @@ SPA.toggleBranches = function() {
       });
     })
     .catch(function(err) {
-      dd.innerHTML = '<div style="color:#f66;padding:8px 12px">Error: ' + err + '</div>';
+      dd.innerHTML = '<div style="color:var(--danger-fg);padding:8px 12px">Error: ' + esc(String(err)) + '</div>';
     });
 };
 

--- a/site/index.html
+++ b/site/index.html
@@ -3523,6 +3523,7 @@ function showReview(talkId) {
     }
   }).catch(function(err) {
     if (!isCurrentLoad(reviewState, loadToken)) return;
+    clearReviewContent();
     statusEl.textContent = isOfflineError(err, navigator.onLine)
       ? t('error.offline_content') : t('review.load_error').replace('{err}', err);
     statusEl.classList.add('status-error');
@@ -3710,6 +3711,7 @@ SPA.switchReviewMode = function(mode, videoSlug) {
       }
     }).catch(function(err) {
       if (!isCurrentLoad(reviewState, tToken)) return;
+      clearReviewContent();
       statusEl.textContent = isOfflineError(err, navigator.onLine)
         ? t('error.offline_content') : t('review.load_error').replace('{err}', err);
       statusEl.classList.add('status-error');
@@ -3762,6 +3764,7 @@ SPA.switchReviewMode = function(mode, videoSlug) {
     statusEl.classList.remove('status-error');
   }).catch(function(err) {
     if (!isCurrentLoad(reviewState, srtToken)) return;
+    clearReviewContent();
     statusEl.textContent = isOfflineError(err, navigator.onLine)
       ? t('error.offline_content') : t('review.srt_load_error').replace('{err}', err);
     statusEl.classList.add('status-error');
@@ -3988,6 +3991,21 @@ function reviewStorageKey() {
       + '_' + reviewState.srtLeftLang + '_' + reviewState.srtRightLang;
   }
   return 'review_' + reviewState.talkId;
+}
+
+// After a failed mode/talk load the in-memory rows/edits still belong to the
+// PREVIOUS view while mode/videoSlug already point at the new one — any
+// consumer (an openEditor export, a saveReview) would mix the two, e.g.
+// exporting the old rows as the new file. Drop the in-memory content: every
+// edit is already persisted under its own key on each keystroke, so nothing
+// is lost, and the next successful load restores it via loadReviewEditsForMode.
+function clearReviewContent() {
+  reviewState.leftParas = [];
+  reviewState.rightParas = [];
+  reviewState.alignedRows = null;
+  reviewState.rightParsed = null;
+  reviewState.marks = {};
+  reviewState.edits = {};
 }
 
 // Restore saved marks/edits for the current mode (and, for SRT, the current
@@ -4239,10 +4257,6 @@ SPA.switchSrtLang = function(side, lang) {
 
   var leftLang = side === 'left' ? lang : (reviewState.srtLeftLang);
   var rightLang = side === 'right' ? lang : (reviewState.srtRightLang);
-  reviewState.srtLeftLang = leftLang;
-  reviewState.srtRightLang = rightLang;
-  localStorage.setItem('sy_review_srt_left_' + talkId, leftLang);
-  localStorage.setItem('sy_review_srt_right_' + talkId, rightLang);
   var leftSha = (talk && talk._srcSrtSha && talk._srcSrtSha[videoSlug + '/' + leftLang]) || '';
   var rightSha = (talk && talk._srtSha && talk._srtSha[videoSlug + '/' + rightLang]) || '';
   var enUrl = RAW + '/talks/' + talkId + '/' + videoSlug + '/source/' + leftLang + '.srt' + (leftSha ? '?v=' + leftSha.substring(0, 8) : '');
@@ -4257,6 +4271,15 @@ SPA.switchSrtLang = function(side, lang) {
     var enBlocks = parseSRT(texts[0]);
     var ukBlocks = parseSRT(texts[1]);
     var aligned = alignSubtitlesByTime(enBlocks, ukBlocks);
+    // Commit the language switch only now: reviewStorageKey() must keep
+    // matching the rows/edits still on screen — the old grid stays editable
+    // during the load (no skeleton here), so flipping the langs before the
+    // fetch resolves would make one keystroke save the OLD pair's edit-set
+    // under the NEW pair's key, clobbering it.
+    reviewState.srtLeftLang = leftLang;
+    reviewState.srtRightLang = rightLang;
+    localStorage.setItem('sy_review_srt_left_' + talkId, leftLang);
+    localStorage.setItem('sy_review_srt_right_' + talkId, rightLang);
     reviewState.leftParas = aligned.map(function(r) { return r.en ? r.en.text : ''; });
     reviewState.rightParas = aligned.map(function(r) { return r.uk ? r.uk.text : ''; });
     reviewState.alignedRows = aligned;

--- a/site/js/load_token.js
+++ b/site/js/load_token.js
@@ -1,0 +1,30 @@
+'use strict';
+// Stale-fetch guards for view/state switches, single-sourced for the SPA and
+// the Node test suite (tests/test_load_token.js).
+//
+// Every mode/language/video switch bumps a token on the shared state object;
+// async callbacks capture the token at entry and bail if it is no longer
+// current, so a late-resolving fetch can't render the wrong content or write
+// edits under the wrong localStorage key. The counter is module-global, so a
+// token minted on a replaced state object never matches its successor.
+
+var _loadCounter = 0;
+
+function bumpLoadToken(state) {
+  state._loadToken = ++_loadCounter;
+  return state._loadToken;
+}
+
+function isCurrentLoad(state, token) {
+  return !!state && state._loadToken === token;
+}
+
+// Append a query parameter to a URL that may or may not already carry one
+// (hash-less Vimeo embeds have no query string).
+function withQueryParam(url, param) {
+  return url + (url.indexOf('?') >= 0 ? '&' : '?') + param;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { bumpLoadToken: bumpLoadToken, isCurrentLoad: isCurrentLoad, withQueryParam: withQueryParam };
+}

--- a/site/sw.js
+++ b/site/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for SPA caching
 // Browser detects changes by comparing sw.js byte-for-byte.
 // CACHE_VERSION: bump when cache format changes or to force purge.
-var CACHE_VERSION = 5;
+var CACHE_VERSION = 6;
 var CACHE_NAME = 'sy-subtitles-c' + CACHE_VERSION;
 
 // Routing predicates (isImmutable / isApiOrRaw / isNavigation / pickStrategy) are
@@ -34,6 +34,7 @@ var SHELL_ASSETS = [
   'css/components.css',
   'js/preview_srt_parser.js',
   'js/preview_state.js',
+  'js/load_token.js',
   'js/index_url_state.js',
   'js/manifest_fetch.js',
   'js/offline_fallback.js',

--- a/tests/test_load_token.js
+++ b/tests/test_load_token.js
@@ -1,0 +1,41 @@
+'use strict';
+// Tests for site/js/load_token.js — stale-fetch guard tokens + URL param helper.
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const { bumpLoadToken, isCurrentLoad, withQueryParam } = require('../site/js/load_token.js');
+
+test('bump marks the newest load as current, older callbacks as stale', () => {
+  const state = {};
+  const t1 = bumpLoadToken(state);
+  assert.equal(isCurrentLoad(state, t1), true);
+  const t2 = bumpLoadToken(state);
+  assert.equal(isCurrentLoad(state, t1), false, 'first load is stale after a second bump');
+  assert.equal(isCurrentLoad(state, t2), true);
+});
+
+test('token from a replaced state object never matches the new state', () => {
+  // showReview replaces the global state object; a stale callback holding a
+  // token minted on the OLD object must not pass against the NEW one.
+  const oldState = {};
+  const tOld = bumpLoadToken(oldState);
+  const newState = {};
+  bumpLoadToken(newState);
+  assert.equal(isCurrentLoad(newState, tOld), false);
+});
+
+test('isCurrentLoad is false for missing state', () => {
+  assert.equal(isCurrentLoad(null, 1), false);
+  assert.equal(isCurrentLoad(undefined, 1), false);
+});
+
+test('withQueryParam uses ? for bare URLs and & when a query exists', () => {
+  assert.equal(
+    withQueryParam('https://player.vimeo.com/video/123', 'texttrack=false'),
+    'https://player.vimeo.com/video/123?texttrack=false'
+  );
+  assert.equal(
+    withQueryParam('https://player.vimeo.com/video/123?h=abc', 'texttrack=false'),
+    'https://player.vimeo.com/video/123?h=abc&texttrack=false'
+  );
+});

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -27,7 +27,7 @@ from tests.test_preview_spa import (  # noqa: F401  — re-exported fixtures
 # only the scheduling is not — so retry rather than widen the timeout forever.
 pytestmark = [pytest.mark.e2e, pytest.mark.flaky(reruns=2, reruns_delay=2)]
 
-CACHE = "sy-subtitles-c5"  # CACHE_NAME in sw.js (CACHE_VERSION = 5)
+CACHE = "sy-subtitles-c6"  # CACHE_NAME in sw.js (CACHE_VERSION = 6)
 SW_WAIT_MS = 15000
 
 
@@ -48,7 +48,7 @@ class TestServiceWorker:
         _register_sw(page, server)
         page.evaluate("() => fetch('icon.png')")
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c5');"
+            "async () => { const c = await caches.open('sy-subtitles-c6');"
             " return !!(await c.match(location.origin + '/icon.png')); }",
             timeout=10000,
         )
@@ -59,7 +59,7 @@ class TestServiceWorker:
         # Seed a sentinel under the icon.png key; cache-first must return it
         # without going to the network.
         page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c5');"
+            "async () => { const c = await caches.open('sy-subtitles-c6');"
             " await c.put(location.origin + '/icon.png',"
             " new Response('SENTINEL', {headers: {'content-type': 'text/plain'}})); }"
         )
@@ -71,7 +71,7 @@ class TestServiceWorker:
         # Seed a stale sentinel for index.html; network-first must prefer the
         # live response when the network is reachable.
         page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c5');"
+            "async () => { const c = await caches.open('sy-subtitles-c6');"
             " await c.put(location.origin + '/index.html',"
             " new Response('STALE', {headers: {'content-type': 'text/html'}})); }"
         )
@@ -100,14 +100,14 @@ class TestServiceWorker:
         # with a sentinel before activation; it (and its entry) must survive.
         page.goto(f"{server}/index.html")
         page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c5');"
+            "async () => { const c = await caches.open('sy-subtitles-c6');"
             " await c.put(location.origin + '/keep', new Response('KEEP')); }"
         )
         page.evaluate("() => navigator.serviceWorker.register('sw.js')")
         page.wait_for_function("() => !!navigator.serviceWorker.controller", timeout=SW_WAIT_MS)
         assert CACHE in page.evaluate("() => caches.keys()")
         survived = page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c5');"
+            "async () => { const c = await caches.open('sy-subtitles-c6');"
             " const r = await c.match(location.origin + '/keep'); return r ? await r.text() : null; }"
         )
         assert survived == "KEEP", "activate wrongly purged the current-version cache"
@@ -129,7 +129,7 @@ class TestServiceWorker:
         # so they would not otherwise be cached).
         _register_sw(page, server)
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c5');"
+            "async () => { const c = await caches.open('sy-subtitles-c6');"
             " const us = (await c.keys()).map(r => r.url);"
             " return us.some(u => u.split('?')[0].endsWith('/index.html'))"
             " && us.filter(u => u.includes('/js/')).length >= 11"
@@ -137,7 +137,7 @@ class TestServiceWorker:
             timeout=10000,
         )
         shell = page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c5');"
+            "async () => { const c = await caches.open('sy-subtitles-c6');"
             " const us = (await c.keys()).map(r => r.url);"
             " return { index: us.some(u => u.split('?')[0].endsWith('/index.html')),"
             " js: us.filter(u => u.includes('/js/')).length,"
@@ -168,17 +168,17 @@ class TestServiceWorkerOffline:
         # icon.png, so delete it first to exercise the genuine miss path.)
         _register_sw(page, server)
         page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c5');"
+            "async () => { const c = await caches.open('sy-subtitles-c6');"
             " await c.delete(location.origin + '/icon.png'); }"
         )
         miss = page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c5');"
+            "async () => { const c = await caches.open('sy-subtitles-c6');"
             " return !!(await c.match(location.origin + '/icon.png')); }"
         )
         assert miss is False, "precondition: icon.png must not be cached yet"
         page.evaluate("() => fetch('icon.png')")
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c5');"
+            "async () => { const c = await caches.open('sy-subtitles-c6');"
             " return !!(await c.match(location.origin + '/icon.png')); }",
             timeout=10000,
         )
@@ -197,7 +197,7 @@ class TestServiceWorkerOffline:
         _register_sw(page, server)
         page.evaluate("() => fetch('index.html')")
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c5');"
+            "async () => { const c = await caches.open('sy-subtitles-c6');"
             " return !!(await c.match(location.origin + '/index.html')); }",
             timeout=10000,
         )
@@ -216,7 +216,7 @@ class TestServiceWorkerOffline:
         # Seed a cached asset so we can prove the SW is still alive afterwards.
         page.evaluate("() => fetch('icon.png')")
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c5');"
+            "async () => { const c = await caches.open('sy-subtitles-c6');"
             " return !!(await c.match(location.origin + '/icon.png')); }",
             timeout=10000,
         )
@@ -240,7 +240,7 @@ class TestServiceWorkerOffline:
         status = page.evaluate("async () => (await fetch('definitely-missing-asset.js')).status")
         assert status == 404, f"expected a 404 from the test server, got {status}"
         cached = page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c5');"
+            "async () => { const c = await caches.open('sy-subtitles-c6');"
             " return !!(await c.match(location.origin + '/definitely-missing-asset.js')); }"
         )
         assert cached is False, "a 404 response was wrongly written to the cache"
@@ -251,7 +251,7 @@ class TestServiceWorkerOffline:
         _register_sw(page, server)
         page.evaluate("() => fetch('js/sw_routing.js')")
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c5');"
+            "async () => { const c = await caches.open('sy-subtitles-c6');"
             " return !!(await c.match(location.origin + '/js/sw_routing.js')); }",
             timeout=10000,
         )
@@ -270,7 +270,7 @@ class TestServiceWorkerOffline:
         _register_sw(page, server)
         srt_url = "https://raw.githubusercontent.com/o/r/main/talks/x/uk/final/uk.srt?v=ab12cd34"
         page.evaluate(
-            "async (u) => { const c = await caches.open('sy-subtitles-c5');"
+            "async (u) => { const c = await caches.open('sy-subtitles-c6');"
             " await c.put(u, new Response('CACHED-SRT',"
             " {status: 200, headers: {'content-type': 'text/plain'}})); }",
             srt_url,
@@ -286,7 +286,7 @@ class TestServiceWorkerOffline:
         _register_sw(page, server)
         url = "https://raw.githubusercontent.com/o/r/main/talks/x/meta.yaml"
         page.evaluate(
-            "async (u) => { const c = await caches.open('sy-subtitles-c5');"
+            "async (u) => { const c = await caches.open('sy-subtitles-c6');"
             " await c.put(u, new Response('CACHED-META',"
             " {status: 200, headers: {'content-type': 'text/plain'}})); }",
             url,
@@ -308,7 +308,7 @@ class TestServiceWorkerOffline:
         _register_sw(page, server)
         api = "https://api.github.com/git/trees/main?recursive=1"
         page.evaluate(
-            "async (u) => { const c = await caches.open('sy-subtitles-c5');"
+            "async (u) => { const c = await caches.open('sy-subtitles-c6');"
             " await c.put(u, new Response('SHOULD-NOT-BE-SERVED', {status: 200})); }",
             api,
         )


### PR DESCRIPTION
Seven SPA findings from the 2026-07-02 multi-agent audit (MEDIUM ×2, LOW ×5), fixed with the module-first pattern and verified live.

## Fixes

1. **Stale-fetch guard for the review view (MEDIUM).** `switchReviewMode`, `switchSrtLang`, `showReview` and `openTranscriptVideo` mutated the shared `reviewState` in fetch callbacks with no entry token (unlike `showPreview`'s `stillOnSameVideo()`), so a slow response could render the previous mode/language/talk's content into the new view — and persist edits under the wrong localStorage key. New single-sourced **`site/js/load_token.js`** (node-tested) mints monotonic load tokens; every switch bumps, every callback bails when stale. The module-global counter also covers the replaced-state-object case.

2. **Missing `.catch` on review fetch chains (MEDIUM).** A network failure in `switchSrtLang` / `switchReviewMode`'s transcript branch / `openTranscriptVideo` left "Loading transcripts…" up forever. All chains now surface the offline/error status (toast for the video picker).

3. **`previewState.talk`/`.video` were never assigned** — two dead conditionals: the `?v=<sha>` cache-buster on preview SRT fetches never fired, and preview issue titles fell back to raw IDs. Now assigned on both the fresh-entry and same-video paths.

4. **`&texttrack=false` without `?`** — hash-less Vimeo embeds got a malformed player URL. `withQueryParam()` picks `?`/`&`.

5. **`translatePage()` clobbered Edit-mode labels** — `applyPreviewMode` now updates `data-i18n`/`data-i18n-title` along with the text, so a UI-language toggle in Edit mode keeps «✎ Edit»/«Edits».

6. **`openEditor` clipboard rejection was silent** (no dialog, no editor, edits not exported). Added `.catch` + toast with new `error.clipboard` i18n key (uk/en).

7. **Hardcoded `#666`/`#888`/`#f66` in dynamic HTML** → `var(--fg5/--fg4/--danger-fg)` per the token contract (old values fell below AA in the dark theme). The branch-dropdown error is also `esc()`'d.

## SW
`js/load_token.js` added to `SHELL_ASSETS`; **CACHE_VERSION 5→6**; `tests/test_service_worker.py` refs updated (lockstep guard enforced it).

## Verification
- `tests/test_load_token.js` (4 tests, watched failing first); node suite **613 passed**
- pytest fast lane **617 passed**; boot smoke ✅; SW + theme-token e2e (22) ✅
- Live in browser (`?repo=…`): index renders; review loads 118 cells with token guard active; preview iframe URL = `…?h=…&texttrack=false`; `previewState.talk/video` set (SRT loaded via `?v=`); Edit-mode labels survive `translatePage()`; screenshot-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)