### PR TITLE
fix(bookmarklet): keep short transcript paragraphs (no 20-char gate)

### DIFF
--- a/site/js/bookmarklet.js
+++ b/site/js/bookmarklet.js
@@ -10,6 +10,15 @@
 // required by the Node test suite (tests reach extractAmrutaTalk via the
 // browser global it exports) — single source, no inline mirror.
 (function () {
+  // A collapsed (whitespace-normalized, trimmed) <p> belongs in the transcript
+  // body if it carries any content and is not the metadata header line (which
+  // the pipeline synthesizes from meta, so it must not leak into the body).
+  // NB: keep every non-empty paragraph — a length threshold here silently drops
+  // legitimately short lines like "Welcome to you all." / "May God bless you.".
+  function isTranscriptBodyParagraph(pt) {
+    return !!pt && pt.indexOf("Talk Language:") < 0;
+  }
+
   // Scrape a talk page's DOM into the bookmarklet payload {t,d,u,loc,v,tx}.
   function extractAmrutaTalk(doc) {
     var titleEl = doc.querySelector("h1.entry-title,h1,.entry-title");
@@ -81,7 +90,7 @@
           b.replaceWith(" ");
         });
         var pt = pc.textContent.replace(/\s+/g, " ").trim();
-        if (pt.length > 20 && pt.indexOf("Talk Language:") < 0) {
+        if (isTranscriptBodyParagraph(pt)) {
           tx += (tx ? "\n" : "") + pt;
         }
       }
@@ -93,6 +102,7 @@
   // Expose for tests / debugging.
   if (typeof window !== "undefined") {
     window.extractAmrutaTalk = extractAmrutaTalk;
+    window.isTranscriptBodyParagraph = isTranscriptBodyParagraph;
   }
 
   // When injected as a real <script> by the loader bookmarklet, scrape the
@@ -109,6 +119,9 @@
   }
 
   if (typeof module !== "undefined" && module.exports) {
-    module.exports = { extractAmrutaTalk: extractAmrutaTalk };
+    module.exports = {
+      extractAmrutaTalk: extractAmrutaTalk,
+      isTranscriptBodyParagraph: isTranscriptBodyParagraph,
+    };
   }
 })();

--- a/tests/test_bookmarklet.js
+++ b/tests/test_bookmarklet.js
@@ -1,0 +1,39 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { isTranscriptBodyParagraph } = require('../site/js/bookmarklet');
+
+// The bookmarklet scrapes each <p> of the amruta talk page into the transcript
+// body. A blunt "paragraph must be longer than 20 chars" gate silently dropped
+// legitimate short lines — e.g. the opening "Welcome to you all." (19 chars) and
+// the closing "May God bless you." (18 chars) — losing them from the transcript,
+// the translation, and the final subtitles (regression: 1989-12-17 Devi Puja).
+describe('bookmarklet: transcript paragraph filter', () => {
+  it('keeps a short real closing line ("May God bless you.")', () => {
+    assert.strictEqual(isTranscriptBodyParagraph('May God bless you.'), true);
+  });
+
+  it('keeps a short real opening line ("Welcome to you all.")', () => {
+    assert.strictEqual(isTranscriptBodyParagraph('Welcome to you all.'), true);
+  });
+
+  it('keeps a normal prose paragraph', () => {
+    assert.strictEqual(
+      isTranscriptBodyParagraph('There is no need to discuss in Sahaja Yoga.'),
+      true
+    );
+  });
+
+  it('drops an empty paragraph', () => {
+    assert.strictEqual(isTranscriptBodyParagraph(''), false);
+  });
+
+  it('drops the metadata header line (contains "Talk Language:")', () => {
+    assert.strictEqual(
+      isTranscriptBodyParagraph(
+        '17 December 1989 Devi Puja: Nothing to discuss in Sahaja Yoga ' +
+          'Alibag (India) Talk Language: English | Transcript (English)'
+      ),
+      false
+    );
+  });
+});


### PR DESCRIPTION
## Problem

The add-talk bookmarklet (`site/js/bookmarklet.js`) scraped each `<p>` of the amruta talk page into the transcript body but gated inclusion on `pt.length > 20`. That silently dropped legitimately **short** lines:

- opening **"Welcome to you all."** (19 chars)
- closing **"May God bless you."** (18 chars)

Because the transcript feeds translation → build, those lines never reached `transcript_en.txt`, `transcript_uk.txt`, or the final UK subtitles. Observed on **1989-12-17 Devi Puja** (both lines were present in `source/en.srt` but missing everywhere downstream). The talk's data was hot-fixed separately on `main` (`4618a571`, `8ecf27b4`); this PR fixes the **root cause** so it can't recur.

## Fix

The metadata header is captured separately from the page `<h4>` and is already guarded by the `"Talk Language:"` marker, so the length threshold guarded nothing real — it only discarded content. Match the reference Python extractor (`tools/download.py` keeps every non-empty block): **keep any non-empty paragraph that isn't the header line.**

The decision is extracted into a pure `isTranscriptBodyParagraph()` so it is unit-testable without a DOM (single source, wired into the scrape loop).

## Tests (TDD)

- New `tests/test_bookmarklet.js`: RED on the two short lines under the old gate, GREEN after the fix; preserved behavior (normal prose kept, empty + header dropped) asserted too.
- Full JS suite green (618 tests). Boot smoke green.
- **Integration-verified against the live amruta page**: 42/43 `<p>` kept (only the empty paragraph dropped); both "Welcome to you all." and "May God bless you." restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)