### PR TITLE
docs: model-neutral wording — drop hard-coded 'Opus 4.8' references

### DIFF
--- a/.github/workflows/subtitle-pipeline.yml
+++ b/.github/workflows/subtitle-pipeline.yml
@@ -447,7 +447,7 @@ jobs:
             talks/${{ matrix.talk_id }}/review_report.md
             talks/${{ matrix.talk_id }}/glossary.json
 
-  # --- Build subtitles: 2-phase pipeline (prepare + single Opus 4.8 pass) ---
+  # --- Build subtitles: 2-phase pipeline (prepare + single builder-agent pass) ---
 
   # Phase 1: Split UK text into subtitle blocks
   prepare-build:
@@ -577,7 +577,7 @@ jobs:
           path: |
             talks/${{ needs.discover.outputs.talk_id }}/*/work/uk_blocks.json
 
-  # Phase 2: Single Opus 4.8 pass — assign timecodes, build SRT
+  # Phase 2: Single builder-agent pass (MODEL_HEAVY) — assign timecodes, build SRT
   build-timecodes:
     needs: prepare-build
     if: ${{ !cancelled() && needs.prepare-build.result == 'success' }}
@@ -671,7 +671,7 @@ jobs:
             --snapshot "tests/fixtures/pipeline_snapshots/${TALK_ID}/${VIDEO_SLUG}" \
             --work-dir "talks/${TALK_ID}/${VIDEO_SLUG}/work"
 
-      - name: Build timecodes (Opus 4.8)
+      - name: Build timecodes (Claude)
         if: inputs.dry_run != true
         uses: anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a  # v1.0.165
         env:
@@ -750,7 +750,7 @@ jobs:
         run: |
           N=$(python3 -c "import json; print(len(json.load(open('talks/${TALK_ID}/${VIDEO_SLUG}/work/uk_blocks.json'))))")
           # WHISPER mode: every uk_block must have a timecode — exact count.
-          # EN-SRT mode: Opus is allowed to SKIP UK blocks with no EN
+          # EN-SRT mode: the builder agent is allowed to SKIP UK blocks with no EN
           # counterpart, so count is an upper bound; IDs must still be
           # strictly ascending.
           if [ "$TIMING_SOURCE" = "en-srt" ]; then
@@ -860,7 +860,7 @@ jobs:
               # produce occasional high-CPS blocks unfixable without silence).
               EXTRA_FLAGS="--skip-text-check --skip-time-check --skip-cps-check"
             elif [ "${{ needs.prepare-build.outputs.timing_source }}" = "en-srt" ]; then
-              # Primary in en-srt mode: Opus is instructed to DROP UK blocks
+              # Primary in en-srt mode: the builder agent is instructed to DROP UK blocks
               # with no EN counterpart (trailing signatures, stage
               # directions), so transcript ↔ SRT word equality no longer
               # holds. Replace text-preservation with a block-count sanity

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,7 +11,7 @@
   │ (local)  │               │                                      │
   └─────────┘               │  ┌─────────┐   ┌───────────────────┐ │
    meta.yaml                │  │ whisper  │──►│ translate+review  │ │
-   transcript_en.txt        │  │ (.yml)   │   │ (Claude Opus)     │ │
+   transcript_en.txt        │  │ (.yml)   │   │ (Claude)          │ │
    en.srt                   │  └─────────┘   └───────────────────┘ │
                             │                        │              │
                             │                        ▼              │
@@ -117,7 +117,7 @@ sy-subtitles/
 Triggered manually via `workflow_dispatch`. Full pipeline:
 1. **Discover** — finds videos and determines what needs processing
 2. **Whisper** — calls `whisper.yml` for word-level speech timestamps
-3. **Translate + Review** — Claude Opus translates EN→UK, then 2+1 review
+3. **Translate + Review** — a Claude agent translates EN→UK, then 2+1 review
 4. **Build** — `build_map.py prepare` → single-pass LLM timecodes (`build-timecodes` job) → `build_map.py assemble` → `build_srt.py`
 5. **Validate** — text preservation, CPS, timing checks
 6. **Commit** — pushes results + creates review tracking Issue
@@ -162,7 +162,7 @@ the build/sync stack without burning Claude calls.
 
 Three-phase architecture:
 1. **Prepare** (Python, deterministic) — splits Ukrainian text into subtitle-sized blocks and prepares timing data (`build_map.py prepare` / `prepare-timing`)
-2. **Build timecodes** (LLM, single pass) — one Opus 4.8 agent receives the UK blocks + EN transcript + timing source (whisper words or en.srt) and writes `timecodes.txt` (`#N | start | end` per block). The LLM returns ONLY timecodes, never modifies text
+2. **Build timecodes** (LLM, single pass) — one Claude builder agent (model selectable via the `model` input) receives the UK blocks + EN transcript + timing source (whisper words or en.srt) and writes `timecodes.txt` (`#N | start | end` per block). The LLM returns ONLY timecodes, never modifies text
 3. **Assemble** (Python, deterministic) — merges `timecodes.txt` with `uk_blocks.json` in memory and generates SRT via `build_srt.py`
 
 Key principle: **LLM determines timing, Python guarantees text integrity.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,14 +18,15 @@ Source language: English. Target language: Ukrainian.
 1. Download talk: `python -m tools.download --url "https://www.amruta.org/..."`
 2. Push source files (`meta.yaml`, `transcript_en.txt`, `en.srt`)
 3. Trigger pipeline: `gh workflow run subtitle-pipeline.yml -f talk_id={date}_{slug}`
-   Optional inputs: `timing_source=auto|whisper|en-srt` (default `auto` —
+   Optional inputs: `model=claude-opus-4-8|claude-fable-5|claude-sonnet-5`
+   (default `claude-opus-4-8`), `timing_source=auto|whisper|en-srt` (default `auto` —
    en-srt if present, else whisper), `dry_run=true` (replay snapshots via
    `tools.fake_llm`, no commit).
 4. Pipeline runs automatically:
    - **Whisper**: speech detection → `whisper.json` (word-level timestamps)
    - **Translate**: Claude agent translates EN → UK → `transcript_uk.txt`
    - **Review**: 2+1 review (Reviewer L + Reviewer S + Critic)
-   - **Build**: single-pass Opus 4.8 agent writes `timecodes.txt` (`#N | start | end`
+   - **Build**: single-pass Claude builder agent writes `timecodes.txt` (`#N | start | end`
      per block); Python merges with `uk_blocks.json` in memory → `final/uk.srt`
    - **Validate**: structural checks (text, CPL, CPS, overlaps, gaps)
    - **Commit**: pushes all results back to repo

--- a/tests/test_build_map.py
+++ b/tests/test_build_map.py
@@ -346,7 +346,7 @@ class TestCmdAssemble:
     def test_assemble_missing_block(self, tmp_path):
         """timecodes.txt missing a UK block id → that block is skipped, assemble succeeds.
 
-        This is the en-srt-mode contract: Opus may drop UK blocks with no
+        This is the en-srt-mode contract: the builder agent may drop UK blocks with no
         EN counterpart (trailing signatures, editorial stage directions).
         `validate_artifacts --allow-skipped-ids` gates the gap upstream;
         `cmd_assemble` just emits an SRT from whatever timecodes arrive.

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -42,7 +42,7 @@ UK_TRANSCRIPT = """\
 def _generate_mock_timecodes(uk_blocks):
     """Distribute timecodes evenly across all blocks.
 
-    Simulates what a single-pass Opus agent would return: one timecode
+    Simulates what a single-pass builder agent would return: one timecode
     line per block, with even spacing across the full time range.
     """
     # 2 seconds per block, 100ms gap

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -794,7 +794,7 @@ def test_block_count_over_ratio_fails(tmp_path):
 
 
 def test_block_count_fewer_uk_is_ok(tmp_path):
-    """UK count lower than EN is fine — Opus dropped editorial blocks."""
+    """UK count lower than EN is fine — the builder agent dropped editorial blocks."""
     en_path = tmp_path / "en.srt"
     _write_srt(en_path, [(i, "00:00:01,000", "00:00:03,000", "x") for i in range(1, 21)])
     uk_blocks = [_block(i, 1000 * i, 1000 * i + 500) for i in range(1, 6)]  # 5 UK vs 20 EN

--- a/tests/test_validate_artifacts.py
+++ b/tests/test_validate_artifacts.py
@@ -1,7 +1,7 @@
 """Tests for tools.validate_artifacts — timecode validation modes.
 
 Covers the en-srt-mode relaxations added alongside the builder/validator
-contract change: in en-srt mode Opus may drop UK blocks without an EN
+contract change: in en-srt mode the builder agent may drop UK blocks without an EN
 counterpart, so the timecode artifact is allowed to have skipped IDs up
 to a maximum block count, instead of a strict 1..N sequence.
 """

--- a/tools/build_map.py
+++ b/tools/build_map.py
@@ -10,7 +10,7 @@ Usage (local):
     python -m tools.build_map prepare-timing --talk-dir TALK --video-slug VIDEO
     python -m tools.build_map assemble --talk-dir TALK --video-slug VIDEO
 
-In CI, `prepare` and `prepare-timing` run first, then a single Opus 4.8 agent
+In CI, `prepare` and `prepare-timing` run first, then a single Claude builder agent
 session produces timecodes.txt, then `assemble` builds the final SRT.
 """
 
@@ -143,7 +143,7 @@ def cmd_assemble(args):
         if m:
             all_timecodes[int(m.group(1))] = (m.group(2), m.group(3))
 
-    # UK blocks may legitimately skip timecodes in en-srt mode — Opus is
+    # UK blocks may legitimately skip timecodes in en-srt mode — the builder agent is
     # instructed to drop UK blocks without an EN SRT counterpart (closing
     # signatures, trailing stage directions, transcript content past the
     # last EN block). Whisper mode still produces timecodes for every id,

--- a/tools/validate_artifacts.py
+++ b/tools/validate_artifacts.py
@@ -67,7 +67,7 @@ def _check_timecodes(
         if idx in seen_ids:
             _fail(f"timecodes {path}:{line_no}: duplicate block id #{idx}")
         # IDs must be strictly ascending. With `allow_skipped_ids` (en-srt
-        # mode — Opus may drop UK blocks without an EN counterpart), gaps
+        # mode — the builder agent may drop UK blocks without an EN counterpart), gaps
         # are fine; without the flag (whisper mode), every id must follow
         # its predecessor exactly.
         if allow_skipped_ids:
@@ -118,12 +118,12 @@ def main() -> None:
     parser.add_argument(
         "--max-blocks",
         type=int,
-        help="Maximum number of blocks in --timecodes (upper bound; for en-srt mode where Opus may skip)",
+        help="Maximum number of blocks in --timecodes (upper bound; for en-srt mode where the builder agent may skip)",
     )
     parser.add_argument(
         "--allow-skipped-ids",
         action="store_true",
-        help="Allow gaps in block IDs (en-srt mode — Opus may drop UK blocks without an EN counterpart)",
+        help="Allow gaps in block IDs (en-srt mode — the builder agent may drop UK blocks without an EN counterpart)",
     )
     parser.add_argument("--talk-dir", help="Validate every artifact under a talk dir")
     args = parser.parse_args()

--- a/tools/validate_subtitles.py
+++ b/tools/validate_subtitles.py
@@ -156,7 +156,7 @@ def check_text_preservation(srt_blocks, transcript_path, report):
 def check_block_count_vs_en_srt(srt_blocks, en_srt_path, report, max_ratio=2.0):
     """Compare UK SRT block count against EN SRT block count.
 
-    Intended for en-srt mode with text preservation skipped: if Opus
+    Intended for en-srt mode with text preservation skipped: if the builder agent
     legitimately drops UK blocks that have no EN counterpart, the UK
     count should stay near or below the EN count. A UK count much higher
     than EN suggests transcript-only content leaked into the SRT.
@@ -356,7 +356,7 @@ def manifest_validate_flags(srt_path) -> dict:
         return flags
     if role == "primary" and mode == "en-srt":
         # En-srt primary: transcript-only content is legitimately dropped
-        # by Opus (no EN counterpart), so text preservation is replaced by
+        # by the builder agent (no EN counterpart), so text preservation is replaced by
         # a block-count sanity against the EN SRT.
         flags["skip_text_check"] = True
         en_srt = srt_path.parent.parent / "source" / "en.srt"


### PR DESCRIPTION
Модель тепер обирається інпутом `model` (#684), тож назви кроків, коментарі, докстрінги і документація не повинні стверджувати конкретну модель. Лише проза/коментарі — поведінка не змінюється. Крок `Build timecodes (Opus 4.8)` → `Build timecodes (Claude)` (залежностей від назви кроку немає — перевірено grep-ом по tests/tools/.github).

🤖 Generated with [Claude Code](https://claude.com/claude-code)