### PR TITLE
feat(pipeline): build_model input — build step may run on a different model

### DIFF
--- a/.github/workflows/subtitle-pipeline.yml
+++ b/.github/workflows/subtitle-pipeline.yml
@@ -49,6 +49,15 @@ on:
           - claude-fable-5
           - claude-sonnet-5
         default: claude-opus-4-8
+      build_model:
+        description: 'Override model for the build step only (timecode alignment); same-as-model follows `model`'
+        type: choice
+        options:
+          - same-as-model
+          - claude-opus-4-8
+          - claude-fable-5
+          - claude-sonnet-5
+        default: same-as-model
   workflow_call:
     inputs:
       talk_id:
@@ -80,6 +89,10 @@ on:
         description: 'Claude model for LLM steps (translate, review, build)'
         type: string
         default: claude-opus-4-8
+      build_model:
+        description: 'Override model for the build step only; empty or same-as-model follows `model`'
+        type: string
+        default: ''
 
 permissions:
   contents: write
@@ -90,6 +103,10 @@ permissions:
 env:
   # Push-triggered runs have no inputs context — fall back to the default.
   MODEL_HEAVY: ${{ inputs.model || 'claude-opus-4-8' }}
+  # Build is mechanical timecode alignment — may run on a different model
+  # than review (e.g. review=Fable, build=Opus). The 'same-as-model'
+  # sentinel (choice inputs can't default to '') follows MODEL_HEAVY.
+  MODEL_BUILD: ${{ (inputs.build_model != 'same-as-model' && inputs.build_model) || inputs.model || 'claude-opus-4-8' }}
 
 jobs:
   discover:
@@ -680,7 +697,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_bun_executable: ${{ steps.tools.outputs.bun }}
           path_to_claude_code_executable: ${{ steps.tools.outputs.claude }}
-          claude_args: "--max-turns 80 --dangerously-skip-permissions --effort high --model ${{ env.MODEL_HEAVY }}"
+          claude_args: "--max-turns 80 --dangerously-skip-permissions --effort high --model ${{ env.MODEL_BUILD }}"
           show_full_output: true
           prompt: |
             Assign timecodes to Ukrainian subtitle blocks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,8 @@ Source language: English. Target language: Ukrainian.
 2. Push source files (`meta.yaml`, `transcript_en.txt`, `en.srt`)
 3. Trigger pipeline: `gh workflow run subtitle-pipeline.yml -f talk_id={date}_{slug}`
    Optional inputs: `model=claude-opus-4-8|claude-fable-5|claude-sonnet-5`
-   (default `claude-opus-4-8`), `timing_source=auto|whisper|en-srt` (default `auto` —
+   (default `claude-opus-4-8`), `build_model=...` (build-step-only override,
+   default `same-as-model`), `timing_source=auto|whisper|en-srt` (default `auto` —
    en-srt if present, else whisper), `dry_run=true` (replay snapshots via
    `tools.fake_llm`, no commit).
 4. Pipeline runs automatically:

--- a/tests/test_pipeline_model_input.py
+++ b/tests/test_pipeline_model_input.py
@@ -45,6 +45,48 @@ def test_model_input_on_dispatch_and_call() -> None:
     assert call["model"].get("type") == "string"
 
 
+def test_build_model_input_on_dispatch_and_call() -> None:
+    """The build step is mechanical timecode alignment — it may run on a
+    cheaper/different model than review (e.g. review=Fable, build=Opus).
+    An empty default falls back to `model`, so single-model runs need no
+    extra input."""
+    on = _on(_load())
+
+    dispatch = on["workflow_dispatch"]["inputs"]
+    assert "build_model" in dispatch, "workflow_dispatch is missing the `build_model` input"
+    assert dispatch["build_model"].get("type") == "choice"
+    options = dispatch["build_model"].get("options", [])
+    assert DEFAULT_MODEL in options
+    assert "claude-fable-5" in options
+    # first option is the default for a choice input without explicit default;
+    # an explicit empty-string default is not representable in choice, so the
+    # sentinel option "same-as-model" must come first.
+    assert options[0] == "same-as-model"
+
+    call = on["workflow_call"]["inputs"]
+    assert "build_model" in call, "workflow_call is missing the `build_model` input"
+    assert call["build_model"].get("type") == "string"
+    assert call["build_model"].get("default", "") in ("", "same-as-model")
+
+
+def test_build_model_env_fallback_chain() -> None:
+    """MODEL_BUILD: build_model if set (and not the sentinel) → model → default."""
+    env = _load()["env"]
+    build = str(env.get("MODEL_BUILD", ""))
+    assert "inputs.build_model" in build, f"MODEL_BUILD must consider inputs.build_model, got: {build!r}"
+    assert "inputs.model" in build, f"MODEL_BUILD must fall back to inputs.model, got: {build!r}"
+    assert DEFAULT_MODEL in build, f"MODEL_BUILD must keep the push-run fallback, got: {build!r}"
+    assert "same-as-model" in build, f"MODEL_BUILD must neutralize the sentinel option, got: {build!r}"
+
+
+def test_build_step_uses_model_build() -> None:
+    text = (WORKFLOWS / "subtitle-pipeline.yml").read_text(encoding="utf-8")
+    build_args = [line for line in text.splitlines() if "claude_args" in line and "--effort high" in line]
+    assert build_args, "build-step claude_args not found (expected the only --effort high)"
+    for line in build_args:
+        assert "env.MODEL_BUILD" in line, f"build step must use env.MODEL_BUILD: {line.strip()}"
+
+
 def test_model_env_wired_to_input() -> None:
     heavy = _load()["env"]["MODEL_HEAVY"]
     assert "inputs.model" in str(heavy), f"MODEL_HEAVY must be driven by inputs.model, got: {heavy!r}"


### PR DESCRIPTION
## Що
- Інпут `build_model` (dispatch: choice з sentinel `same-as-model`; call: string, default `''`) → `env.MODEL_BUILD` з ланцюжком fallback: `build_model` (якщо не sentinel) → `model` → `claude-opus-4-8`.
- Build-крок тепер бере `--model ${{ env.MODEL_BUILD }}`; translate/review — без змін (`MODEL_HEAVY`).
- CLAUDE.md: задокументовано.

## Навіщо
Split-режим для корпусного прогону: review на Fable (мовна цінність), build на Opus (механічне зіставлення таймкодів) — вдвічі дешевше по Fable-ліміту на промову.

## Тести
TDD: 3 нові структурні гарди в `tests/test_pipeline_model_input.py` (RED→GREEN): інпути на dispatch+call, fallback-ланцюжок env, використання `MODEL_BUILD` саме в build-кроці.

🤖 Generated with [Claude Code](https://claude.com/claude-code)