### PR TITLE
GitHub sign-in (auth core) for the review SPA

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -27,7 +27,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Deploy Worker + push its secrets
-        uses: cloudflare/wrangler-action@v3
+        # Third-party action that receives all four secrets — pinned to an
+        # immutable commit SHA, not a movable tag.
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,42 @@
+name: Deploy OAuth Worker
+
+# Deploys workers/oauth-exchange to Cloudflare. Runs on merge to main when the
+# Worker (or this workflow) changes, and on manual dispatch. Requires repo
+# secrets: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, GH_OAUTH_CLIENT_ID,
+# GH_OAUTH_CLIENT_SECRET (see docs/github-app-setup.md).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'workers/oauth-exchange/**'
+      - '.github/workflows/deploy-worker.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-worker
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Deploy Worker + push its secrets
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: workers/oauth-exchange
+          # Worker secrets are uploaded from same-named env vars below —
+          # values live only in repo secrets, never in this file.
+          secrets: |
+            GH_CLIENT_ID
+            GH_CLIENT_SECRET
+        env:
+          GH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
+          GH_CLIENT_SECRET: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,8 @@ docs/superpowers/
 # OS
 .DS_Store
 Thumbs.db
+
+# Cloudflare Worker local dev (secrets + wrangler state + npm)
+.dev.vars
+workers/oauth-exchange/.wrangler/
+node_modules/

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -1,0 +1,60 @@
+# GitHub App + OAuth Worker setup (one-time, admin)
+
+The review SPA signs users in via a GitHub App; a Cloudflare Worker
+(`workers/oauth-exchange/`) swaps the OAuth `code` for a user token.
+Until these steps are done, `APP_GH_CLIENT_ID` in `site/index.html` stays
+empty and the sign-in UI is hidden.
+
+## 1. Create the GitHub App (org sy-tools)
+
+Settings → Developer settings → GitHub Apps → New GitHub App:
+
+- **Name**: `sy-subtitles-review`
+- **Homepage URL**: `https://sy-tools.github.io/sy-subtitles/`
+- **Callback URLs** (add both):
+  - `https://sy-tools.github.io/sy-subtitles/`
+  - `http://localhost:8000/`
+- **Expire user authorization tokens**: OFF (the SPA has no refresh logic)
+- **Request user authorization (OAuth) during installation**: ON
+- **Webhook**: Inactive (uncheck Active)
+- **Repository permissions**: Issues RW, Contents RW, Pull requests RW
+- **Where can this app be installed**: Only on this account
+
+After creation: note the **Client ID** (`Iv1.…`), generate a **client secret**.
+
+## 2. Install the App
+
+App settings → Install App → sy-tools → Only select repositories →
+`sy-subtitles`.
+
+## 3. Deploy the Worker
+
+```bash
+cd workers/oauth-exchange
+wrangler deploy
+wrangler secret put GH_CLIENT_ID      # the Iv1.… client id
+wrangler secret put GH_CLIENT_SECRET  # the generated secret
+```
+
+Note the deployed URL, e.g. `https://sy-subtitles-oauth.<account>.workers.dev`.
+Allowed origins live in `wrangler.toml` `[vars] ALLOWED_ORIGINS`.
+
+## 4. Point the SPA at them
+
+In `site/index.html` set:
+
+```js
+var APP_GH_CLIENT_ID = 'Iv1.…';
+var APP_GH_EXCHANGE_URL = 'https://sy-subtitles-oauth.<account>.workers.dev/exchange';
+```
+
+Commit + deploy (Pages). The "Sign in" button appears for everyone; only
+collaborators gain useful write actions.
+
+## Rotation / revocation
+
+- Rotate the client secret: regenerate in the App settings, `wrangler secret
+  put GH_CLIENT_SECRET` again. Users stay signed in (tokens are unaffected).
+- Revoke all user tokens: App settings → Advanced → Revoke all user tokens.
+- A revoked/expired token in a browser triggers a silent sign-out on the next
+  API call.

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -5,9 +5,9 @@ The review SPA signs users in via a GitHub App; a Cloudflare Worker
 Until these steps are done, `APP_GH_CLIENT_ID` in `site/index.html` stays
 empty and the sign-in UI is hidden.
 
-## 1. Create the GitHub App (org sy-tools)
+## 1. Create the GitHub App (org sy-tools, manual — GitHub has no CLI for this)
 
-Settings → Developer settings → GitHub Apps → New GitHub App:
+Org **sy-tools** → Settings → Developer settings → GitHub Apps → New GitHub App:
 
 - **Name**: `sy-subtitles-review`
 - **Homepage URL**: `https://sy-tools.github.io/sy-subtitles/`
@@ -27,19 +27,34 @@ After creation: note the **Client ID** (`Iv1.…`), generate a **client secret**
 App settings → Install App → sy-tools → Only select repositories →
 `sy-subtitles`.
 
-## 3. Deploy the Worker
+## 3. Set repo secrets (once)
+
+The Worker is deployed by CI (`.github/workflows/deploy-worker.yml`), never
+from a laptop. It needs four repo secrets:
 
 ```bash
-cd workers/oauth-exchange
-wrangler deploy
-wrangler secret put GH_CLIENT_ID      # the Iv1.… client id
-wrangler secret put GH_CLIENT_SECRET  # the generated secret
+gh secret set GH_OAUTH_CLIENT_ID      # the Iv1.… client id (step 1)
+gh secret set GH_OAUTH_CLIENT_SECRET  # the generated client secret (step 1)
+gh secret set CLOUDFLARE_ACCOUNT_ID   # Cloudflare dashboard -> Workers -> Account ID
+gh secret set CLOUDFLARE_API_TOKEN    # dashboard -> My Profile -> API Tokens ->
+                                      #   Create Token -> "Edit Cloudflare Workers" template
 ```
 
-Note the deployed URL, e.g. `https://sy-subtitles-oauth.<account>.workers.dev`.
-Allowed origins live in `wrangler.toml` `[vars] ALLOWED_ORIGINS`.
+## 4. Deploy the Worker (CI)
 
-## 4. Point the SPA at them
+The workflow deploys automatically on every merge to `main` that touches
+`workers/oauth-exchange/**`, and can be run by hand:
+
+```bash
+gh workflow run deploy-worker.yml
+```
+
+It runs `wrangler deploy` and pushes `GH_CLIENT_ID`/`GH_CLIENT_SECRET` to the
+Worker from the repo secrets. The deployed URL is
+`https://sy-subtitles-oauth.<account-subdomain>.workers.dev` (shown in the run
+log). Allowed origins live in `wrangler.toml` `[vars] ALLOWED_ORIGINS`.
+
+## 5. Point the SPA at them
 
 In `site/index.html` set:
 
@@ -51,10 +66,40 @@ var APP_GH_EXCHANGE_URL = 'https://sy-subtitles-oauth.<account>.workers.dev/exch
 Commit + deploy (Pages). The "Sign in" button appears for everyone; only
 collaborators gain useful write actions.
 
+## Local verification (before merging any of this)
+
+Run the Worker locally instead of deploying:
+
+```bash
+cd workers/oauth-exchange
+cp .dev.vars.example .dev.vars       # fill in the real Iv1.… id + secret
+npx wrangler dev                      # serves http://localhost:8787
+```
+
+Serve the SPA on port 8000 (`python -m http.server 8000 -d site`) and point it
+at the local Worker via the runtime hooks (no code edits needed) — in the
+browser console:
+
+```js
+window.__SY_GH_CLIENT_ID = 'Iv1.…';
+window.__SY_GH_EXCHANGE_URL = 'http://localhost:8787/exchange';
+updateAuthUI();
+```
+
+Click "Sign in" → GitHub → redirected back to localhost:8000 → the exchange
+hits the local Worker. `http://localhost:8000` is already in the Worker's
+`ALLOWED_ORIGINS` and must be one of the App's callback URLs (step 1).
+Note: the hooks live only in that tab's session — re-set them after a reload
+(the callback handler runs before you can retype them, so for the full
+round-trip test serve an injected copy of index.html, e.g. with the snippet in
+`tests/test_spa_auth_e2e.py`'s `auth_server` fixture, or temporarily set the
+two constants in `site/index.html` without committing).
+
 ## Rotation / revocation
 
-- Rotate the client secret: regenerate in the App settings, `wrangler secret
-  put GH_CLIENT_SECRET` again. Users stay signed in (tokens are unaffected).
+- Rotate the client secret: regenerate in the App settings, update the
+  `GH_OAUTH_CLIENT_SECRET` repo secret, re-run `deploy-worker.yml`. Users stay
+  signed in (tokens are unaffected).
 - Revoke all user tokens: App settings → Advanced → Revoke all user tokens.
 - A revoked/expired token in a browser triggers a silent sign-out on the next
   API call.

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -35,10 +35,50 @@ from a laptop. It needs four repo secrets:
 ```bash
 gh secret set GH_OAUTH_CLIENT_ID      # the Iv1.… client id (step 1)
 gh secret set GH_OAUTH_CLIENT_SECRET  # the generated client secret (step 1)
-gh secret set CLOUDFLARE_ACCOUNT_ID   # Cloudflare dashboard -> Workers -> Account ID
-gh secret set CLOUDFLARE_API_TOKEN    # dashboard -> My Profile -> API Tokens ->
-                                      #   Create Token -> "Edit Cloudflare Workers" template
+gh secret set CLOUDFLARE_ACCOUNT_ID   # see 3a
+gh secret set CLOUDFLARE_API_TOKEN    # see 3b
 ```
+
+### 3a. CLOUDFLARE_ACCOUNT_ID
+
+A Cloudflare account on the **free plan** is enough (Workers free tier:
+100k requests/day). After signing up at <https://dash.cloudflare.com>:
+
+- Open **Workers & Pages** in the left menu. On the first visit Cloudflare
+  asks you to register a `*.workers.dev` subdomain — pick one (e.g.
+  `sy-tools`); the Worker URL becomes
+  `https://sy-subtitles-oauth.<subdomain>.workers.dev`.
+- The **Account ID** is shown in the right-hand column of the Workers & Pages
+  overview page (also: it is the 32-hex-char segment in the dashboard URL,
+  `dash.cloudflare.com/<account-id>/...`).
+
+### 3b. CLOUDFLARE_API_TOKEN
+
+1. Dashboard → profile icon (top-right) → **My Profile** → **API Tokens**
+   (direct link: <https://dash.cloudflare.com/profile/api-tokens>).
+2. **Create Token** → in the templates list pick **Edit Cloudflare Workers**
+   → *Use template*.
+3. On the token form:
+   - **Account Resources**: *Include* → your account (the one from 3a).
+   - **Zone Resources**: *All zones from an account* → your account. (The
+     template bundles zone-level Workers-routes permissions; this deploy uses
+     only workers.dev, so no zone is ever touched — but the template requires
+     a selection.)
+   - Optionally set **TTL** — but note an expired token silently breaks the
+     deploy workflow later; no expiry + rotation on demand is simpler here.
+4. **Continue to summary** → **Create Token**.
+5. Copy the token — **it is shown exactly once**. Verify it works:
+
+   ```bash
+   curl -s https://api.cloudflare.com/client/v4/user/tokens/verify \
+     -H "Authorization: Bearer <token>"   # expect "status": "active"
+   ```
+
+6. `gh secret set CLOUDFLARE_API_TOKEN` (paste the token).
+
+This token can deploy/edit Workers on the account — treat it like a password:
+it lives only in the repo secret, and can be revoked/rolled any time from the
+same API Tokens page (then update the secret and re-run the workflow).
 
 ## 4. Deploy the Worker (CI)
 

--- a/site/css/components.css
+++ b/site/css/components.css
@@ -434,6 +434,8 @@ body {
 }
 .talk-item:hover { border-color: var(--border3); }
 .talk-item.selected { border-color: var(--link); background: var(--stat-active-bg); }
+/* Talk assigned to the signed-in reviewer — a quiet left accent, no new palette. */
+.talk-item--mine { box-shadow: inset 3px 0 0 var(--accent-green); }
 
 .stat-card {
   border-radius: 2px;

--- a/site/index.html
+++ b/site/index.html
@@ -717,8 +717,8 @@ var PAGES_BASE = location.pathname.replace(/\/[^/]*$/, '');
 var APP_DEPLOY_SHA = ''; // app-shell version (index.html + js/*.js) at deploy
 var APP_DEPLOY_DATE = ''; // deploy date YYYY-MM-DD
 var APP_GATE_HASH = ''; // passphrase-gate PBKDF2 hash, injected at deploy from the GATE_PASSPHRASE secret (empty => gate disabled / fail-open)
-var APP_GH_CLIENT_ID = ''; // GitHub App client id (public). Empty => GitHub sign-in hidden.
-var APP_GH_EXCHANGE_URL = ''; // code->token exchange Worker (workers/oauth-exchange)
+var APP_GH_CLIENT_ID = 'Iv23liUDzvKwr32aTyMc'; // GitHub App client id (public). Empty => GitHub sign-in hidden.
+var APP_GH_EXCHANGE_URL = 'https://sy-subtitles-oauth.sy-tools.workers.dev/exchange'; // code->token exchange Worker (workers/oauth-exchange)
 // Test hooks mirror __SY_GATE_HASH: Playwright injects these to enable the
 // feature without editing the shipped (empty => disabled) config.
 function ghClientId() { return window.__SY_GH_CLIENT_ID || APP_GH_CLIENT_ID; }

--- a/site/index.html
+++ b/site/index.html
@@ -377,6 +377,7 @@
         <div id="video-picker-dropdown" class="video-dropdown" role="listbox"></div>
       </span>
       <button class="btn btn--issue" onclick="SPA.createReviewIssue()" data-i18n="btn.create_review_issue">Create Issue</button>
+      <button id="btn-create-pr" class="btn btn--primary" data-gh-only style="display:none" onclick="SPA.createReviewPr()" data-i18n="btn.create_pr">Create PR</button>
       <button class="btn btn--primary" onclick="SPA.openEditor()" data-i18n="btn.open_editor">Open in GitHub Editor</button>
       <button onclick="SPA.revertAllEdits()" id="btn-revert-all" class="btn btn--danger" style="display:none" data-i18n="btn.revert_all">Revert all</button>
     </div>
@@ -862,6 +863,15 @@ var I18N = {
     'auth.error_state': '\u041F\u043E\u043C\u0438\u043B\u043A\u0430 \u0432\u0445\u043E\u0434\u0443: \u043D\u0435\u0432\u0430\u043B\u0456\u0434\u043D\u0438\u0439 state. \u0421\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0449\u0435 \u0440\u0430\u0437.',
     'auth.error_exchange': '\u041D\u0435 \u0432\u0434\u0430\u043B\u043E\u0441\u044F \u0443\u0432\u0456\u0439\u0442\u0438 \u0447\u0435\u0440\u0435\u0437 GitHub',
     'auth.expired': '\u0421\u0435\u0441\u0456\u044F GitHub \u043D\u0435\u0434\u0456\u0439\u0441\u043D\u0430 \u2014 \u0432\u0438\u043A\u043E\u043D\u0430\u043D\u043E \u0432\u0438\u0445\u0456\u0434',
+    'btn.create_pr': '\u0421\u0442\u0432\u043E\u0440\u0438\u0442\u0438 PR',
+    'btn.take_review': '\u0412\u0437\u044F\u0442\u0438 \u043D\u0430 \u0440\u0435\u0432\u02BC\u044E',
+    'stat.mine': '\u043C\u043E\u0457',
+    'pr.created': 'PR \u0441\u0442\u0432\u043E\u0440\u0435\u043D\u043E',
+    'pr.no_edits': '\u041D\u0435\u043C\u0430\u0454 \u0440\u0435\u0434\u0430\u0433\u0443\u0432\u0430\u043D\u044C \u0434\u043B\u044F PR',
+    'pr.failed': '\u041D\u0435 \u0432\u0434\u0430\u043B\u043E\u0441\u044F \u0441\u0442\u0432\u043E\u0440\u0438\u0442\u0438 PR',
+    'issue.created': '\u0406\u0448\u02BC\u044E \u0441\u0442\u0432\u043E\u0440\u0435\u043D\u043E',
+    'review.taken': '\u041F\u0440\u043E\u043C\u043E\u0432\u0443 \u0432\u0437\u044F\u0442\u043E \u043D\u0430 \u0440\u0435\u0432\u02BC\u044E',
+    'gh.error': '\u041F\u043E\u043C\u0438\u043B\u043A\u0430 GitHub',
     'title.lang': '\u041C\u043E\u0432\u0430 \u0456\u043D\u0442\u0435\u0440\u0444\u0435\u0439\u0441\u0443'
   },
   en: {
@@ -999,6 +1009,15 @@ var I18N = {
     'auth.error_state': 'Sign-in failed: invalid state. Please try again.',
     'auth.error_exchange': 'GitHub sign-in failed',
     'auth.expired': 'GitHub session invalid — signed out',
+    'btn.create_pr': 'Create PR',
+    'btn.take_review': 'Take for review',
+    'stat.mine': 'mine',
+    'pr.created': 'PR created',
+    'pr.no_edits': 'No edits to submit as a PR',
+    'pr.failed': 'Could not create the PR',
+    'issue.created': 'Issue created',
+    'review.taken': 'Talk taken for review',
+    'gh.error': 'GitHub error',
     'title.lang': 'Interface language'
   }
 };
@@ -2222,19 +2241,22 @@ function buildManifest(tree) {
 // Review Status (static JSON, zero API cost)
 // ============================================================
 function computeStats(talks, statuses, query) {
-  var total = { talks: 0, needs_review: 0, in_review: 0, approved: 0, pending: 0 };
-  var filtered = { talks: 0, needs_review: 0, in_review: 0, approved: 0, pending: 0 };
+  var total = { talks: 0, needs_review: 0, in_review: 0, approved: 0, pending: 0, mine: 0 };
+  var filtered = { talks: 0, needs_review: 0, in_review: 0, approved: 0, pending: 0, mine: 0 };
+  var authLogin = (getAuthUser() || {}).login || null;
   talks.forEach(function(t) {
     var matchesSearch = !query || ((t.title || '') + ' ' + (t.date || '') + ' ' + t.id).toLowerCase().indexOf(query) !== -1;
     var st = statuses[t.id] || null;
     var stages = getPipelineStages(t, st);
     var status = getOverallStatus(stages, st);
+    var isMine = !!(authLogin && st && st.reviewer === authLogin);
     // Total counts
     total.talks++;
     if (status === 'ready-for-review') total.needs_review++;
     if (status === 'in-review') total.in_review++;
     if (status === 'approved') total.approved++;
     if (status === 'in-progress') total.pending++;
+    if (isMine) total.mine++;
     // Filtered counts (by search)
     if (matchesSearch) {
       filtered.talks++;
@@ -2242,6 +2264,7 @@ function computeStats(talks, statuses, query) {
       if (status === 'in-review') filtered.in_review++;
       if (status === 'approved') filtered.approved++;
       if (status === 'in-progress') filtered.pending++;
+      if (isMine) filtered.mine++;
     }
   });
   return { total: total, filtered: filtered };
@@ -2272,6 +2295,10 @@ function renderStats() {
       { f: s.filtered.needs_review, t: s.total.needs_review, label: t('stat.needs_review'), cls: 'warn', filter: 'needs-review' },
       { f: s.filtered.in_review, t: s.total.in_review, label: t('stat.in_review'), cls: 'info', filter: 'in-review' },
     ];
+  }
+  // Signed-in reviewers get a "mine" chip in both modes.
+  if (getAuthUser()) {
+    cards.push({ f: s.filtered.mine, t: s.total.mine, label: t('stat.mine'), cls: 'good', filter: 'mine' });
   }
   bar.innerHTML = '';
   cards.forEach(function(c) {
@@ -2402,11 +2429,13 @@ function renderIndex(el) {
   document.getElementById('index-toolbar').style.display = 'block';
   var statuses = (reviewStatus && reviewStatus.talks) || {};
   var query = (document.getElementById('search-input').value || '').toLowerCase();
+  var authLogin = (getAuthUser() || {}).login || null;
 
   manifest.talks.forEach(function(tk) {
     var st = statuses[tk.id] || null;
     var stages = getPipelineStages(tk, st);
     var status = getOverallStatus(stages, st);
+    var isMine = !!(authLogin && st && st.reviewer === authLogin);
 
     // Filter by status
     if (activeFilter === 'all' && !expertMode) {
@@ -2417,6 +2446,7 @@ function renderIndex(el) {
       if (activeFilter === 'in-review' && status !== 'in-review') return;
       if (activeFilter === 'pending' && status !== 'in-progress') return;
       if (activeFilter === 'approved' && status !== 'approved') return;
+      if (activeFilter === 'mine' && !isMine) return;
     }
 
     // Search
@@ -2425,7 +2455,7 @@ function renderIndex(el) {
 
     // Build card — all data is from trusted manifest, escaped with esc()
     var div = document.createElement('div');
-    div.className = 'talk-item';
+    div.className = 'talk-item' + (isMine ? ' talk-item--mine' : '');
     var dateStr = tk.date || tk.id.substring(0, 10);
     var badge = '';
     if (st) {
@@ -2452,6 +2482,12 @@ function renderIndex(el) {
     if (actions.review) {
       reviewLink = '<a href="' + safeHref('#/review/' + tk.id) + '" class="review-link">&#x270E; ' + t('link.review') + '</a>';
     }
+    // "Take for review" — signed-in reviewers claim an unassigned talk right
+    // from the card (id is bound via addEventListener below, not inline HTML).
+    var takeBtn = '';
+    if (authLogin && actions.review && status !== 'approved' && !(st && st.reviewer)) {
+      takeBtn = '<button class="btn btn--sm btn--ghost take-review-btn">' + esc(t('btn.take_review')) + '</button>';
+    }
     // Assemble card. amruta_url is attacker-influenceable (meta.yaml from a
     // PR / the amruta-scraping bookmarklet) so route it through safeHref;
     // dateStr is escaped too. The expert button's talk-id copy is bound via
@@ -2464,7 +2500,14 @@ function renderIndex(el) {
     var statusBadge = renderStatusBadge(status, st);
     div.innerHTML = '<div class="talk-date"><span>' + dateHtml + expertHtml + '</span>' + statusBadge + '</div>'
       + '<div class="talk-title">' + esc(tk.title || tk.id) + '</div>'
-      + ((videoLinks || reviewLink) ? '<div class="talk-actions">' + videoLinks + reviewLink + '</div>' : '');
+      + ((videoLinks || reviewLink || takeBtn) ? '<div class="talk-actions">' + videoLinks + reviewLink + takeBtn + '</div>' : '');
+
+    var takeEl = div.querySelector('.take-review-btn');
+    if (takeEl) takeEl.addEventListener('click', function(e) {
+      e.stopPropagation();
+      takeEl.disabled = true;
+      SPA.takeForReview(tk.id);
+    });
 
     // Copy the talk id on expert-button click (id comes from the closure, never
     // injected into HTML). stopPropagation keeps the card from expanding; the
@@ -3386,22 +3429,11 @@ SPA.createPreviewIssue = function() {
   }
   var issueTitle = (s.mode === 'edit' ? 'Subtitle edits: ' : 'Subtitle review: ') + (s.video ? s.video.title : s.videoSlug);
   var issueBody = lines.join('\n');
-  var url = gh + '/issues/new?title=' + encodeURIComponent(issueTitle) + '&labels=review:pending&body=' + encodeURIComponent(issueBody);
-  var shortUrl = gh + '/issues/new?title=' + encodeURIComponent(issueTitle) + '&labels=review:pending';
-  if (url.length > 8000) {
-    navigator.clipboard.writeText(issueBody).then(function() {
-      SPA.confirm({
-        title: t('modal.copied_title_issue'),
-        body: t('modal.copied_body_issue'),
-        confirmLabel: t('modal.open_github'),
-        singleButton: true
-      }).then(function() { window.open(shortUrl); });
-    }).catch(function() {
-      window.open(shortUrl);
-    });
-  } else {
-    window.open(url);
+  if (getAuthUser() && getAuthToken()) {
+    submitIssueViaApi(issueTitle, issueBody);
+    return;
   }
+  openIssuePage(issueTitle, issueBody);
 };
 
 SPA.openPreviewEditor = function() {
@@ -4104,15 +4136,74 @@ function updateRevertBtn() {
   btn.textContent = ec > 0 ? t('btn.revert_all') + ' (' + ec + ')' : t('btn.revert_all');
 }
 
-SPA.createReviewIssue = function() {
+// Path + label of the file the review view edits (the right column). Shared
+// by the issue body, the GitHub-editor flow and the signed-in PR flow.
+function reviewFilePath() {
+  var isSrt = reviewState.mode === 'srt';
+  return {
+    isSrt: isSrt,
+    path: isSrt
+      ? 'talks/' + reviewState.talkId + '/' + reviewState.videoSlug + '/final/' + (reviewState.srtRightLang) + '.srt'
+      : 'talks/' + reviewState.talkId + '/transcript_' + reviewState.rightLang + '.txt',
+    label: isSrt ? 'Subtitles' : 'Transcript'
+  };
+}
+
+// Success dialog for a created issue/PR: window.open must happen on the
+// dialog's confirm click (a user gesture) or popup blockers eat it.
+function ghCreatedDialog(titleKey, res) {
+  SPA.confirm({
+    title: t(titleKey),
+    body: '<a href="' + safeHref(res.html_url) + '" target="_blank">#' + res.number + '</a>',
+    confirmLabel: t('modal.open_github'),
+    singleButton: true
+  }).then(function() { window.open(res.html_url); });
+}
+
+// Shared failure path for signed-in write calls. 401 = revoked token → silent
+// sign-out; an error carrying .branch (the PR chain died after the branch was
+// pushed) links to the orphan branch; anything else is a toast.
+function ghWriteError(err) {
+  console.warn('GitHub write failed:', err && err.status, err && err.message);
+  if (err && err.status === 401) {
+    clearAuth();
+    updateAuthUI();
+    showToast(t('auth.expired'));
+    return;
+  }
+  var msg = t('gh.error') + (err && err.message ? ': ' + err.message : '');
+  if (err && err.branch) {
+    var burl = 'https://github.com/' + REPO + '/tree/' + err.branch;
+    SPA.confirm({
+      title: t('pr.failed'),
+      body: esc(msg) + '<br><br><a href="' + safeHref(burl) + '" target="_blank">' + esc(err.branch) + '</a>',
+      confirmLabel: 'OK',
+      singleButton: true
+    });
+    return;
+  }
+  showToast(msg);
+}
+
+// Signed-in issue path: POST /issues directly (no URL-length limit, no
+// clipboard round-trip).
+function submitIssueViaApi(issueTitle, issueBody) {
+  return createIssue(API, getAuthToken(),
+    { title: issueTitle, body: issueBody, labels: ['review:pending'] })
+    .then(function(res) { ghCreatedDialog('issue.created', res); })
+    .catch(ghWriteError);
+}
+
+// {title, body} of the review issue — also reused verbatim as the PR body by
+// SPA.createReviewPr, so both write paths describe the same marks/edits.
+function buildReviewIssueContent() {
   var gh = 'https://github.com/' + REPO;
   var talk = manifest ? manifest.talks.find(function(t) { return t.id === reviewState.talkId; }) : null;
   var title = talk ? talk.title : reviewState.talkId;
-  var isSrt = reviewState.mode === 'srt';
-  var filePath = isSrt
-    ? 'talks/' + reviewState.talkId + '/' + reviewState.videoSlug + '/final/' + (reviewState.srtRightLang) + '.srt'
-    : 'talks/' + reviewState.talkId + '/transcript_' + reviewState.rightLang + '.txt';
-  var fileLabel = isSrt ? 'Subtitles' : 'Transcript';
+  var file = reviewFilePath();
+  var isSrt = file.isSrt;
+  var filePath = file.path;
+  var fileLabel = file.label;
   var aligned = isSrt ? (reviewState.alignedRows || []) : null;
 
   function rowLabel(idx) {
@@ -4142,8 +4233,13 @@ SPA.createReviewIssue = function() {
       lines.push('<details><summary><b>' + rowLabel(idx) + '</b></summary>', '', '**Before:**', '> ' + (reviewState.rightParas[idx]||''), '', '**After:**', '> ' + reviewState.edits[idx], '', '</details>', '');
     });
   }
-  var issueTitle = 'Translation review: ' + title;
-  var issueBody = lines.join('\n');
+  return { title: 'Translation review: ' + title, body: lines.join('\n') };
+}
+
+// Prefilled-URL issue flow with the ~8k URL-length clipboard fallback — the
+// signed-OUT path, byte-identical to the pre-auth behaviour.
+function openIssuePage(issueTitle, issueBody) {
+  var gh = 'https://github.com/' + REPO;
   var url = gh + '/issues/new?title=' + encodeURIComponent(issueTitle) + '&labels=review:pending&body=' + encodeURIComponent(issueBody);
   var shortUrl = gh + '/issues/new?title=' + encodeURIComponent(issueTitle) + '&labels=review:pending';
   // GitHub URL limit ~8192 chars — if too long, copy body to clipboard
@@ -4161,15 +4257,47 @@ SPA.createReviewIssue = function() {
   } else {
     window.open(url);
   }
+}
+
+SPA.createReviewIssue = function() {
+  var content = buildReviewIssueContent();
+  if (getAuthUser() && getAuthToken()) {
+    submitIssueViaApi(content.title, content.body);
+    return;
+  }
+  openIssuePage(content.title, content.body);
 };
 
-SPA.openEditor = function() {
+// One-button PR from the review edits: new timestamped branch off BRANCH,
+// commit the rebuilt file, open the PR (whose body = the review issue body).
+// The existing sync-subtitles.yml then reconciles transcript↔SRT on the PR.
+SPA.createReviewPr = function() {
+  var user = getAuthUser(), token = getAuthToken();
+  if (!user || !token) return;
+  if (!Object.keys(reviewState.edits).length) { showToast(t('pr.no_edits')); return; }
+  var file = reviewFilePath();
+  var content = buildReviewIssueContent();
+  var btn = document.getElementById('btn-create-pr');
+  if (btn) btn.disabled = true;
+  submitFilesPr(API, token, {
+    branch: makeBranchName('review/' + reviewState.talkId, user.login),
+    base: BRANCH,
+    files: [{ path: file.path, content: buildReviewEditedContent() }],
+    commitMessage: 'Review edits: ' + reviewState.talkId + ' (' + file.label + ')',
+    prTitle: content.title,
+    prBody: content.body
+  }).then(function(pr) {
+    ghCreatedDialog('pr.created', pr);
+  }).catch(ghWriteError)
+    .then(function() { if (btn) btn.disabled = false; });
+};
+
+// Full new content of the review view's edited file: SRT rebuilt with original
+// numbering/timecodes and edited text substituted; transcript re-serialized
+// byte-exact (BOM/CRLF/header preserved). Callers ensure edits exist.
+function buildReviewEditedContent() {
   var isSrt = reviewState.mode === 'srt';
-  var filePath = isSrt
-    ? 'talks/' + reviewState.talkId + '/' + reviewState.videoSlug + '/final/' + (reviewState.srtRightLang) + '.srt'
-    : 'talks/' + reviewState.talkId + '/transcript_' + reviewState.rightLang + '.txt';
-  var url = 'https://github.com/' + REPO + '/edit/main/' + filePath;
-  if (Object.keys(reviewState.edits).length > 0) {
+  {
     var full;
     if (isSrt) {
       // Rebuild a valid SRT from alignedRows: keep block numbering and timecodes
@@ -4205,7 +4333,14 @@ SPA.openEditor = function() {
       var parsed = reviewState.rightParsed || { header: '', separator: '\n', bom: '', lineEnding: '\n' };
       full = serializeTranscript(parsed, paras);
     }
-    navigator.clipboard.writeText(full).then(function() {
+    return full;
+  }
+}
+
+SPA.openEditor = function() {
+  var url = 'https://github.com/' + REPO + '/edit/main/' + reviewFilePath().path;
+  if (Object.keys(reviewState.edits).length > 0) {
+    navigator.clipboard.writeText(buildReviewEditedContent()).then(function() {
       SPA.confirm({
         title: t('modal.copied_title_srt'),
         body: t('modal.copied_body_srt'),
@@ -4258,7 +4393,60 @@ function updateAuthUI() {
   } else {
     avatar.style.display = 'none';
   }
+  // Signed-in-only controls (e.g. the review view's Create PR button).
+  var ghOnly = document.querySelectorAll('[data-gh-only]');
+  for (var i = 0; i < ghOnly.length; i++) ghOnly[i].style.display = user ? '' : 'none';
+  // Index cards/chips render auth-dependent bits ("take for review", the
+  // 'mine' chip, own-talk highlight) — refresh them on login/logout.
+  if (manifest && document.getElementById('index-content')) {
+    // A saved 'mine' filter is meaningless signed out — fall back to 'all'.
+    if (!user && activeFilter === 'mine') activeFilter = 'all';
+    renderStats();
+    renderIndex(document.getElementById('index-content'));
+  }
 }
+
+// "Take for review": assign the talk's review issue to the signed-in user,
+// creating the issue first when none exists (title/label contract of
+// .github/scripts/sync-review-status.py: "Review: <talk_id>" + talk-review).
+// The workflow then flips labels/review-status.json; the UI updates
+// optimistically so the badge doesn't lag behind the bot commit.
+SPA.takeForReview = function(talkId) {
+  var user = getAuthUser(), token = getAuthToken();
+  if (!user || !token) return;
+  var st = (reviewStatus && reviewStatus.talks && reviewStatus.talks[talkId]) || null;
+  var done = function(issueNumber) {
+    if (!reviewStatus) reviewStatus = { talks: {} };
+    if (!reviewStatus.talks) reviewStatus.talks = {};
+    reviewStatus.talks[talkId] = {
+      status: 'in-progress',
+      reviewer: user.login,
+      issue_number: issueNumber,
+      updated_at: new Date().toISOString()
+    };
+    renderStats();
+    renderIndex(document.getElementById('index-content'));
+    showToast(t('review.taken'));
+  };
+  if (st && st.issue_number) {
+    addAssignees(API, token, st.issue_number, [user.login])
+      .then(function() { done(st.issue_number); })
+      .catch(ghWriteError);
+  } else {
+    var talk = manifest ? manifest.talks.find(function(t) { return t.id === talkId; }) : null;
+    var gh = 'https://github.com/' + REPO;
+    var body = 'Review of [`' + talkId + '`](' + gh + '/tree/main/talks/' + talkId + ')'
+      + '\n\nTaken via the SY Subtitles SPA'
+      + (talk && talk.title ? ' — ' + talk.title : '') + '.';
+    createIssue(API, token, {
+      title: 'Review: ' + talkId,
+      body: body,
+      labels: ['talk-review', 'review:in-progress'],
+      assignees: [user.login]
+    }).then(function(res) { done(res.number); })
+      .catch(ghWriteError);
+  }
+};
 
 SPA.ghLogin = function() {
   var state = makeAuthState();
@@ -4772,6 +4960,23 @@ SPA.submitAddTalk = function() {
   var talkId = date + '_' + slug;
   var yaml = document.getElementById('add-preview').textContent;
   var filename = 'talks/' + talkId + '/meta.yaml';
+
+  // Signed-in path: branch + commit + PR in one click. sync-subtitles /
+  // new-talk automation then picks the PR up exactly as a hand-made one.
+  var user = getAuthUser(), token = getAuthToken();
+  if (user && token) {
+    submitFilesPr(API, token, {
+      branch: makeBranchName('add-talk/' + talkId, user.login),
+      base: BRANCH,
+      files: [{ path: filename, content: yaml }],
+      commitMessage: 'Add ' + title,
+      prTitle: 'Add ' + title,
+      prBody: 'Added via SY Subtitles SPA from: ' + url
+    }).then(function(pr) {
+      ghCreatedDialog('pr.created', pr);
+    }).catch(ghWriteError);
+    return false;
+  }
 
   // GitHub new file URL — auto-forks for external contributors
   var ghUrl = 'https://github.com/' + REPO + '/new/main?filename=' + encodeURIComponent(filename)

--- a/site/index.html
+++ b/site/index.html
@@ -27,6 +27,8 @@
 <script src="js/shell_version.js"></script>
 <script src="js/talk_actions.js"></script>
 <script src="js/passphrase_gate.js"></script>
+<script src="js/github_auth.js"></script>
+<script src="js/github_api.js"></script>
 <link rel="stylesheet" href="css/tokens.css">
 <link rel="stylesheet" href="css/components.css">
 </head>
@@ -305,6 +307,8 @@
       <button class="stale-x" onclick="SPA.dismissStale()" data-i18n-title="stale.dismiss" style="background:none;border:none;color:var(--fg5);cursor:pointer;font-size:13px;line-height:1;padding:0 2px;">&#x00D7;</button>
     </span>
     <span id="last-updated"></span>
+    <img id="gh-avatar" src="" alt="" onclick="SPA.ghAccountMenu()" style="display:none;width:20px;height:20px;border-radius:50%;cursor:pointer;border:1px solid var(--border2);vertical-align:middle;">
+    <button id="gh-login-btn" onclick="SPA.ghLogin()" data-i18n="auth.login" data-i18n-title="auth.login_title" style="display:none;background:none;color:var(--fg5);border:1px solid var(--border2);border-radius:4px;padding:2px 6px;font-size:11px;cursor:pointer;">GitHub</button>
     <button id="refresh-btn" onclick="SPA.refreshManifest()" style="background:none;color:var(--fg5);border:1px solid var(--border2);border-radius:4px;padding:2px 6px;font-size:11px;cursor:pointer;display:none;" data-i18n-title="title.refresh">&#x21bb;</button>
     <button id="lang-btn" onclick="SPA.toggleLang()" style="background:none;color:var(--fg5);border:1px solid var(--border2);border-radius:4px;padding:2px 6px;font-size:11px;cursor:pointer;" data-i18n-title="title.lang">UK</button>
     <button id="theme-btn" onclick="SPA.cycleTheme()" style="background:none;color:var(--fg5);border:1px solid var(--border2);border-radius:4px;padding:2px 6px;font-size:11px;cursor:pointer;" data-i18n-title="title.theme.auto">&#x263C;</button>
@@ -692,6 +696,12 @@ var PAGES_BASE = location.pathname.replace(/\/[^/]*$/, '');
 var APP_DEPLOY_SHA = ''; // app-shell version (index.html + js/*.js) at deploy
 var APP_DEPLOY_DATE = ''; // deploy date YYYY-MM-DD
 var APP_GATE_HASH = ''; // passphrase-gate PBKDF2 hash, injected at deploy from the GATE_PASSPHRASE secret (empty => gate disabled / fail-open)
+var APP_GH_CLIENT_ID = ''; // GitHub App client id (public). Empty => GitHub sign-in hidden.
+var APP_GH_EXCHANGE_URL = ''; // code->token exchange Worker (workers/oauth-exchange)
+// Test hooks mirror __SY_GATE_HASH: Playwright injects these to enable the
+// feature without editing the shipped (empty => disabled) config.
+function ghClientId() { return window.__SY_GH_CLIENT_ID || APP_GH_CLIENT_ID; }
+function ghExchangeUrl() { return window.__SY_GH_EXCHANGE_URL || APP_GH_EXCHANGE_URL; }
 
 // ============================================================
 // Cache — schema versioned, auto-migrates on format change
@@ -844,6 +854,14 @@ var I18N = {
     'confirm.unsaved_edits': '\u041D\u0435\u0437\u0431\u0435\u0440\u0435\u0436\u0435\u043D\u0456 \u0440\u0435\u0434\u0430\u0433\u0443\u0432\u0430\u043D\u043D\u044F \u0431\u0443\u0434\u0443\u0442\u044C \u0432\u0442\u0440\u0430\u0447\u0435\u043D\u0456. \u041F\u0440\u043E\u0434\u043E\u0432\u0436\u0438\u0442\u0438?',
     'editor.clipboard_alert': '\u0412\u0456\u0434\u0440\u0435\u0434\u0430\u0433\u043E\u0432\u0430\u043D\u0438\u0439 \u0442\u0440\u0430\u043D\u0441\u043A\u0440\u0438\u043F\u0442 \u0441\u043A\u043E\u043F\u0456\u0439\u043E\u0432\u0430\u043D\u043E.\nGitHub \u0440\u0435\u0434\u0430\u043A\u0442\u043E\u0440 \u0432\u0456\u0434\u043A\u0440\u0438\u0454\u0442\u044C\u0441\u044F \u2014 \u0432\u0438\u0434\u0456\u043B\u0456\u0442\u044C \u0432\u0441\u0435 (Ctrl+A) \u0456 \u0432\u0441\u0442\u0430\u0432\u0442\u0435 (Ctrl+V).',
     'no_transcripts': '\u041D\u0435\u043C\u0430\u0454 \u0442\u0440\u0430\u043D\u0441\u043A\u0440\u0438\u043F\u0442\u0456\u0432',
+    'auth.login': '\u0423\u0432\u0456\u0439\u0442\u0438',
+    'auth.login_title': '\u0423\u0432\u0456\u0439\u0442\u0438 \u0447\u0435\u0440\u0435\u0437 GitHub, \u0449\u043E\u0431 \u0441\u0442\u0432\u043E\u0440\u044E\u0432\u0430\u0442\u0438 PR \u0442\u0430 \u0456\u0448\u02BC\u044E \u0437\u0456 SPA',
+    'auth.logout': '\u0412\u0438\u0439\u0442\u0438',
+    'auth.logout_confirm': '\u0412\u0438\u0439\u0442\u0438 \u0437 GitHub?',
+    'auth.signed_in': '\u0412\u0438 \u0443\u0432\u0456\u0439\u0448\u043B\u0438 \u044F\u043A',
+    'auth.error_state': '\u041F\u043E\u043C\u0438\u043B\u043A\u0430 \u0432\u0445\u043E\u0434\u0443: \u043D\u0435\u0432\u0430\u043B\u0456\u0434\u043D\u0438\u0439 state. \u0421\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0449\u0435 \u0440\u0430\u0437.',
+    'auth.error_exchange': '\u041D\u0435 \u0432\u0434\u0430\u043B\u043E\u0441\u044F \u0443\u0432\u0456\u0439\u0442\u0438 \u0447\u0435\u0440\u0435\u0437 GitHub',
+    'auth.expired': '\u0421\u0435\u0441\u0456\u044F GitHub \u043D\u0435\u0434\u0456\u0439\u0441\u043D\u0430 \u2014 \u0432\u0438\u043A\u043E\u043D\u0430\u043D\u043E \u0432\u0438\u0445\u0456\u0434',
     'title.lang': '\u041C\u043E\u0432\u0430 \u0456\u043D\u0442\u0435\u0440\u0444\u0435\u0439\u0441\u0443'
   },
   en: {
@@ -973,6 +991,14 @@ var I18N = {
     'confirm.unsaved_edits': 'Unsaved edits will be lost. Continue?',
     'editor.clipboard_alert': 'Edited transcript copied to clipboard.\nGitHub editor will open \u2014 select all (Ctrl+A) and paste (Ctrl+V).',
     'no_transcripts': 'No transcripts available',
+    'auth.login': 'Sign in',
+    'auth.login_title': 'Sign in with GitHub to create PRs and issues from the SPA',
+    'auth.logout': 'Sign out',
+    'auth.logout_confirm': 'Sign out of GitHub?',
+    'auth.signed_in': 'Signed in as',
+    'auth.error_state': 'Sign-in failed: invalid state. Please try again.',
+    'auth.error_exchange': 'GitHub sign-in failed',
+    'auth.expired': 'GitHub session invalid — signed out',
     'title.lang': 'Interface language'
   }
 };
@@ -1994,6 +2020,10 @@ function loadManifest() {
   try { cache = JSON.parse(localStorage.getItem(CACHE_KEY)); } catch(e) {}
 
   var headers = {};
+  // 5000 req/h authenticated vs 60 unauthenticated; the token goes ONLY to
+  // api.github.com (raw.githubusercontent fetches stay tokenless).
+  var hadToken = getAuthToken();
+  if (hadToken) headers['Authorization'] = 'Bearer ' + hadToken;
   if (cache && cache.etag) headers['If-None-Match'] = cache.etag;
 
   // Serve the cached manifest (flagged stale) instead of a blank index when the
@@ -2008,6 +2038,14 @@ function loadManifest() {
 
   return fetch(API + '/git/trees/' + BRANCH + '?recursive=1', { headers: headers })
     .then(function(r) {
+      if (r.status === 401 && hadToken) {
+        // Revoked/invalid token: silently sign out and retry unauthenticated
+        // (loop-safe — the token is cleared before the retry).
+        clearAuth();
+        updateAuthUI();
+        showToast(t('auth.expired'));
+        return loadManifest();
+      }
       if (r.status === 304 && cache) {
         // On 304, Last-Modified header is still returned
         var lm304 = r.headers.get('Last-Modified');
@@ -2490,6 +2528,8 @@ SPA.filterTalks = function(filter) {
 };
 
 document.addEventListener('DOMContentLoaded', function() {
+  handleAuthCallback();
+  updateAuthUI();
   var searchEl = document.getElementById('search-input');
   if (searchEl) {
     var debounce;
@@ -4197,6 +4237,78 @@ function showToast(msg) {
 }
 function fmtTime(sec) {
   return String(Math.floor(sec/3600)).padStart(2,'0') + ':' + String(Math.floor((sec%3600)/60)).padStart(2,'0') + ':' + String(Math.floor(sec%60)).padStart(2,'0');
+}
+
+// ============================================================
+// GitHub sign-in (auth core). Pure logic lives in js/github_auth.js and
+// js/github_api.js (Node-tested); this block only wires URL, storage,
+// header UI and toasts together.
+// ============================================================
+function updateAuthUI() {
+  var loginBtn = document.getElementById('gh-login-btn');
+  var avatar = document.getElementById('gh-avatar');
+  if (!loginBtn || !avatar) return;
+  var user = getAuthUser();
+  loginBtn.style.display = (ghClientId() && !user) ? '' : 'none';
+  if (user) {
+    avatar.src = user.avatar_url;
+    avatar.title = t('auth.signed_in') + ' ' + user.login;
+    avatar.alt = user.login;
+    avatar.style.display = '';
+  } else {
+    avatar.style.display = 'none';
+  }
+}
+
+SPA.ghLogin = function() {
+  var state = makeAuthState();
+  try { sessionStorage.setItem('sy_gh_state', state); } catch (e) {}
+  location.href = buildAuthorizeUrl(ghClientId(), state,
+    location.origin + location.pathname + location.search);
+};
+
+SPA.ghAccountMenu = function() {
+  var user = getAuthUser() || {};
+  SPA.confirm({
+    title: t('auth.logout_confirm'),
+    body: esc(user.login || ''),
+    confirmLabel: t('auth.logout')
+  }).then(function(ok) {
+    if (!ok) return;
+    clearAuth();
+    updateAuthUI();
+  });
+};
+
+// On boot: if the URL is an OAuth callback, validate the CSRF state, scrub the
+// auth params from the URL (keeping ?repo/?branch), swap the code for a token
+// and load the profile. Every failure path leaves the user signed out with the
+// old flows fully working.
+function handleAuthCallback() {
+  var params = parseAuthCallback(location.search);
+  if (!params) return;
+  var saved = null;
+  try {
+    saved = sessionStorage.getItem('sy_gh_state');
+    sessionStorage.removeItem('sy_gh_state');
+  } catch (e) {}
+  history.replaceState(null, '', location.pathname + stripAuthParams(location.search) + location.hash);
+  if (!isValidAuthCallback(params, saved)) {
+    showToast(t('auth.error_state'));
+    return;
+  }
+  exchangeCode(ghExchangeUrl(), params.code)
+    .then(function(token) {
+      return getViewer(token).then(function(user) {
+        saveAuth(token, user);
+        updateAuthUI();
+        showToast(t('auth.signed_in') + ' ' + user.login);
+      });
+    })
+    .catch(function(err) {
+      console.warn('GitHub sign-in failed:', err && err.status);
+      showToast(t('auth.error_exchange'));
+    });
 }
 
 // ============================================================

--- a/site/index.html
+++ b/site/index.html
@@ -681,6 +681,23 @@ function deriveRepo(hostname, pathname, search) {
   throw new Error('Cannot determine GitHub repo: serve from <owner>.github.io '
     + 'or pass ?repo=owner/name (host was "' + hostname + '").');
 }
+// The OAuth callback returns to the BARE app URL (a GitHub App redirect_uri
+// must exactly match a registered callback, so ?repo/?branch cannot ride
+// along). Restore the app params saved by SPA.ghLogin BEFORE deriveRepo needs
+// them. Runs only on a callback (GitHub always sends `state` back — on both
+// the success and the error path).
+(function() {
+  try {
+    var saved = sessionStorage.getItem('sy_gh_return');
+    if (saved == null) return;
+    if (!new URLSearchParams(location.search).get('state')) return;
+    sessionStorage.removeItem('sy_gh_return');
+    var merged = mergeAuthReturn(location.search, saved);
+    if (merged !== location.search) {
+      history.replaceState(null, '', location.pathname + merged + location.hash);
+    }
+  } catch (e) {}
+})();
 var REPO = deriveRepo();
 function getBranchFromURL() {
   var params = new URLSearchParams(location.search);
@@ -4450,9 +4467,14 @@ SPA.takeForReview = function(talkId) {
 
 SPA.ghLogin = function() {
   var state = makeAuthState();
-  try { sessionStorage.setItem('sy_gh_state', state); } catch (e) {}
+  try {
+    sessionStorage.setItem('sy_gh_state', state);
+    // App params can't ride in redirect_uri (exact-match rule) — they are
+    // restored from here on the way back, before deriveRepo runs.
+    sessionStorage.setItem('sy_gh_return', location.search);
+  } catch (e) {}
   location.href = buildAuthorizeUrl(ghClientId(), state,
-    location.origin + location.pathname + location.search);
+    buildRedirectUri(location.origin, location.pathname));
 };
 
 SPA.ghAccountMenu = function() {
@@ -4473,14 +4495,22 @@ SPA.ghAccountMenu = function() {
 // and load the profile. Every failure path leaves the user signed out with the
 // old flows fully working.
 function handleAuthCallback() {
-  var params = parseAuthCallback(location.search);
-  if (!params) return;
+  var search = location.search;
+  var params = parseAuthCallback(search);
+  var errParam = null;
+  try { errParam = new URLSearchParams(search).get('error'); } catch (e) {}
+  if (!params && !errParam) return;
   var saved = null;
   try {
     saved = sessionStorage.getItem('sy_gh_state');
     sessionStorage.removeItem('sy_gh_state');
   } catch (e) {}
-  history.replaceState(null, '', location.pathname + stripAuthParams(location.search) + location.hash);
+  history.replaceState(null, '', location.pathname + stripAuthParams(search) + location.hash);
+  if (errParam) {
+    // User cancelled on GitHub (?error=access_denied) or the App refused.
+    showToast(t('auth.error_exchange'));
+    return;
+  }
   if (!isValidAuthCallback(params, saved)) {
     showToast(t('auth.error_state'));
     return;

--- a/site/index.html
+++ b/site/index.html
@@ -297,9 +297,13 @@
 
 <!-- === FRESHNESS BAR (global, all views) === -->
 <div id="freshness-bar" style="background:var(--bg2);border-bottom:1px solid var(--border);padding:4px 20px;display:flex;align-items:center;justify-content:space-between;font-size:12px;color:var(--fg6);position:sticky;top:0;z-index:30;">
-  <div class="branch-selector">
-    <button class="branch-btn" id="branch-btn" onclick="SPA.toggleBranches()">main &#x25BE;</button>
-    <div class="branch-dropdown" id="branch-dropdown"></div>
+  <div style="display:flex;align-items:center;gap:8px;">
+    <img id="gh-avatar" src="" alt="" onclick="SPA.ghAccountMenu()" style="display:none;width:20px;height:20px;border-radius:50%;cursor:pointer;border:1px solid var(--border2);vertical-align:middle;">
+    <button id="gh-login-btn" onclick="SPA.ghLogin()" data-i18n="auth.login" data-i18n-title="auth.login_title" style="display:none;background:none;color:var(--fg5);border:1px solid var(--border2);border-radius:4px;padding:2px 6px;font-size:11px;cursor:pointer;">GitHub</button>
+    <div class="branch-selector">
+      <button class="branch-btn" id="branch-btn" onclick="SPA.toggleBranches()">main &#x25BE;</button>
+      <div class="branch-dropdown" id="branch-dropdown"></div>
+    </div>
   </div>
   <div style="display:flex;align-items:center;gap:8px;">
     <span id="stale-indicator" style="display:none;align-items:center;gap:6px;background:var(--bg4);color:var(--fg3);border:1px solid var(--border3);border-radius:10px;padding:1px 4px 1px 8px;font-size:11px;">
@@ -307,8 +311,6 @@
       <button class="stale-x" onclick="SPA.dismissStale()" data-i18n-title="stale.dismiss" style="background:none;border:none;color:var(--fg5);cursor:pointer;font-size:13px;line-height:1;padding:0 2px;">&#x00D7;</button>
     </span>
     <span id="last-updated"></span>
-    <img id="gh-avatar" src="" alt="" onclick="SPA.ghAccountMenu()" style="display:none;width:20px;height:20px;border-radius:50%;cursor:pointer;border:1px solid var(--border2);vertical-align:middle;">
-    <button id="gh-login-btn" onclick="SPA.ghLogin()" data-i18n="auth.login" data-i18n-title="auth.login_title" style="display:none;background:none;color:var(--fg5);border:1px solid var(--border2);border-radius:4px;padding:2px 6px;font-size:11px;cursor:pointer;">GitHub</button>
     <button id="refresh-btn" onclick="SPA.refreshManifest()" style="background:none;color:var(--fg5);border:1px solid var(--border2);border-radius:4px;padding:2px 6px;font-size:11px;cursor:pointer;display:none;" data-i18n-title="title.refresh">&#x21bb;</button>
     <button id="lang-btn" onclick="SPA.toggleLang()" style="background:none;color:var(--fg5);border:1px solid var(--border2);border-radius:4px;padding:2px 6px;font-size:11px;cursor:pointer;" data-i18n-title="title.lang">UK</button>
     <button id="theme-btn" onclick="SPA.cycleTheme()" style="background:none;color:var(--fg5);border:1px solid var(--border2);border-radius:4px;padding:2px 6px;font-size:11px;cursor:pointer;" data-i18n-title="title.theme.auto">&#x263C;</button>
@@ -338,6 +340,7 @@
     <div class="header-actions">
       <button id="btn-copy-all" class="btn" onclick="SPA.copyMarkers()" data-i18n="btn.copy_all">Copy all</button>
       <button id="btn-preview-issue" class="btn btn--issue" onclick="SPA.createPreviewIssue()" data-i18n="btn.create_issue">Create issue</button>
+      <button id="btn-preview-pr" class="btn btn--primary" style="display:none" onclick="SPA.createPreviewPr()" data-i18n="btn.create_pr">Create PR</button>
       <button id="btn-preview-editor" class="btn btn--primary" style="display:none" onclick="SPA.openPreviewEditor()" data-i18n="btn.open_editor">Open in GitHub Editor</button>
       <button id="btn-clear-all" class="btn btn--danger" style="display:none" onclick="SPA.clearAll()" data-i18n="btn.clear_all">Clear all</button>
     </div>
@@ -378,7 +381,7 @@
       </span>
       <button class="btn btn--issue" onclick="SPA.createReviewIssue()" data-i18n="btn.create_review_issue">Create Issue</button>
       <button id="btn-create-pr" class="btn btn--primary" data-gh-only style="display:none" onclick="SPA.createReviewPr()" data-i18n="btn.create_pr">Create PR</button>
-      <button class="btn btn--primary" onclick="SPA.openEditor()" data-i18n="btn.open_editor">Open in GitHub Editor</button>
+      <button id="btn-review-editor" class="btn btn--primary" data-gh-hide onclick="SPA.openEditor()" data-i18n="btn.open_editor">Open in GitHub Editor</button>
       <button onclick="SPA.revertAllEdits()" id="btn-revert-all" class="btn btn--danger" style="display:none" data-i18n="btn.revert_all">Revert all</button>
     </div>
   </div>
@@ -889,6 +892,7 @@ var I18N = {
     'issue.created': '\u0406\u0448\u02BC\u044E \u0441\u0442\u0432\u043E\u0440\u0435\u043D\u043E',
     'review.taken': '\u041F\u0440\u043E\u043C\u043E\u0432\u0443 \u0432\u0437\u044F\u0442\u043E \u043D\u0430 \u0440\u0435\u0432\u02BC\u044E',
     'gh.error': '\u041F\u043E\u043C\u0438\u043B\u043A\u0430 GitHub',
+    'gh.no_app_access': 'GitHub App \u043D\u0435 \u043C\u0430\u0454 \u0434\u043E\u0441\u0442\u0443\u043F\u0443 \u0434\u043E \u0440\u0435\u043F\u043E\u0437\u0438\u0442\u043E\u0440\u0456\u044E \u2014 \u0430\u0434\u043C\u0456\u043D\u0456\u0441\u0442\u0440\u0430\u0442\u043E\u0440 \u043C\u0430\u0454 \u0432\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u0438 \u0437\u0430\u0441\u0442\u043E\u0441\u0443\u043D\u043E\u043A \u043D\u0430 \u043D\u044C\u043E\u043C\u0443',
     'title.lang': '\u041C\u043E\u0432\u0430 \u0456\u043D\u0442\u0435\u0440\u0444\u0435\u0439\u0441\u0443'
   },
   en: {
@@ -1035,6 +1039,7 @@ var I18N = {
     'issue.created': 'Issue created',
     'review.taken': 'Talk taken for review',
     'gh.error': 'GitHub error',
+    'gh.no_app_access': 'The GitHub App has no access to this repository — an admin must install the app on it',
     'title.lang': 'Interface language'
   }
 };
@@ -2523,7 +2528,9 @@ function renderIndex(el) {
     if (takeEl) takeEl.addEventListener('click', function(e) {
       e.stopPropagation();
       takeEl.disabled = true;
-      SPA.takeForReview(tk.id);
+      // Success re-renders the index (this button is replaced); on failure
+      // the re-enable makes the card claimable again.
+      SPA.takeForReview(tk.id).then(function() { takeEl.disabled = false; });
     });
 
     // Copy the talk id on expert-button click (id comes from the closure, never
@@ -3022,6 +3029,20 @@ function flushPreviewPos() {
   writePreviewPosNow();
 }
 
+// Edit-submission buttons live at the mode × auth intersection: edit mode
+// shows exactly ONE of them — Create PR signed in, the clipboard+editor flow
+// signed out (both submit the same edits, showing both would duplicate the
+// action). Called from applyPreviewMode (mode flips) AND updateAuthUI
+// (login/logout while the preview is open).
+function updatePreviewSubmitButtons() {
+  var mode = (typeof previewState !== 'undefined' && previewState.mode) || 'marker';
+  var signedIn = !!getAuthUser();
+  var editorBtn = document.getElementById('btn-preview-editor');
+  if (editorBtn) editorBtn.style.display = (mode === 'edit' && !signedIn) ? 'inline-block' : 'none';
+  var prBtn = document.getElementById('btn-preview-pr');
+  if (prBtn) prBtn.style.display = (mode === 'edit' && signedIn) ? 'inline-block' : 'none';
+}
+
 function applyPreviewMode() {
   var mode = previewState.mode || 'marker';
   document.querySelectorAll('.preview-mode-toggle button').forEach(function(b) {
@@ -3040,8 +3061,7 @@ function applyPreviewMode() {
   }
   var copyBtn = document.getElementById('btn-copy-all');
   if (copyBtn) copyBtn.style.display = mode === 'marker' ? 'inline-block' : 'none';
-  var editorBtn = document.getElementById('btn-preview-editor');
-  if (editorBtn) editorBtn.style.display = mode === 'edit' ? 'inline-block' : 'none';
+  updatePreviewSubmitButtons();
   var label = document.getElementById('preview-list-label');
   if (label) {
     label.textContent = mode === 'edit' ? t('edits.summary') : t('markers.summary');
@@ -3413,7 +3433,9 @@ SPA.copyMarkers = function() {
   });
 };
 
-SPA.createPreviewIssue = function() {
+// {title, body} of the preview issue \u2014 also reused verbatim as the PR body by
+// SPA.createPreviewPr, so both write paths describe the same marks/edits.
+function buildPreviewIssueContent() {
   var s = previewState;
   var gh = 'https://github.com/' + REPO;
   var lang = s.srtLang || 'uk';
@@ -3444,13 +3466,46 @@ SPA.createPreviewIssue = function() {
       lines.push('| ' + m.tc + ' | ' + m.text + ' | ' + (m.comment || '') + ' |');
     });
   }
-  var issueTitle = (s.mode === 'edit' ? 'Subtitle edits: ' : 'Subtitle review: ') + (s.video ? s.video.title : s.videoSlug);
-  var issueBody = lines.join('\n');
+  return {
+    title: (s.mode === 'edit' ? 'Subtitle edits: ' : 'Subtitle review: ') + (s.video ? s.video.title : s.videoSlug),
+    body: lines.join('\n')
+  };
+}
+
+SPA.createPreviewIssue = function() {
+  var content = buildPreviewIssueContent();
   if (getAuthUser() && getAuthToken()) {
-    submitIssueViaApi(issueTitle, issueBody);
+    submitIssueViaApi(content.title, content.body);
     return;
   }
-  openIssuePage(issueTitle, issueBody);
+  openIssuePage(content.title, content.body);
+};
+
+// One-button PR from the preview's subtitle edits: new timestamped branch off
+// BRANCH, commit the rebuilt final/<lang>.srt, open the PR (whose body = the
+// preview issue body). sync-subtitles.yml then reconciles SRT\u2194transcript.
+SPA.createPreviewPr = function() {
+  var user = getAuthUser(), token = getAuthToken();
+  if (!user || !token) return;
+  var s = previewState;
+  var lang = s.srtLang || 'uk';
+  var langEdits = (s.edits && s.edits[lang]) || {};
+  if (!Object.keys(langEdits).length) { showToast(t('pr.no_edits')); return; }
+  var filePath = 'talks/' + s.talkId + '/' + s.videoSlug + '/final/' + lang + '.srt';
+  var content = buildPreviewIssueContent();
+  var btn = document.getElementById('btn-preview-pr');
+  if (btn) btn.disabled = true;
+  submitFilesPr(API, token, {
+    branch: makeBranchName('preview/' + s.talkId, user.login),
+    base: BRANCH,
+    files: [{ path: filePath, content: applyEditsToSrt(s.subtitles || [], langEdits) }],
+    commitMessage: 'Subtitle edits: ' + s.talkId + ' (' + s.videoSlug + '/' + lang + ')',
+    prTitle: content.title,
+    prBody: content.body
+  }).then(function(pr) {
+    ghCreatedDialog('pr.created', pr);
+  }).catch(ghWriteError)
+    .then(function() { if (btn) btn.disabled = false; });
 };
 
 SPA.openPreviewEditor = function() {
@@ -4188,6 +4243,13 @@ function ghWriteError(err) {
     showToast(t('auth.expired'));
     return;
   }
+  // 403 "Resource not accessible by integration": the GitHub App is not
+  // installed on the repo (or lacks a permission) — name the fix, don't echo
+  // the opaque API message.
+  if (isIntegrationAccessError(err)) {
+    showToast(t('gh.no_app_access'), 6000);
+    return;
+  }
   var msg = t('gh.error') + (err && err.message ? ': ' + err.message : '');
   if (err && err.branch) {
     var burl = 'https://github.com/' + REPO + '/tree/' + err.branch;
@@ -4199,7 +4261,7 @@ function ghWriteError(err) {
     });
     return;
   }
-  showToast(msg);
+  showToast(msg, 4000);
 }
 
 // Signed-in issue path: POST /issues directly (no URL-length limit, no
@@ -4382,10 +4444,10 @@ function esc(s) { return (s||'').replace(/&/g, '&amp;').replace(/</g, '&lt;').re
 // protocol-relative //host), then HTML-escape so a quote/tag cannot break out
 // of the href="" attribute. Returns '' for disallowed/empty URLs.
 function safeHref(u) { return /^(https?:\/\/|#|mailto:)/i.test(u || '') ? esc(u) : ''; }
-function showToast(msg) {
+function showToast(msg, ms) {
   var el = document.getElementById('toast');
   el.textContent = msg; el.classList.add('show');
-  setTimeout(function() { el.classList.remove('show'); }, 2000);
+  setTimeout(function() { el.classList.remove('show'); }, ms || 2000);
 }
 function fmtTime(sec) {
   return String(Math.floor(sec/3600)).padStart(2,'0') + ':' + String(Math.floor((sec%3600)/60)).padStart(2,'0') + ':' + String(Math.floor(sec%60)).padStart(2,'0');
@@ -4410,9 +4472,15 @@ function updateAuthUI() {
   } else {
     avatar.style.display = 'none';
   }
-  // Signed-in-only controls (e.g. the review view's Create PR button).
+  // Signed-in-only controls (e.g. the review view's Create PR button) and
+  // their signed-out twins (data-gh-hide, e.g. Open in GitHub Editor): the
+  // API action REPLACES the manual flow — never both at once.
   var ghOnly = document.querySelectorAll('[data-gh-only]');
   for (var i = 0; i < ghOnly.length; i++) ghOnly[i].style.display = user ? '' : 'none';
+  var ghHide = document.querySelectorAll('[data-gh-hide]');
+  for (var j = 0; j < ghHide.length; j++) ghHide[j].style.display = user ? 'none' : '';
+  // The preview's pair also depends on the marker/edit mode — delegate.
+  updatePreviewSubmitButtons();
   // Index cards/chips render auth-dependent bits ("take for review", the
   // 'mine' chip, own-talk highlight) — refresh them on login/logout.
   if (manifest && document.getElementById('index-content')) {
@@ -4430,7 +4498,7 @@ function updateAuthUI() {
 // optimistically so the badge doesn't lag behind the bot commit.
 SPA.takeForReview = function(talkId) {
   var user = getAuthUser(), token = getAuthToken();
-  if (!user || !token) return;
+  if (!user || !token) return Promise.resolve();
   var st = (reviewStatus && reviewStatus.talks && reviewStatus.talks[talkId]) || null;
   var done = function(issueNumber) {
     if (!reviewStatus) reviewStatus = { talks: {} };
@@ -4445,24 +4513,26 @@ SPA.takeForReview = function(talkId) {
     renderIndex(document.getElementById('index-content'));
     showToast(t('review.taken'));
   };
+  // Returns a promise that settles when the claim attempt is over (errors are
+  // reported via ghWriteError, not rethrown) — the card's click handler
+  // re-enables its button on it, so a failure never leaves a dead button.
   if (st && st.issue_number) {
-    addAssignees(API, token, st.issue_number, [user.login])
+    return addAssignees(API, token, st.issue_number, [user.login])
       .then(function() { done(st.issue_number); })
       .catch(ghWriteError);
-  } else {
-    var talk = manifest ? manifest.talks.find(function(t) { return t.id === talkId; }) : null;
-    var gh = 'https://github.com/' + REPO;
-    var body = 'Review of [`' + talkId + '`](' + gh + '/tree/main/talks/' + talkId + ')'
-      + '\n\nTaken via the SY Subtitles SPA'
-      + (talk && talk.title ? ' — ' + talk.title : '') + '.';
-    createIssue(API, token, {
-      title: 'Review: ' + talkId,
-      body: body,
-      labels: ['talk-review', 'review:in-progress'],
-      assignees: [user.login]
-    }).then(function(res) { done(res.number); })
-      .catch(ghWriteError);
   }
+  var talk = manifest ? manifest.talks.find(function(t) { return t.id === talkId; }) : null;
+  var gh = 'https://github.com/' + REPO;
+  var body = 'Review of [`' + talkId + '`](' + gh + '/tree/main/talks/' + talkId + ')'
+    + '\n\nTaken via the SY Subtitles SPA'
+    + (talk && talk.title ? ' — ' + talk.title : '') + '.';
+  return createIssue(API, token, {
+    title: 'Review: ' + talkId,
+    body: body,
+    labels: ['talk-review', 'review:in-progress'],
+    assignees: [user.login]
+  }).then(function(res) { done(res.number); })
+    .catch(ghWriteError);
 };
 
 SPA.ghLogin = function() {

--- a/site/js/github_api.js
+++ b/site/js/github_api.js
@@ -47,10 +47,153 @@ function getViewer(token, fetchImpl) {
     .then(function (u) { return { login: u.login, avatar_url: u.avatar_url }; });
 }
 
+// ---------------------------------------------------------------------------
+// Write path (issues / branches / contents / pulls). Every function takes the
+// repo API base (https://api.github.com/repos/<owner>/<name>) and the token —
+// the module never guesses the repo. fetchImpl is injectable for tests.
+// ---------------------------------------------------------------------------
+
+// Shared JSON request: auth + JSON body + uniform Error{status, message}.
+function ghJson(url, token, opts, fetchImpl) {
+  var f = fetchImpl || fetch;
+  var init = { method: (opts && opts.method) || 'GET', headers: authHeaders(token) };
+  if (opts && opts.body !== undefined) {
+    init.headers['Content-Type'] = 'application/json';
+    init.body = JSON.stringify(opts.body);
+  }
+  return f(url, init).then(function (r) {
+    return r.json().catch(function () { return {}; }).then(function (body) {
+      if (!r.ok) {
+        var e = new Error((body && body.message) || ('HTTP ' + r.status));
+        e.status = r.status;
+        throw e;
+      }
+      return body;
+    });
+  });
+}
+
+// UTF-8 → base64 for the contents API (btoa alone breaks on non-Latin-1).
+// Works in both the browser and Node (btoa is global in Node 16+).
+function utf8ToBase64(s) {
+  return btoa(unescape(encodeURIComponent(s)));
+}
+
+// review/<talk>--<login>--HHMMSS, scrubbed of characters git refs reject.
+// Timestamp suffix makes retries collision-free.
+function makeBranchName(prefix, login, now) {
+  var d = now || new Date();
+  var stamp = String(d.getUTCHours()).padStart(2, '0')
+    + String(d.getUTCMinutes()).padStart(2, '0')
+    + String(d.getUTCSeconds()).padStart(2, '0');
+  return (prefix + '--' + login + '--' + stamp)
+    .replace(/[ ~^:?*[\]\\]/g, '-')
+    .replace(/\.\.+/g, '.');
+}
+
+// POST /issues → {number, html_url}. fields: {title, body, labels, assignees}.
+function createIssue(api, token, fields, fetchImpl) {
+  return ghJson(api + '/issues', token, { method: 'POST', body: fields }, fetchImpl)
+    .then(function (r) { return { number: r.number, html_url: r.html_url }; });
+}
+
+function addAssignees(api, token, issueNumber, logins, fetchImpl) {
+  return ghJson(api + '/issues/' + issueNumber + '/assignees', token,
+    { method: 'POST', body: { assignees: logins } }, fetchImpl);
+}
+
+function getBranchHeadSha(api, token, branch, fetchImpl) {
+  return ghJson(api + '/git/ref/heads/' + branch, token, null, fetchImpl)
+    .then(function (r) { return r.object.sha; });
+}
+
+function createRef(api, token, branchName, sha, fetchImpl) {
+  return ghJson(api + '/git/refs', token,
+    { method: 'POST', body: { ref: 'refs/heads/' + branchName, sha: sha } }, fetchImpl);
+}
+
+// Blob sha of an existing file (needed to update it), or null when the path
+// does not exist yet (create).
+function getFileSha(api, token, path, ref, fetchImpl) {
+  return ghJson(api + '/contents/' + path + '?ref=' + ref, token, null, fetchImpl)
+    .then(function (r) { return r.sha; })
+    .catch(function (e) {
+      if (e.status === 404) return null;
+      throw e;
+    });
+}
+
+// PUT /contents/<path> — creates or (with sha) updates the file on the branch.
+function putFile(api, token, opts, fetchImpl) {
+  var body = {
+    message: opts.message,
+    branch: opts.branch,
+    content: utf8ToBase64(opts.content),
+  };
+  if (opts.sha) body.sha = opts.sha;
+  return ghJson(api + '/contents/' + opts.path, token,
+    { method: 'PUT', body: body }, fetchImpl);
+}
+
+function createPull(api, token, opts, fetchImpl) {
+  return ghJson(api + '/pulls', token, {
+    method: 'POST',
+    body: { head: opts.head, base: opts.base, title: opts.title, body: opts.body },
+  }, fetchImpl).then(function (r) { return { number: r.number, html_url: r.html_url }; });
+}
+
+// One-button PR: base head sha → new branch → per-file (blob sha on base →
+// PUT to branch, sequential to keep commit order) → open the PR. A failure
+// after the branch exists carries e.branch so the UI can link to the orphan
+// branch; a retry uses a fresh timestamped name, so there are no collisions.
+function submitFilesPr(api, token, opts, fetchImpl) {
+  var branchCreated = false;
+  return getBranchHeadSha(api, token, opts.base, fetchImpl)
+    .then(function (sha) { return createRef(api, token, opts.branch, sha, fetchImpl); })
+    .then(function () {
+      branchCreated = true;
+      var chain = Promise.resolve();
+      opts.files.forEach(function (file) {
+        chain = chain.then(function () {
+          return getFileSha(api, token, file.path, opts.base, fetchImpl);
+        }).then(function (sha) {
+          return putFile(api, token, {
+            path: file.path,
+            branch: opts.branch,
+            message: opts.commitMessage,
+            content: file.content,
+            sha: sha,
+          }, fetchImpl);
+        });
+      });
+      return chain;
+    })
+    .then(function () {
+      return createPull(api, token, {
+        head: opts.branch, base: opts.base, title: opts.prTitle, body: opts.prBody,
+      }, fetchImpl);
+    })
+    .then(function (pr) { return { number: pr.number, html_url: pr.html_url, branch: opts.branch }; })
+    .catch(function (e) {
+      if (branchCreated) e.branch = opts.branch;
+      throw e;
+    });
+}
+
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     authHeaders: authHeaders,
     exchangeCode: exchangeCode,
     getViewer: getViewer,
+    utf8ToBase64: utf8ToBase64,
+    makeBranchName: makeBranchName,
+    createIssue: createIssue,
+    addAssignees: addAssignees,
+    getBranchHeadSha: getBranchHeadSha,
+    createRef: createRef,
+    getFileSha: getFileSha,
+    putFile: putFile,
+    createPull: createPull,
+    submitFilesPr: submitFilesPr,
   };
 }

--- a/site/js/github_api.js
+++ b/site/js/github_api.js
@@ -1,0 +1,56 @@
+// Thin authenticated GitHub API client (fetch-injectable, Node-tested).
+// Single source: loaded via <script src="js/github_api.js"> in site/index.html
+// AND required by the Node test suite — no inline mirror.
+//
+// Phase 1 (auth core): the code→token exchange call to workers/oauth-exchange,
+// the viewer lookup, and the Authorization header helper. The token is ONLY
+// ever sent to api.github.com; the exchange Worker receives the one-shot code,
+// never the token.
+
+function authHeaders(token) {
+  return token ? { Authorization: 'Bearer ' + token } : {};
+}
+
+// POST {code} to the exchange Worker; resolves the access-token string.
+// Rejects with Error{status} on HTTP errors or a missing token.
+function exchangeCode(exchangeUrl, code, fetchImpl) {
+  var f = fetchImpl || fetch;
+  return f(exchangeUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code: code }),
+  }).then(function (r) {
+    return r.json().catch(function () { return {}; }).then(function (body) {
+      if (!r.ok || !body.token) {
+        var e = new Error('exchange failed: ' + (body.error || ('HTTP ' + r.status)));
+        e.status = r.status;
+        throw e;
+      }
+      return body.token;
+    });
+  });
+}
+
+// GET /user -> {login, avatar_url}. A 401 rejection means the token was
+// revoked — callers should clear the session.
+function getViewer(token, fetchImpl) {
+  var f = fetchImpl || fetch;
+  return f('https://api.github.com/user', { headers: authHeaders(token) })
+    .then(function (r) {
+      if (!r.ok) {
+        var e = new Error('GET /user: HTTP ' + r.status);
+        e.status = r.status;
+        throw e;
+      }
+      return r.json();
+    })
+    .then(function (u) { return { login: u.login, avatar_url: u.avatar_url }; });
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    authHeaders: authHeaders,
+    exchangeCode: exchangeCode,
+    getViewer: getViewer,
+  };
+}

--- a/site/js/github_api.js
+++ b/site/js/github_api.js
@@ -73,6 +73,14 @@ function ghJson(url, token, opts, fetchImpl) {
   });
 }
 
+// A 403 "Resource not accessible by integration" from ghJson means the
+// GitHub App is not installed on the repository (or lacks a permission) —
+// an admin-fixable configuration problem the UI should name explicitly
+// instead of echoing the opaque API message.
+function isIntegrationAccessError(err) {
+  return !!(err && err.status === 403 && /integration/i.test(err.message || ''));
+}
+
 // UTF-8 → base64 for the contents API (btoa alone breaks on non-Latin-1).
 // Works in both the browser and Node (btoa is global in Node 16+).
 function utf8ToBase64(s) {
@@ -185,6 +193,7 @@ if (typeof module !== 'undefined' && module.exports) {
     authHeaders: authHeaders,
     exchangeCode: exchangeCode,
     getViewer: getViewer,
+    isIntegrationAccessError: isIntegrationAccessError,
     utf8ToBase64: utf8ToBase64,
     makeBranchName: makeBranchName,
     createIssue: createIssue,

--- a/site/js/github_auth.js
+++ b/site/js/github_auth.js
@@ -42,13 +42,36 @@ function isValidAuthCallback(params, savedState) {
   return !!(params && params.state && savedState && params.state === savedState);
 }
 
-// Drop auth params (code/state + GitHub-App install extras) from a query
-// string while preserving app params like ?repo= and ?branch=.
+// Drop auth params (code/state, error-callback params, GitHub-App install
+// extras) from a query string while preserving app params like ?repo=.
 function stripAuthParams(search) {
   var p = new URLSearchParams(search || '');
   p.delete('code'); p.delete('state');
+  p.delete('error'); p.delete('error_description'); p.delete('error_uri');
   p.delete('installation_id'); p.delete('setup_action');
   var s = p.toString();
+  return s ? '?' + s : '';
+}
+
+// GitHub Apps require redirect_uri to EXACTLY match a registered callback
+// URL, so it is the bare origin+path — never the query. /index.html collapses
+// to the directory root so one registered callback covers both ways of
+// opening the app. App params (?repo/?branch/…) round-trip via
+// sessionStorage instead (see mergeAuthReturn).
+function buildRedirectUri(origin, pathname) {
+  return origin + pathname.replace(/index\.html$/, '');
+}
+
+// Merge the pre-login app params (saved before the redirect) back into the
+// callback query. Callback params (code/state/error) always win — a saved
+// value must not be able to spoof them.
+function mergeAuthReturn(currentSearch, savedSearch) {
+  var merged = new URLSearchParams(currentSearch || '');
+  var saved = new URLSearchParams(savedSearch || '');
+  saved.forEach(function (v, k) {
+    if (!merged.has(k)) merged.set(k, v);
+  });
+  var s = merged.toString();
   return s ? '?' + s : '';
 }
 
@@ -78,6 +101,8 @@ if (typeof module !== 'undefined' && module.exports) {
     parseAuthCallback: parseAuthCallback,
     isValidAuthCallback: isValidAuthCallback,
     stripAuthParams: stripAuthParams,
+    buildRedirectUri: buildRedirectUri,
+    mergeAuthReturn: mergeAuthReturn,
     saveAuth: saveAuth,
     getAuthToken: getAuthToken,
     getAuthUser: getAuthUser,

--- a/site/js/github_auth.js
+++ b/site/js/github_auth.js
@@ -1,0 +1,88 @@
+// GitHub sign-in session logic (pure, storage-injectable) for the review SPA.
+// Single source: loaded by the browser via <script src="js/github_auth.js">
+// in site/index.html AND required by the Node test suite — no inline mirror.
+//
+// The SPA authenticates as a GitHub App user (user-to-server token, token
+// expiration disabled in the app settings) via the standard web flow: redirect
+// to github.com/login/oauth/authorize carrying a one-shot CSRF `state`, then
+// swap the returned ?code for a token through workers/oauth-exchange (the
+// exchange needs the app's client_secret, which must not ship in the SPA).
+
+var GH_TOKEN_KEY = 'sy_gh_token';
+var GH_USER_KEY = 'sy_gh_user';
+
+// One-shot CSRF state: 16 random bytes as 32 hex chars. The RNG is injectable
+// for deterministic tests; production uses WebCrypto.
+function makeAuthState(getRandomValues) {
+  var rng = getRandomValues || function (a) { return crypto.getRandomValues(a); };
+  var bytes = new Uint8Array(16);
+  rng(bytes);
+  var hex = '';
+  for (var i = 0; i < bytes.length; i++) hex += (bytes[i] + 256).toString(16).slice(1);
+  return hex;
+}
+
+function buildAuthorizeUrl(clientId, state, redirectUri) {
+  return 'https://github.com/login/oauth/authorize'
+    + '?client_id=' + encodeURIComponent(clientId)
+    + '&state=' + encodeURIComponent(state)
+    + '&redirect_uri=' + encodeURIComponent(redirectUri);
+}
+
+// {code, state} from a callback query string, or null on normal page loads.
+function parseAuthCallback(search) {
+  var p = new URLSearchParams(search || '');
+  var code = p.get('code');
+  return code ? { code: code, state: p.get('state') || '' } : null;
+}
+
+// CSRF check: callback state must equal the state saved before the redirect,
+// and both must be non-empty.
+function isValidAuthCallback(params, savedState) {
+  return !!(params && params.state && savedState && params.state === savedState);
+}
+
+// Drop auth params (code/state + GitHub-App install extras) from a query
+// string while preserving app params like ?repo= and ?branch=.
+function stripAuthParams(search) {
+  var p = new URLSearchParams(search || '');
+  p.delete('code'); p.delete('state');
+  p.delete('installation_id'); p.delete('setup_action');
+  var s = p.toString();
+  return s ? '?' + s : '';
+}
+
+function saveAuth(token, user, storage) {
+  var s = storage || localStorage;
+  s.setItem(GH_TOKEN_KEY, token);
+  s.setItem(GH_USER_KEY, JSON.stringify({ login: user.login, avatar_url: user.avatar_url }));
+}
+function getAuthToken(storage) {
+  return (storage || localStorage).getItem(GH_TOKEN_KEY) || null;
+}
+function getAuthUser(storage) {
+  // JSON.parse(null) is null — the desired "no user" result for a missing key.
+  try { return JSON.parse((storage || localStorage).getItem(GH_USER_KEY)); }
+  catch (e) { return null; }
+}
+function clearAuth(storage) {
+  var s = storage || localStorage;
+  s.removeItem(GH_TOKEN_KEY);
+  s.removeItem(GH_USER_KEY);
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    makeAuthState: makeAuthState,
+    buildAuthorizeUrl: buildAuthorizeUrl,
+    parseAuthCallback: parseAuthCallback,
+    isValidAuthCallback: isValidAuthCallback,
+    stripAuthParams: stripAuthParams,
+    saveAuth: saveAuth,
+    getAuthToken: getAuthToken,
+    getAuthUser: getAuthUser,
+    clearAuth: clearAuth,
+    GH_TOKEN_KEY: GH_TOKEN_KEY,
+    GH_USER_KEY: GH_USER_KEY,
+  };
+}

--- a/site/js/index_url_state.js
+++ b/site/js/index_url_state.js
@@ -10,7 +10,9 @@
 //
 // There is intentionally no ?sort= — the index has no sort control to bind it to.
 
-var INDEX_FILTERS = ['all', 'needs-review', 'in-review', 'pending', 'approved'];
+// 'mine' = talks whose review-status reviewer is the signed-in GitHub login;
+// only meaningful when signed in, harmless (matches nothing) otherwise.
+var INDEX_FILTERS = ['all', 'needs-review', 'in-review', 'pending', 'approved', 'mine'];
 
 function _params(search) {
   try {

--- a/site/sw.js
+++ b/site/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for SPA caching
 // Browser detects changes by comparing sw.js byte-for-byte.
 // CACHE_VERSION: bump when cache format changes or to force purge.
-var CACHE_VERSION = 6;
+var CACHE_VERSION = 7;
 var CACHE_NAME = 'sy-subtitles-c' + CACHE_VERSION;
 
 // Routing predicates (isImmutable / isApiOrRaw / isNavigation / pickStrategy) are
@@ -43,7 +43,9 @@ var SHELL_ASSETS = [
   'js/add_talk_data.js',
   'js/shell_version.js',
   'js/talk_actions.js',
-  'js/passphrase_gate.js'
+  'js/passphrase_gate.js',
+  'js/github_auth.js',
+  'js/github_api.js'
 ];
 
 // Cross-origin libs the shell needs to boot (js-yaml parses every meta.yaml).

--- a/tests/test_deploy_worker_workflow.py
+++ b/tests/test_deploy_worker_workflow.py
@@ -35,6 +35,16 @@ def test_uses_wrangler_action_from_worker_directory() -> None:
     assert "workingDirectory: workers/oauth-exchange" in text
 
 
+def test_wrangler_action_is_sha_pinned() -> None:
+    """Third-party action handling all four secrets must be pinned to an
+    immutable commit SHA (a movable tag could be repointed at hostile code)."""
+    import re
+
+    text = WF.read_text(encoding="utf-8")
+    ref = re.search(r"cloudflare/wrangler-action@(\S+)", text).group(1)
+    assert re.fullmatch(r"[0-9a-f]{40}", ref), f"not SHA-pinned: {ref}"
+
+
 def test_worker_secrets_come_from_repo_secrets_not_inline() -> None:
     """GH_CLIENT_ID / GH_CLIENT_SECRET must flow repo-secret -> env -> wrangler
     `secrets:` input; a literal value in the workflow would leak the secret."""

--- a/tests/test_deploy_worker_workflow.py
+++ b/tests/test_deploy_worker_workflow.py
@@ -1,0 +1,56 @@
+"""Structural guards for the OAuth-exchange Worker deploy workflow.
+
+The Worker (workers/oauth-exchange/) must be deployed through CI, not from a
+laptop: the workflow deploys on merge to main (paths-filtered) and on manual
+dispatch, and injects the GitHub App credentials as Worker secrets from repo
+secrets — never inline.
+"""
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+WF = WORKFLOWS / "deploy-worker.yml"
+
+
+def _load():
+    return yaml.safe_load(WF.read_text(encoding="utf-8"))
+
+
+def test_deploys_on_main_push_touching_worker_and_on_dispatch() -> None:
+    data = _load()
+    on = data[True] if True in data else data["on"]  # yaml parses bare `on:` as True
+    assert "workflow_dispatch" in on
+    push = on["push"]
+    assert push["branches"] == ["main"]
+    assert any(p.startswith("workers/oauth-exchange") for p in push["paths"])
+    # The workflow file itself must retrigger a deploy when it changes.
+    assert ".github/workflows/deploy-worker.yml" in push["paths"]
+
+
+def test_uses_wrangler_action_from_worker_directory() -> None:
+    text = WF.read_text(encoding="utf-8")
+    assert "cloudflare/wrangler-action@" in text
+    assert "workingDirectory: workers/oauth-exchange" in text
+
+
+def test_worker_secrets_come_from_repo_secrets_not_inline() -> None:
+    """GH_CLIENT_ID / GH_CLIENT_SECRET must flow repo-secret -> env -> wrangler
+    `secrets:` input; a literal value in the workflow would leak the secret."""
+    text = WF.read_text(encoding="utf-8")
+    assert "${{ secrets.CLOUDFLARE_API_TOKEN }}" in text
+    assert "${{ secrets.GH_OAUTH_CLIENT_ID }}" in text
+    assert "${{ secrets.GH_OAUTH_CLIENT_SECRET }}" in text
+    data = _load()
+    deploy = data["jobs"]["deploy"]
+    step = next(s for s in deploy["steps"] if "wrangler-action" in str(s.get("uses", "")))
+    wrangler_secrets = step["with"]["secrets"].split()
+    assert wrangler_secrets == ["GH_CLIENT_ID", "GH_CLIENT_SECRET"]
+    assert step["env"]["GH_CLIENT_ID"] == "${{ secrets.GH_OAUTH_CLIENT_ID }}"
+    assert step["env"]["GH_CLIENT_SECRET"] == "${{ secrets.GH_OAUTH_CLIENT_SECRET }}"
+
+
+def test_minimal_permissions() -> None:
+    data = _load()
+    assert data["permissions"] == {"contents": "read"}

--- a/tests/test_github_api.js
+++ b/tests/test_github_api.js
@@ -1,0 +1,54 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { authHeaders, exchangeCode, getViewer } = require('../site/js/github_api');
+
+function fetchDouble(status, payload, capture) {
+  return async (url, init) => {
+    if (capture) { capture.url = url; capture.init = init || {}; }
+    return new Response(JSON.stringify(payload), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+}
+
+describe('authHeaders', () => {
+  it('builds a Bearer header from a token and {} from nothing', () => {
+    assert.deepStrictEqual(authHeaders('gho_x'), { Authorization: 'Bearer gho_x' });
+    assert.deepStrictEqual(authHeaders(null), {});
+    assert.deepStrictEqual(authHeaders(''), {});
+  });
+});
+
+describe('exchangeCode', () => {
+  it('POSTs {code} as JSON and resolves the token', async () => {
+    const capture = {};
+    const token = await exchangeCode('https://w.example/exchange', 'c1', fetchDouble(200, { token: 'gho_t' }, capture));
+    assert.strictEqual(token, 'gho_t');
+    assert.strictEqual(capture.url, 'https://w.example/exchange');
+    assert.strictEqual(capture.init.method, 'POST');
+    assert.deepStrictEqual(JSON.parse(capture.init.body), { code: 'c1' });
+  });
+  it('rejects with Error{status} on an {error} payload', async () => {
+    await assert.rejects(
+      exchangeCode('https://w.example/exchange', 'c1', fetchDouble(502, { error: 'bad_verification_code' })),
+      (e) => e.status === 502 && /bad_verification_code/.test(e.message));
+  });
+  it('rejects on a 200 without token (malformed worker reply)', async () => {
+    await assert.rejects(exchangeCode('https://w.example/exchange', 'c1', fetchDouble(200, {})));
+  });
+});
+
+describe('getViewer', () => {
+  it('GETs /user with the Bearer header and trims the profile', async () => {
+    const capture = {};
+    const u = await getViewer('gho_x', fetchDouble(200, { login: 'ira', avatar_url: 'http://a/i.png', id: 5 }, capture));
+    assert.deepStrictEqual(u, { login: 'ira', avatar_url: 'http://a/i.png' });
+    assert.strictEqual(capture.url, 'https://api.github.com/user');
+    assert.strictEqual(capture.init.headers.Authorization, 'Bearer gho_x');
+  });
+  it('rejects with status 401 on a revoked token', async () => {
+    await assert.rejects(getViewer('gho_x', fetchDouble(401, { message: 'Bad credentials' })),
+      (e) => e.status === 401);
+  });
+});

--- a/tests/test_github_api.js
+++ b/tests/test_github_api.js
@@ -52,3 +52,187 @@ describe('getViewer', () => {
       (e) => e.status === 401);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Write-path additions (issues / branches / contents / pulls)
+// ---------------------------------------------------------------------------
+const {
+  utf8ToBase64, makeBranchName, createIssue, addAssignees,
+  getBranchHeadSha, createRef, getFileSha, putFile, createPull, submitFilesPr,
+} = require('../site/js/github_api');
+
+const API = 'https://api.github.com/repos/sy-tools/sy-subtitles';
+
+// Router double: dispatches on "METHOD url-substring", records every call.
+function routerFetch(routes, calls) {
+  return async (url, init) => {
+    init = init || {};
+    const method = init.method || 'GET';
+    calls.push({ method, url, body: init.body ? JSON.parse(init.body) : null, headers: init.headers || {} });
+    for (const r of routes) {
+      if (method === r.method && url.includes(r.match)) {
+        return new Response(JSON.stringify(r.payload), {
+          status: r.status || 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+    }
+    throw new Error('unrouted: ' + method + ' ' + url);
+  };
+}
+
+describe('utf8ToBase64', () => {
+  it('encodes Ukrainian text so GitHub decodes it back to UTF-8', () => {
+    const b64 = utf8ToBase64('Привіт, Мамо!');
+    assert.strictEqual(Buffer.from(b64, 'base64').toString('utf8'), 'Привіт, Мамо!');
+  });
+});
+
+describe('makeBranchName', () => {
+  it('builds prefix--login--HHMMSS from the injected date', () => {
+    const d = new Date('2026-07-12T08:05:09Z');
+    const name = makeBranchName('review/1993-05-09_Talk', 'slava', d);
+    assert.match(name, /^review\/1993-05-09_Talk--slava--\d{6}$/);
+  });
+  it('sanitizes characters git refs cannot hold', () => {
+    const d = new Date('2026-07-12T08:05:09Z');
+    const name = makeBranchName('review/a b~c', 'l..in', d);
+    assert.ok(!/[ ~^:?*\[\\]/.test(name) && !name.includes('..'));
+  });
+});
+
+describe('createIssue', () => {
+  it('POSTs title/body/labels/assignees with auth and returns number+url', async () => {
+    const calls = [];
+    const f = routerFetch([{ method: 'POST', match: '/issues', status: 201,
+      payload: { number: 42, html_url: 'https://github.com/x/issues/42' } }], calls);
+    const res = await createIssue(API, 'gho_x',
+      { title: 'Review: t', body: 'b', labels: ['talk-review'], assignees: ['slava'] }, f);
+    assert.deepStrictEqual(res, { number: 42, html_url: 'https://github.com/x/issues/42' });
+    assert.strictEqual(calls[0].url, API + '/issues');
+    assert.strictEqual(calls[0].headers.Authorization, 'Bearer gho_x');
+    assert.deepStrictEqual(calls[0].body,
+      { title: 'Review: t', body: 'b', labels: ['talk-review'], assignees: ['slava'] });
+  });
+  it('rejects with Error{status} on 422', async () => {
+    const f = routerFetch([{ method: 'POST', match: '/issues', status: 422,
+      payload: { message: 'Validation Failed' } }], []);
+    await assert.rejects(createIssue(API, 'gho_x', { title: 't' }, f),
+      (e) => e.status === 422 && /Validation Failed/.test(e.message));
+  });
+});
+
+describe('addAssignees', () => {
+  it('POSTs the logins to the issue assignees endpoint', async () => {
+    const calls = [];
+    const f = routerFetch([{ method: 'POST', match: '/issues/7/assignees', status: 201,
+      payload: { number: 7 } }], calls);
+    await addAssignees(API, 'gho_x', 7, ['slava'], f);
+    assert.strictEqual(calls[0].url, API + '/issues/7/assignees');
+    assert.deepStrictEqual(calls[0].body, { assignees: ['slava'] });
+  });
+});
+
+describe('branch + contents + pull primitives', () => {
+  it('getBranchHeadSha reads object.sha from git/ref', async () => {
+    const calls = [];
+    const f = routerFetch([{ method: 'GET', match: '/git/ref/heads/main',
+      payload: { object: { sha: 'abc123' } } }], calls);
+    assert.strictEqual(await getBranchHeadSha(API, 'gho_x', 'main', f), 'abc123');
+  });
+  it('createRef POSTs refs/heads/<name> with the sha', async () => {
+    const calls = [];
+    const f = routerFetch([{ method: 'POST', match: '/git/refs', status: 201,
+      payload: { ref: 'refs/heads/b' } }], calls);
+    await createRef(API, 'gho_x', 'review/b', 'abc123', f);
+    assert.deepStrictEqual(calls[0].body, { ref: 'refs/heads/review/b', sha: 'abc123' });
+  });
+  it('getFileSha returns the blob sha, and null on 404 (new file)', async () => {
+    const f = routerFetch([
+      { method: 'GET', match: '/contents/talks/a.txt', payload: { sha: 'blob1' } },
+      { method: 'GET', match: '/contents/none.txt', status: 404, payload: { message: 'Not Found' } },
+    ], []);
+    assert.strictEqual(await getFileSha(API, 'gho_x', 'talks/a.txt', 'main', f), 'blob1');
+    assert.strictEqual(await getFileSha(API, 'gho_x', 'none.txt', 'main', f), null);
+  });
+  it('putFile PUTs base64 content to the branch, sha only when updating', async () => {
+    const calls = [];
+    const f = routerFetch([{ method: 'PUT', match: '/contents/', status: 201,
+      payload: { content: {} } }], calls);
+    await putFile(API, 'gho_x',
+      { path: 'talks/t/transcript_uk.txt', branch: 'review/b', message: 'm', content: 'Привіт', sha: 'blob1' }, f);
+    await putFile(API, 'gho_x',
+      { path: 'talks/t/new.txt', branch: 'review/b', message: 'm', content: 'x', sha: null }, f);
+    assert.strictEqual(calls[0].url, API + '/contents/talks/t/transcript_uk.txt');
+    assert.strictEqual(Buffer.from(calls[0].body.content, 'base64').toString('utf8'), 'Привіт');
+    assert.strictEqual(calls[0].body.sha, 'blob1');
+    assert.strictEqual(calls[0].body.branch, 'review/b');
+    assert.ok(!('sha' in calls[1].body));
+  });
+  it('createPull POSTs head/base/title/body and returns number+url', async () => {
+    const calls = [];
+    const f = routerFetch([{ method: 'POST', match: '/pulls', status: 201,
+      payload: { number: 9, html_url: 'https://github.com/x/pull/9' } }], calls);
+    const res = await createPull(API, 'gho_x', { head: 'review/b', base: 'main', title: 't', body: 'b' }, f);
+    assert.deepStrictEqual(res, { number: 9, html_url: 'https://github.com/x/pull/9' });
+    assert.deepStrictEqual(calls[0].body, { head: 'review/b', base: 'main', title: 't', body: 'b' });
+  });
+});
+
+describe('submitFilesPr', () => {
+  const FILES = [
+    { path: 'talks/t/transcript_uk.txt', content: 'Нове' },
+    { path: 'talks/t/extra.txt', content: 'x' },
+  ];
+  function routes(overrides) {
+    return Object.assign({
+      ref: { method: 'GET', match: '/git/ref/heads/main', payload: { object: { sha: 'base1' } } },
+      newRef: { method: 'POST', match: '/git/refs', status: 201, payload: {} },
+      sha1: { method: 'GET', match: '/contents/talks/t/transcript_uk.txt', payload: { sha: 'old1' } },
+      sha2: { method: 'GET', match: '/contents/talks/t/extra.txt', status: 404, payload: {} },
+      put: { method: 'PUT', match: '/contents/', status: 201, payload: { content: {} } },
+      pull: { method: 'POST', match: '/pulls', status: 201,
+        payload: { number: 5, html_url: 'https://github.com/x/pull/5' } },
+    }, overrides);
+  }
+  it('runs ref->branch->per-file(sha,put)->pull and returns the PR', async () => {
+    const calls = [];
+    const f = routerFetch(Object.values(routes()), calls);
+    const res = await submitFilesPr(API, 'gho_x', {
+      branch: 'review/b', base: 'main', files: FILES,
+      commitMessage: 'edit', prTitle: 'T', prBody: 'B',
+    }, f);
+    assert.deepStrictEqual(res, { number: 5, html_url: 'https://github.com/x/pull/5', branch: 'review/b' });
+    const seq = calls.map((c) => c.method + ' ' + c.url.replace(API, ''));
+    assert.deepStrictEqual(seq, [
+      'GET /git/ref/heads/main',
+      'POST /git/refs',
+      'GET /contents/talks/t/transcript_uk.txt?ref=main',
+      'PUT /contents/talks/t/transcript_uk.txt',
+      'GET /contents/talks/t/extra.txt?ref=main',
+      'PUT /contents/talks/t/extra.txt',
+      'POST /pulls',
+    ]);
+    // update carries the old sha, brand-new file none
+    assert.strictEqual(calls[3].body.sha, 'old1');
+    assert.ok(!('sha' in calls[5].body));
+  });
+  it('a failure after the branch exists rejects with .branch for the UI link', async () => {
+    const f = routerFetch(Object.values(routes({
+      put: { method: 'PUT', match: '/contents/', status: 409, payload: { message: 'Conflict' } },
+    })), []);
+    await assert.rejects(submitFilesPr(API, 'gho_x', {
+      branch: 'review/b', base: 'main', files: FILES,
+      commitMessage: 'edit', prTitle: 'T', prBody: 'B',
+    }, f), (e) => e.status === 409 && e.branch === 'review/b');
+  });
+  it('a failure before the branch exists rejects without .branch', async () => {
+    const f = routerFetch(Object.values(routes({
+      ref: { method: 'GET', match: '/git/ref/heads/main', status: 401, payload: { message: 'Bad credentials' } },
+    })), []);
+    await assert.rejects(submitFilesPr(API, 'gho_x', {
+      branch: 'review/b', base: 'main', files: FILES,
+      commitMessage: 'edit', prTitle: 'T', prBody: 'B',
+    }, f), (e) => e.status === 401 && !e.branch);
+  });
+});

--- a/tests/test_github_api.js
+++ b/tests/test_github_api.js
@@ -59,7 +59,21 @@ describe('getViewer', () => {
 const {
   utf8ToBase64, makeBranchName, createIssue, addAssignees,
   getBranchHeadSha, createRef, getFileSha, putFile, createPull, submitFilesPr,
+  isIntegrationAccessError,
 } = require('../site/js/github_api');
+
+describe('isIntegrationAccessError', () => {
+  it('recognizes the 403 "Resource not accessible by integration" reply', () => {
+    assert.strictEqual(isIntegrationAccessError(
+      { status: 403, message: 'Resource not accessible by integration' }), true);
+  });
+  it('rejects other 403s, other statuses, and empty errors', () => {
+    assert.strictEqual(isIntegrationAccessError({ status: 403, message: 'Forbidden' }), false);
+    assert.strictEqual(isIntegrationAccessError({ status: 404, message: 'Resource not accessible by integration' }), false);
+    assert.strictEqual(isIntegrationAccessError({ status: 403 }), false);
+    assert.strictEqual(isIntegrationAccessError(null), false);
+  });
+});
 
 const API = 'https://api.github.com/repos/sy-tools/sy-subtitles';
 

--- a/tests/test_github_auth.js
+++ b/tests/test_github_auth.js
@@ -1,0 +1,83 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const {
+  makeAuthState, buildAuthorizeUrl, parseAuthCallback, isValidAuthCallback,
+  stripAuthParams, saveAuth, getAuthToken, getAuthUser, clearAuth,
+} = require('../site/js/github_auth');
+
+function fakeStorage() {
+  const m = {};
+  return {
+    getItem: (k) => (Object.prototype.hasOwnProperty.call(m, k) ? m[k] : null),
+    setItem: (k, v) => { m[k] = String(v); },
+    removeItem: (k) => { delete m[k]; },
+    _m: m,
+  };
+}
+
+describe('makeAuthState', () => {
+  it('produces 32 lowercase hex chars from the injected RNG', () => {
+    const state = makeAuthState((arr) => { for (let i = 0; i < arr.length; i++) arr[i] = i * 16 + 15; });
+    assert.match(state, /^[0-9a-f]{32}$/);
+    assert.strictEqual(state.slice(0, 4), '0f1f');
+  });
+  it('zero bytes still yield fixed-width hex (leading zeros kept)', () => {
+    const state = makeAuthState((arr) => arr.fill(0));
+    assert.strictEqual(state, '0'.repeat(32));
+  });
+});
+
+describe('buildAuthorizeUrl', () => {
+  it('points at github authorize with encoded client_id, state, redirect_uri', () => {
+    const u = buildAuthorizeUrl('Iv1.abc', 's&1', 'http://localhost:8000/?repo=a/b');
+    assert.ok(u.startsWith('https://github.com/login/oauth/authorize?'));
+    assert.ok(u.includes('client_id=Iv1.abc'));
+    assert.ok(u.includes('state=s%261'));
+    assert.ok(u.includes('redirect_uri=http%3A%2F%2Flocalhost%3A8000%2F%3Frepo%3Da%2Fb'));
+  });
+});
+
+describe('parseAuthCallback / isValidAuthCallback', () => {
+  it('extracts code+state from a callback query', () => {
+    assert.deepStrictEqual(parseAuthCallback('?repo=a/b&code=c1&state=s1'), { code: 'c1', state: 's1' });
+  });
+  it('returns null when there is no code (normal page loads)', () => {
+    assert.strictEqual(parseAuthCallback('?repo=a/b'), null);
+    assert.strictEqual(parseAuthCallback(''), null);
+  });
+  it('accepts only a matching non-empty saved state (CSRF)', () => {
+    assert.strictEqual(isValidAuthCallback({ code: 'c', state: 's1' }, 's1'), true);
+    assert.strictEqual(isValidAuthCallback({ code: 'c', state: 's1' }, 's2'), false);
+    assert.strictEqual(isValidAuthCallback({ code: 'c', state: '' }, ''), false);
+    assert.strictEqual(isValidAuthCallback({ code: 'c', state: 's1' }, null), false);
+    assert.strictEqual(isValidAuthCallback(null, 's1'), false);
+  });
+});
+
+describe('stripAuthParams', () => {
+  it('removes auth params but keeps app params like repo/branch', () => {
+    assert.strictEqual(
+      stripAuthParams('?repo=a%2Fb&code=c&state=s&installation_id=1&setup_action=install&branch=dev'),
+      '?repo=a%2Fb&branch=dev');
+  });
+  it('returns empty string when nothing is left', () => {
+    assert.strictEqual(stripAuthParams('?code=c&state=s'), '');
+  });
+});
+
+describe('auth storage', () => {
+  it('round-trips token and trimmed user profile', () => {
+    const s = fakeStorage();
+    saveAuth('gho_x', { login: 'ira', avatar_url: 'http://a/i.png', extra: 'dropped' }, s);
+    assert.strictEqual(getAuthToken(s), 'gho_x');
+    assert.deepStrictEqual(getAuthUser(s), { login: 'ira', avatar_url: 'http://a/i.png' });
+    clearAuth(s);
+    assert.strictEqual(getAuthToken(s), null);
+    assert.strictEqual(getAuthUser(s), null);
+  });
+  it('getAuthUser survives corrupted JSON', () => {
+    const s = fakeStorage();
+    s.setItem('sy_gh_user', '{nope');
+    assert.strictEqual(getAuthUser(s), null);
+  });
+});

--- a/tests/test_github_auth.js
+++ b/tests/test_github_auth.js
@@ -81,3 +81,48 @@ describe('auth storage', () => {
     assert.strictEqual(getAuthUser(s), null);
   });
 });
+
+// ---------------------------------------------------------------------------
+// GitHub-App exact-match redirect_uri: the query must NOT ride along (GitHub
+// rejects it), so app params round-trip via sessionStorage instead.
+// ---------------------------------------------------------------------------
+const { buildRedirectUri, mergeAuthReturn } = require('../site/js/github_auth');
+
+describe('buildRedirectUri', () => {
+  it('is origin+pathname with no query (exact-match against the App callback)', () => {
+    assert.strictEqual(buildRedirectUri('http://localhost:8000', '/'), 'http://localhost:8000/');
+    assert.strictEqual(
+      buildRedirectUri('https://sy-tools.github.io', '/sy-subtitles/'),
+      'https://sy-tools.github.io/sy-subtitles/');
+  });
+  it('normalizes /index.html to the directory root so ONE callback URL suffices', () => {
+    assert.strictEqual(buildRedirectUri('http://localhost:8000', '/index.html'), 'http://localhost:8000/');
+    assert.strictEqual(
+      buildRedirectUri('https://sy-tools.github.io', '/sy-subtitles/index.html'),
+      'https://sy-tools.github.io/sy-subtitles/');
+  });
+});
+
+describe('mergeAuthReturn', () => {
+  it('adds the saved app params to the callback query, callback params winning', () => {
+    assert.strictEqual(
+      mergeAuthReturn('?code=c1&state=s1', '?repo=a%2Fb&branch=dev'),
+      '?code=c1&state=s1&repo=a%2Fb&branch=dev');
+  });
+  it('does not let a saved param override a callback param', () => {
+    assert.strictEqual(mergeAuthReturn('?code=c1&state=s1', '?state=EVIL&repo=a%2Fb'),
+      '?code=c1&state=s1&repo=a%2Fb');
+  });
+  it('is a no-op for an empty saved search', () => {
+    assert.strictEqual(mergeAuthReturn('?code=c1&state=s1', ''), '?code=c1&state=s1');
+    assert.strictEqual(mergeAuthReturn('?code=c1&state=s1', null), '?code=c1&state=s1');
+  });
+});
+
+describe('stripAuthParams also clears GitHub error-callback params', () => {
+  it('drops error/error_description/error_uri while keeping app params', () => {
+    assert.strictEqual(
+      stripAuthParams('?repo=a%2Fb&error=access_denied&error_description=x&error_uri=y&state=s1'),
+      '?repo=a%2Fb');
+  });
+});

--- a/tests/test_index_url_state.js
+++ b/tests/test_index_url_state.js
@@ -99,3 +99,12 @@ describe('buildIndexSearch', () => {
     assert.strictEqual(readIndexQuery('?' + qs), 'a b&c=d');
   });
 });
+
+describe("'mine' filter (signed-in reviewers)", () => {
+  it('is a known filter: readable from ?f= and kept by buildIndexSearch', () => {
+    assert.ok(INDEX_FILTERS.indexOf('mine') !== -1);
+    assert.strictEqual(readIndexFilter('?f=mine'), 'mine');
+    const qs = buildIndexSearch('?branch=dev', { query: '', filter: 'mine', defaultFilter: 'all' });
+    assert.strictEqual(qs, 'branch=dev&f=mine');
+  });
+});

--- a/tests/test_oauth_exchange.js
+++ b/tests/test_oauth_exchange.js
@@ -1,0 +1,85 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { handleExchange } = require('../workers/oauth-exchange/exchange');
+
+const ENV = {
+  GH_CLIENT_ID: 'Iv1.test',
+  GH_CLIENT_SECRET: 'shhh',
+  ALLOWED_ORIGINS: 'https://sy-tools.github.io,http://localhost:8000',
+};
+
+function req(opts) {
+  opts = opts || {};
+  return new Request('https://worker.example/exchange', {
+    method: opts.method || 'POST',
+    headers: Object.assign({ Origin: opts.origin || 'https://sy-tools.github.io' }, opts.headers || {}),
+    body: opts.method === 'OPTIONS' || opts.method === 'GET' ? undefined
+      : JSON.stringify(opts.body !== undefined ? opts.body : { code: 'abc123' }),
+  });
+}
+
+// fetch double for github.com/login/oauth/access_token
+function ghFetch(status, payload, capture) {
+  return async (url, init) => {
+    if (capture) { capture.url = url; capture.init = init; }
+    return new Response(JSON.stringify(payload), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+}
+
+describe('handleExchange', () => {
+  it('exchanges a code for a token and passes client credentials to GitHub', async () => {
+    const capture = {};
+    const r = await handleExchange(req({}), ENV, ghFetch(200, { access_token: 'gho_x' }, capture));
+    assert.strictEqual(r.status, 200);
+    assert.deepStrictEqual(await r.json(), { token: 'gho_x' });
+    assert.strictEqual(r.headers.get('Access-Control-Allow-Origin'), 'https://sy-tools.github.io');
+    assert.strictEqual(capture.url, 'https://github.com/login/oauth/access_token');
+    const sent = JSON.parse(capture.init.body);
+    assert.deepStrictEqual(sent, { client_id: 'Iv1.test', client_secret: 'shhh', code: 'abc123' });
+    assert.strictEqual(capture.init.headers['Accept'], 'application/json');
+  });
+
+  it('answers OPTIONS preflight with 204 + CORS headers', async () => {
+    const r = await handleExchange(req({ method: 'OPTIONS' }), ENV, ghFetch(200, {}));
+    assert.strictEqual(r.status, 204);
+    assert.strictEqual(r.headers.get('Access-Control-Allow-Origin'), 'https://sy-tools.github.io');
+    assert.match(r.headers.get('Access-Control-Allow-Methods'), /POST/);
+  });
+
+  it('rejects a disallowed origin with 403 and no CORS grant', async () => {
+    const r = await handleExchange(req({ origin: 'https://evil.example' }), ENV, ghFetch(200, {}));
+    assert.strictEqual(r.status, 403);
+    assert.strictEqual(r.headers.get('Access-Control-Allow-Origin'), null);
+  });
+
+  it('rejects non-POST with 405', async () => {
+    const r = await handleExchange(req({ method: 'GET' }), ENV, ghFetch(200, {}));
+    assert.strictEqual(r.status, 405);
+  });
+
+  it('rejects a missing/blank code with 400 without calling GitHub', async () => {
+    let called = false;
+    const f = async () => { called = true; return new Response('{}'); };
+    for (const body of [{}, { code: '' }, { code: 42 }, null]) {
+      const r = await handleExchange(req({ body }), ENV, f);
+      assert.strictEqual(r.status, 400);
+    }
+    assert.strictEqual(called, false);
+  });
+
+  it('maps a GitHub error payload to 502 {error} (never leaks the secret)', async () => {
+    const r = await handleExchange(req({}), ENV, ghFetch(200, { error: 'bad_verification_code' }));
+    assert.strictEqual(r.status, 502);
+    const body = await r.json();
+    assert.strictEqual(body.error, 'bad_verification_code');
+    assert.ok(!JSON.stringify(body).includes('shhh'));
+  });
+
+  it('maps a GitHub HTTP failure to 502', async () => {
+    const r = await handleExchange(req({}), ENV, ghFetch(500, {}));
+    assert.strictEqual(r.status, 502);
+  });
+});

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -27,7 +27,7 @@ from tests.test_preview_spa import (  # noqa: F401  — re-exported fixtures
 # only the scheduling is not — so retry rather than widen the timeout forever.
 pytestmark = [pytest.mark.e2e, pytest.mark.flaky(reruns=2, reruns_delay=2)]
 
-CACHE = "sy-subtitles-c6"  # CACHE_NAME in sw.js (CACHE_VERSION = 6)
+CACHE = "sy-subtitles-c7"  # CACHE_NAME in sw.js (CACHE_VERSION = 7)
 SW_WAIT_MS = 15000
 
 
@@ -48,7 +48,7 @@ class TestServiceWorker:
         _register_sw(page, server)
         page.evaluate("() => fetch('icon.png')")
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c6');"
+            "async () => { const c = await caches.open('sy-subtitles-c7');"
             " return !!(await c.match(location.origin + '/icon.png')); }",
             timeout=10000,
         )
@@ -59,7 +59,7 @@ class TestServiceWorker:
         # Seed a sentinel under the icon.png key; cache-first must return it
         # without going to the network.
         page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c6');"
+            "async () => { const c = await caches.open('sy-subtitles-c7');"
             " await c.put(location.origin + '/icon.png',"
             " new Response('SENTINEL', {headers: {'content-type': 'text/plain'}})); }"
         )
@@ -71,7 +71,7 @@ class TestServiceWorker:
         # Seed a stale sentinel for index.html; network-first must prefer the
         # live response when the network is reachable.
         page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c6');"
+            "async () => { const c = await caches.open('sy-subtitles-c7');"
             " await c.put(location.origin + '/index.html',"
             " new Response('STALE', {headers: {'content-type': 'text/html'}})); }"
         )
@@ -100,14 +100,14 @@ class TestServiceWorker:
         # with a sentinel before activation; it (and its entry) must survive.
         page.goto(f"{server}/index.html")
         page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c6');"
+            "async () => { const c = await caches.open('sy-subtitles-c7');"
             " await c.put(location.origin + '/keep', new Response('KEEP')); }"
         )
         page.evaluate("() => navigator.serviceWorker.register('sw.js')")
         page.wait_for_function("() => !!navigator.serviceWorker.controller", timeout=SW_WAIT_MS)
         assert CACHE in page.evaluate("() => caches.keys()")
         survived = page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c6');"
+            "async () => { const c = await caches.open('sy-subtitles-c7');"
             " const r = await c.match(location.origin + '/keep'); return r ? await r.text() : null; }"
         )
         assert survived == "KEEP", "activate wrongly purged the current-version cache"
@@ -129,7 +129,7 @@ class TestServiceWorker:
         # so they would not otherwise be cached).
         _register_sw(page, server)
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c6');"
+            "async () => { const c = await caches.open('sy-subtitles-c7');"
             " const us = (await c.keys()).map(r => r.url);"
             " return us.some(u => u.split('?')[0].endsWith('/index.html'))"
             " && us.filter(u => u.includes('/js/')).length >= 11"
@@ -137,7 +137,7 @@ class TestServiceWorker:
             timeout=10000,
         )
         shell = page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c6');"
+            "async () => { const c = await caches.open('sy-subtitles-c7');"
             " const us = (await c.keys()).map(r => r.url);"
             " return { index: us.some(u => u.split('?')[0].endsWith('/index.html')),"
             " js: us.filter(u => u.includes('/js/')).length,"
@@ -168,17 +168,17 @@ class TestServiceWorkerOffline:
         # icon.png, so delete it first to exercise the genuine miss path.)
         _register_sw(page, server)
         page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c6');"
+            "async () => { const c = await caches.open('sy-subtitles-c7');"
             " await c.delete(location.origin + '/icon.png'); }"
         )
         miss = page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c6');"
+            "async () => { const c = await caches.open('sy-subtitles-c7');"
             " return !!(await c.match(location.origin + '/icon.png')); }"
         )
         assert miss is False, "precondition: icon.png must not be cached yet"
         page.evaluate("() => fetch('icon.png')")
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c6');"
+            "async () => { const c = await caches.open('sy-subtitles-c7');"
             " return !!(await c.match(location.origin + '/icon.png')); }",
             timeout=10000,
         )
@@ -197,7 +197,7 @@ class TestServiceWorkerOffline:
         _register_sw(page, server)
         page.evaluate("() => fetch('index.html')")
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c6');"
+            "async () => { const c = await caches.open('sy-subtitles-c7');"
             " return !!(await c.match(location.origin + '/index.html')); }",
             timeout=10000,
         )
@@ -216,7 +216,7 @@ class TestServiceWorkerOffline:
         # Seed a cached asset so we can prove the SW is still alive afterwards.
         page.evaluate("() => fetch('icon.png')")
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c6');"
+            "async () => { const c = await caches.open('sy-subtitles-c7');"
             " return !!(await c.match(location.origin + '/icon.png')); }",
             timeout=10000,
         )
@@ -240,7 +240,7 @@ class TestServiceWorkerOffline:
         status = page.evaluate("async () => (await fetch('definitely-missing-asset.js')).status")
         assert status == 404, f"expected a 404 from the test server, got {status}"
         cached = page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c6');"
+            "async () => { const c = await caches.open('sy-subtitles-c7');"
             " return !!(await c.match(location.origin + '/definitely-missing-asset.js')); }"
         )
         assert cached is False, "a 404 response was wrongly written to the cache"
@@ -251,7 +251,7 @@ class TestServiceWorkerOffline:
         _register_sw(page, server)
         page.evaluate("() => fetch('js/sw_routing.js')")
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c6');"
+            "async () => { const c = await caches.open('sy-subtitles-c7');"
             " return !!(await c.match(location.origin + '/js/sw_routing.js')); }",
             timeout=10000,
         )
@@ -270,7 +270,7 @@ class TestServiceWorkerOffline:
         _register_sw(page, server)
         srt_url = "https://raw.githubusercontent.com/o/r/main/talks/x/uk/final/uk.srt?v=ab12cd34"
         page.evaluate(
-            "async (u) => { const c = await caches.open('sy-subtitles-c6');"
+            "async (u) => { const c = await caches.open('sy-subtitles-c7');"
             " await c.put(u, new Response('CACHED-SRT',"
             " {status: 200, headers: {'content-type': 'text/plain'}})); }",
             srt_url,
@@ -286,7 +286,7 @@ class TestServiceWorkerOffline:
         _register_sw(page, server)
         url = "https://raw.githubusercontent.com/o/r/main/talks/x/meta.yaml"
         page.evaluate(
-            "async (u) => { const c = await caches.open('sy-subtitles-c6');"
+            "async (u) => { const c = await caches.open('sy-subtitles-c7');"
             " await c.put(u, new Response('CACHED-META',"
             " {status: 200, headers: {'content-type': 'text/plain'}})); }",
             url,
@@ -308,7 +308,7 @@ class TestServiceWorkerOffline:
         _register_sw(page, server)
         api = "https://api.github.com/git/trees/main?recursive=1"
         page.evaluate(
-            "async (u) => { const c = await caches.open('sy-subtitles-c6');"
+            "async (u) => { const c = await caches.open('sy-subtitles-c7');"
             " await c.put(u, new Response('SHOULD-NOT-BE-SERVED', {status: 200})); }",
             api,
         )

--- a/tests/test_spa_auth_actions_e2e.py
+++ b/tests/test_spa_auth_actions_e2e.py
@@ -1,10 +1,12 @@
 """E2E for the signed-in GitHub write actions: take-for-review (+'mine' chip,
-filter, highlight), Create PR from review edits, and direct issue creation.
-All GitHub endpoints are mocked with page.route; a signed-in session is
-simulated by seeding sy_gh_token / sy_gh_user in localStorage (the app treats
-those as the session — no network auth involved).
+filter, highlight), Create PR from review/preview edits, direct issue
+creation, and the add-talk PR. All GitHub endpoints are mocked with
+page.route; a signed-in session is simulated by seeding sy_gh_token /
+sy_gh_user in localStorage (the app treats those as the session — no network
+auth involved).
 """
 
+import base64
 import http.server
 import json
 import threading
@@ -16,6 +18,7 @@ pytestmark = pytest.mark.e2e
 
 SITE = Path(__file__).parent.parent / "site"
 SPA_URL = "/index.html"
+MOCK_PLAYER_JS = (Path(__file__).parent / "fixtures" / "mock_vimeo_player.js").read_text()
 
 SAMPLE_META = """title: 'Test Talk: Subtitle Preview'
 date: '2001-01-01'
@@ -170,6 +173,16 @@ def _wire(pg, calls, review_status):
     pg.route(
         "**/raw.githubusercontent.com/**/review-status.json",
         lambda r: r.fulfill(status=200, content_type="application/json", body=json.dumps(review_status)),
+    )
+    # Preview needs a player: serve the mock Vimeo SDK and a blank embed page
+    # so nothing reaches the real network.
+    pg.route(
+        "**/player.vimeo.com/api/player.js",
+        lambda r: r.fulfill(status=200, content_type="application/javascript", body=MOCK_PLAYER_JS),
+    )
+    pg.route(
+        "**/player.vimeo.com/video/**",
+        lambda r: r.fulfill(status=200, content_type="text/html", body="<html></html>"),
     )
     # Write endpoints — registered last so they shadow the generic API mock.
     pg.route("**/api.github.com/repos/**/issues/42/assignees", h(201, {"number": 42}))
@@ -345,5 +358,121 @@ def test_signed_out_shows_none_of_the_new_ui(server, browser):
     pg.goto(f"{server}{SPA_URL}#/review/2001-01-01_Test-Talk")
     pg.wait_for_function("document.querySelectorAll('.cell.uk').length > 0", timeout=10000)
     assert not pg.locator("#btn-create-pr").is_visible()
+    # The classic editor flow stays: signed-out users see the editor button.
+    assert pg.locator("#btn-review-editor").is_visible()
     assert not calls, "no write API calls may happen signed out"
+    ctx.close()
+
+
+def test_take_for_review_failure_recovers_the_button(server, browser):
+    """A failed write must not leave a dead disabled button: the card stays
+    claimable and the toast names the actionable problem (app not installed)
+    instead of echoing the opaque API message."""
+    calls = []
+    ctx, pg = _page(browser, calls, REVIEW_STATUS_UNASSIGNED)
+    pg.route(
+        "**/api.github.com/repos/**/issues/42/assignees",
+        lambda r: r.fulfill(
+            status=403,
+            content_type="application/json",
+            body=json.dumps({"message": "Resource not accessible by integration"}),
+        ),
+    )
+    pg.goto(f"{server}{SPA_URL}")
+    pg.wait_for_selector(".take-review-btn", timeout=10000)
+    pg.click(".take-review-btn")
+    pg.wait_for_function("document.getElementById('toast').classList.contains('show')", timeout=5000)
+    assert "GitHub App" in pg.locator("#toast").text_content()
+    pg.wait_for_function(
+        "document.querySelector('.take-review-btn') && !document.querySelector('.take-review-btn').disabled",
+        timeout=5000,
+    )
+    ctx.close()
+
+
+def test_signed_in_review_swaps_editor_for_create_pr(server, browser):
+    """Signed in, Create PR REPLACES Open-in-GitHub-Editor (both submit the
+    same edits — showing both would duplicate the action)."""
+    ctx, pg = _page(browser, [], REVIEW_STATUS_UNASSIGNED)
+    pg.goto(f"{server}{SPA_URL}#/review/2001-01-01_Test-Talk")
+    pg.wait_for_function("document.querySelectorAll('.cell.uk').length > 0", timeout=10000)
+    assert pg.locator("#btn-create-pr").is_visible()
+    assert pg.locator("#btn-review-editor").count() == 1
+    assert not pg.locator("#btn-review-editor").is_visible()
+    ctx.close()
+
+
+def _open_preview_in_edit_mode(pg, server):
+    pg.goto(f"{server}{SPA_URL}#/preview/2001-01-01_Test-Talk/Test-Video")
+    pg.wait_for_selector("#mock-player", state="visible", timeout=10000)
+    pg.click(".preview-mode-toggle [data-mode='edit']")
+
+
+def test_signed_in_preview_swaps_editor_for_create_pr(server, browser):
+    ctx, pg = _page(browser, [], REVIEW_STATUS_UNASSIGNED)
+    _open_preview_in_edit_mode(pg, server)
+    assert pg.locator("#btn-preview-pr").is_visible()
+    assert pg.locator("#btn-preview-editor").count() == 1
+    assert not pg.locator("#btn-preview-editor").is_visible()
+    # Marker mode hides both edit-submission buttons.
+    pg.click(".preview-mode-toggle [data-mode='marker']")
+    assert not pg.locator("#btn-preview-pr").is_visible()
+    assert not pg.locator("#btn-preview-editor").is_visible()
+    ctx.close()
+
+
+def test_signed_out_preview_keeps_editor_button(server, browser):
+    calls = []
+    ctx, pg = _page(browser, calls, REVIEW_STATUS_UNASSIGNED, signed_in=False)
+    _open_preview_in_edit_mode(pg, server)
+    assert pg.locator("#btn-preview-editor").is_visible()
+    assert not pg.locator("#btn-preview-pr").is_visible()
+    assert not calls, "no write API calls may happen signed out"
+    ctx.close()
+
+
+def test_create_pr_from_preview_edits(server, browser):
+    calls = []
+    ctx, pg = _page(browser, calls, REVIEW_STATUS_UNASSIGNED)
+    _open_preview_in_edit_mode(pg, server)
+    # Park the playhead on block 1 and edit it through the real UX path.
+    pg.evaluate("window._vimeoPlayer._setTime(2)")
+    pg.click("#btn-mark")
+    pg.wait_for_selector(".edit-item .edited", timeout=5000)
+    row = pg.locator(".edit-item .edited").first
+    row.click()
+    row.press("End")
+    row.type(" ВИПРАВЛЕНО")
+    pg.click("#btn-preview-pr")
+    pg.wait_for_function("window.__opened.length > 0", timeout=10000)
+
+    put = next(c for c in calls if c["method"] == "PUT")
+    assert put["url"].split("?")[0].endswith("/contents/talks/2001-01-01_Test-Talk/Test-Video/final/uk.srt")
+    committed = base64.b64decode(put["body"]["content"]).decode("utf-8")
+    assert "Перший субтитр ВИПРАВЛЕНО" in committed
+    assert "Другий субтитр" in committed
+    refs = next(c for c in calls if c["url"].endswith("/git/refs"))
+    assert refs["body"]["ref"].startswith("refs/heads/preview/2001-01-01_Test-Talk--tester--")
+    pull = next(c for c in calls if c["url"].endswith("/pulls"))
+    assert pull["body"]["head"] == refs["body"]["ref"].replace("refs/heads/", "")
+    assert pg.evaluate("window.__opened[0]") == "https://github.com/sy-tools/sy-subtitles/pull/9"
+    ctx.close()
+
+
+def test_add_talk_creates_pr_when_signed_in(server, browser):
+    calls = []
+    ctx, pg = _page(browser, calls, REVIEW_STATUS_UNASSIGNED)
+    payload = json.dumps({"t": "Brand New Talk", "d": "2002-02-02", "u": "https://www.amruta.org/talk/"})
+    pg.goto(f"{server}{SPA_URL}#/add?data={payload}")
+    pg.wait_for_selector("#add-form", state="visible", timeout=10000)
+    pg.click("#add-form button[type='submit']")
+    pg.wait_for_function("window.__opened.length > 0", timeout=10000)
+
+    put = next(c for c in calls if c["method"] == "PUT")
+    assert put["url"].split("?")[0].endswith("/contents/talks/2002-02-02_Brand-New-Talk/meta.yaml")
+    committed = base64.b64decode(put["body"]["content"]).decode("utf-8")
+    assert "Brand New Talk" in committed
+    refs = next(c for c in calls if c["url"].endswith("/git/refs"))
+    assert refs["body"]["ref"].startswith("refs/heads/add-talk/2002-02-02_Brand-New-Talk--tester--")
+    assert pg.evaluate("window.__opened[0]") == "https://github.com/sy-tools/sy-subtitles/pull/9"
     ctx.close()

--- a/tests/test_spa_auth_actions_e2e.py
+++ b/tests/test_spa_auth_actions_e2e.py
@@ -1,0 +1,349 @@
+"""E2E for the signed-in GitHub write actions: take-for-review (+'mine' chip,
+filter, highlight), Create PR from review edits, and direct issue creation.
+All GitHub endpoints are mocked with page.route; a signed-in session is
+simulated by seeding sy_gh_token / sy_gh_user in localStorage (the app treats
+those as the session — no network auth involved).
+"""
+
+import http.server
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+SITE = Path(__file__).parent.parent / "site"
+SPA_URL = "/index.html"
+
+SAMPLE_META = """title: 'Test Talk: Subtitle Preview'
+date: '2001-01-01'
+location: Test Location
+videos:
+- slug: Test-Video
+  title: Test Video
+  video_ref: r1DBtMTl9VW1NC
+"""
+
+SAMPLE_UK_SRT = """1
+00:00:01,000 --> 00:00:05,000
+Перший субтитр
+
+2
+00:00:06,000 --> 00:00:10,000
+Другий субтитр
+"""
+
+SAMPLE_EN = "Talk Language: English\n\nFirst paragraph.\n\nSecond paragraph.\n"
+SAMPLE_UK = "Мова промови: англійська\n\nПерший абзац.\n\nДругий абзац.\n"
+
+MOCK_TREE = {
+    "sha": "test123",
+    "tree": [
+        {"path": "talks/2001-01-01_Test-Talk/Test-Video/final/uk.srt", "type": "blob"},
+        {"path": "talks/2001-01-01_Test-Talk/Test-Video/source/en.srt", "type": "blob"},
+        {"path": "talks/2001-01-01_Test-Talk/meta.yaml", "type": "blob"},
+        {"path": "talks/2001-01-01_Test-Talk/review_report.md", "type": "blob"},
+        {"path": "talks/2001-01-01_Test-Talk/transcript_en.txt", "type": "blob"},
+        {"path": "talks/2001-01-01_Test-Talk/transcript_uk.txt", "type": "blob"},
+    ],
+}
+
+REVIEW_STATUS_UNASSIGNED = {
+    "version": 1,
+    "updated_at": "2026-07-12T00:00:00Z",
+    "talks": {
+        "2001-01-01_Test-Talk": {
+            "status": "pending",
+            "reviewer": None,
+            "issue_number": 42,
+            "updated_at": "2026-07-12T00:00:00Z",
+        },
+    },
+}
+
+
+@pytest.fixture(scope="module")
+def server():
+    injected = (
+        (SITE / "index.html")
+        .read_text()
+        .replace(
+            "<head>",
+            "<head><script>window.__SY_REPO='sy-tools/sy-subtitles';"
+            "window.__SY_GH_CLIENT_ID='Iv1.test';"
+            "window.__SY_GH_EXCHANGE_URL='https://oauth-exchange.test/exchange';</script>",
+            1,
+        )
+        .encode("utf-8")
+    )
+    directory = str(SITE)
+
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def __init__(self, *a, **k):
+            super().__init__(*a, directory=directory, **k)
+
+        def log_message(self, *a):
+            pass
+
+        def do_GET(self):
+            if self.path.split("?", 1)[0] in ("/", "/index.html"):
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(injected)))
+                self.end_headers()
+                self.wfile.write(injected)
+                return
+            super().do_GET()
+
+    httpd = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    port = httpd.server_address[1]
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{port}"
+    httpd.shutdown()
+
+
+@pytest.fixture(scope="module")
+def browser():
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        pytest.skip("playwright not installed")
+    with sync_playwright() as p:
+        b = p.chromium.launch()
+        yield b
+        b.close()
+
+
+def _record(calls):
+    def handler_for(status, payload):
+        def handle(route):
+            req = route.request
+            calls.append(
+                {
+                    "method": req.method,
+                    "url": req.url,
+                    "body": json.loads(req.post_data) if req.post_data else None,
+                }
+            )
+            route.fulfill(
+                status=status,
+                content_type="application/json",
+                body=json.dumps(payload),
+            )
+
+        return handle
+
+    return handler_for
+
+
+def _wire(pg, calls, review_status):
+    """Read mocks first, then write mocks (later-registered routes win)."""
+    h = _record(calls)
+    pg.route(
+        "**/api.github.com/**",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            headers={"ETag": '"e2e"'},
+            body=json.dumps(MOCK_TREE),
+        ),
+    )
+    pg.route("**/raw.githubusercontent.com/**", lambda r: r.fulfill(status=404, body="not found"))
+    pg.route(
+        "**/raw.githubusercontent.com/**/meta.yaml",
+        lambda r: r.fulfill(status=200, content_type="text/plain", body=SAMPLE_META),
+    )
+    pg.route(
+        "**/raw.githubusercontent.com/**/uk.srt",
+        lambda r: r.fulfill(status=200, content_type="text/plain", body=SAMPLE_UK_SRT),
+    )
+    pg.route(
+        "**/raw.githubusercontent.com/**/transcript_en.txt",
+        lambda r: r.fulfill(status=200, content_type="text/plain", body=SAMPLE_EN),
+    )
+    pg.route(
+        "**/raw.githubusercontent.com/**/transcript_uk.txt",
+        lambda r: r.fulfill(status=200, content_type="text/plain", body=SAMPLE_UK),
+    )
+    pg.route(
+        "**/raw.githubusercontent.com/**/review-status.json",
+        lambda r: r.fulfill(status=200, content_type="application/json", body=json.dumps(review_status)),
+    )
+    # Write endpoints — registered last so they shadow the generic API mock.
+    pg.route("**/api.github.com/repos/**/issues/42/assignees", h(201, {"number": 42}))
+    pg.route(
+        "**/api.github.com/repos/**/issues",
+        h(201, {"number": 77, "html_url": "https://github.com/sy-tools/sy-subtitles/issues/77"}),
+    )
+    pg.route("**/api.github.com/repos/**/git/ref/heads/main", h(200, {"object": {"sha": "base1"}}))
+    pg.route("**/api.github.com/repos/**/git/refs", h(201, {}))
+
+    def contents(route):
+        req = route.request
+        if req.method == "GET":
+            route.fulfill(status=200, content_type="application/json", body=json.dumps({"sha": "blob1"}))
+            return
+        calls.append(
+            {"method": req.method, "url": req.url, "body": json.loads(req.post_data) if req.post_data else None}
+        )
+        route.fulfill(status=201, content_type="application/json", body=json.dumps({"content": {}}))
+
+    pg.route("**/api.github.com/repos/**/contents/**", contents)
+    pg.route(
+        "**/api.github.com/repos/**/pulls",
+        h(201, {"number": 9, "html_url": "https://github.com/sy-tools/sy-subtitles/pull/9"}),
+    )
+
+
+def _page(browser, calls, review_status, signed_in=True):
+    ctx = browser.new_context()
+    pg = ctx.new_page()
+    _wire(pg, calls, review_status)
+    pg.add_init_script(
+        "localStorage.removeItem('sy_tree_cache__main');localStorage.removeItem('sy_review_status__main');"
+    )
+    if signed_in:
+        pg.add_init_script(
+            "localStorage.setItem('sy_gh_token', 'gho_e2e');"
+            "localStorage.setItem('sy_gh_user',"
+            " JSON.stringify({login: 'tester', avatar_url: 'icon.png'}));"
+        )
+    # Auto-resolve single-button info dialogs; record window.open targets.
+    pg.add_init_script(
+        "window.__spa_auto_info_confirm = true;"
+        "window.__opened = []; window.open = function(u){ window.__opened.push(u); };"
+    )
+    return ctx, pg
+
+
+def test_take_for_review_assigns_existing_issue(server, browser):
+    calls = []
+    ctx, pg = _page(browser, calls, REVIEW_STATUS_UNASSIGNED)
+    pg.goto(f"{server}{SPA_URL}")
+    pg.wait_for_selector(".take-review-btn", timeout=10000)
+    pg.click(".take-review-btn")
+    # Optimistic update: the talk moves out of the default needs-review filter
+    # and into the 'mine' chip; following the chip shows the highlighted card.
+    pg.wait_for_function(
+        "document.querySelector(\".stat-card[data-filter='mine'] .num\")"
+        " && document.querySelector(\".stat-card[data-filter='mine'] .num\").textContent.includes('1')",
+        timeout=5000,
+    )
+    posts = [c for c in calls if c["method"] == "POST"]
+    assert posts and posts[0]["url"].endswith("/issues/42/assignees")
+    assert posts[0]["body"] == {"assignees": ["tester"]}
+    pg.click(".stat-card[data-filter='mine']")
+    pg.wait_for_selector(".talk-item--mine", timeout=5000)
+    assert "tester" in pg.locator(".review-badge, .status-badge").first.text_content()
+    ctx.close()
+
+
+def test_take_for_review_creates_issue_when_none_exists(server, browser):
+    calls = []
+    ctx, pg = _page(browser, calls, {"version": 1, "talks": {}})
+    # A talk with no review issue is 'in-progress' — visible only in expert
+    # mode's 'all' filter, so claim-from-scratch is an expert-mode action.
+    pg.add_init_script("localStorage.setItem('sy_expert_mode', '1');localStorage.setItem('sy_filter_expert', 'all');")
+    pg.goto(f"{server}{SPA_URL}")
+    pg.wait_for_selector(".take-review-btn", timeout=10000)
+    pg.click(".take-review-btn")
+    pg.wait_for_function(
+        "document.querySelector(\".stat-card[data-filter='mine'] .num\")"
+        " && document.querySelector(\".stat-card[data-filter='mine'] .num\").textContent.includes('1')",
+        timeout=5000,
+    )
+    posts = [c for c in calls if c["method"] == "POST"]
+    assert posts and posts[0]["url"].endswith("/issues")
+    body = posts[0]["body"]
+    assert body["title"] == "Review: 2001-01-01_Test-Talk"
+    assert "talk-review" in body["labels"]
+    assert body["assignees"] == ["tester"]
+    ctx.close()
+
+
+def test_mine_chip_filters_and_highlights(server, browser):
+    st = {
+        "version": 1,
+        "talks": {
+            "2001-01-01_Test-Talk": {
+                "status": "in-progress",
+                "reviewer": "tester",
+                "issue_number": 42,
+                "updated_at": "2026-07-12T00:00:00Z",
+            }
+        },
+    }
+    ctx, pg = _page(browser, [], st)
+    pg.goto(f"{server}{SPA_URL}")
+    pg.wait_for_selector(".stat-card[data-filter='mine']", timeout=10000)
+    assert "1" in pg.locator(".stat-card[data-filter='mine'] .num").text_content()
+    pg.click(".stat-card[data-filter='mine']")
+    pg.wait_for_timeout(200)
+    assert pg.locator(".talk-item").count() == 1
+    assert pg.locator(".talk-item--mine").count() == 1
+    ctx.close()
+
+
+def test_create_pr_from_review_edits(server, browser):
+    calls = []
+    ctx, pg = _page(browser, calls, REVIEW_STATUS_UNASSIGNED)
+    pg.goto(f"{server}{SPA_URL}#/review/2001-01-01_Test-Talk")
+    pg.wait_for_function("document.querySelectorAll('.cell.uk').length > 0", timeout=10000)
+    assert pg.locator("#btn-create-pr").is_visible()
+    cell = pg.locator(".cell.uk .cell-text").first
+    cell.click()
+    cell.press("End")
+    cell.type(" ВИПРАВЛЕНО")
+    cell.press("Tab")
+    pg.wait_for_timeout(200)
+    pg.click("#btn-create-pr")
+    pg.wait_for_function("window.__opened.length > 0", timeout=10000)
+
+    seq = [(c["method"], c["url"].split("/repos/")[-1].split("?")[0]) for c in calls]
+    assert ("POST", "sy-tools/sy-subtitles/git/refs") in seq
+    assert ("POST", "sy-tools/sy-subtitles/pulls") in seq
+    refs = next(c for c in calls if c["url"].endswith("/git/refs"))
+    assert refs["body"]["ref"].startswith("refs/heads/review/2001-01-01_Test-Talk--tester--")
+    put = next(c for c in calls if c["method"] == "PUT")
+    assert put["url"].split("?")[0].endswith("/contents/talks/2001-01-01_Test-Talk/transcript_uk.txt")
+    import base64
+
+    committed = base64.b64decode(put["body"]["content"]).decode("utf-8")
+    assert "ВИПРАВЛЕНО" in committed
+    assert put["body"]["sha"] == "blob1"
+    pull = next(c for c in calls if c["url"].endswith("/pulls"))
+    assert pull["body"]["head"] == refs["body"]["ref"].replace("refs/heads/", "")
+    assert "Suggested edits" in pull["body"]["body"]
+    assert pg.evaluate("window.__opened[0]") == "https://github.com/sy-tools/sy-subtitles/pull/9"
+    ctx.close()
+
+
+def test_review_issue_posted_via_api_when_signed_in(server, browser):
+    calls = []
+    ctx, pg = _page(browser, calls, REVIEW_STATUS_UNASSIGNED)
+    pg.goto(f"{server}{SPA_URL}#/review/2001-01-01_Test-Talk")
+    pg.wait_for_function("document.querySelectorAll('.cell.uk').length > 0", timeout=10000)
+    pg.click("#view-review .btn--issue")
+    pg.wait_for_function("window.__opened.length > 0", timeout=10000)
+    posts = [c for c in calls if c["method"] == "POST" and c["url"].endswith("/issues")]
+    assert posts and posts[0]["body"]["title"].startswith("Translation review:")
+    assert posts[0]["body"]["labels"] == ["review:pending"]
+    # The prefilled /issues/new page was NOT opened — the API path was taken.
+    assert pg.evaluate("window.__opened[0]") == "https://github.com/sy-tools/sy-subtitles/issues/77"
+    ctx.close()
+
+
+def test_signed_out_shows_none_of_the_new_ui(server, browser):
+    calls = []
+    ctx, pg = _page(browser, calls, REVIEW_STATUS_UNASSIGNED, signed_in=False)
+    pg.goto(f"{server}{SPA_URL}")
+    pg.wait_for_selector(".talk-item", timeout=10000)
+    assert pg.locator(".take-review-btn").count() == 0
+    assert pg.locator(".stat-card[data-filter='mine']").count() == 0
+    pg.goto(f"{server}{SPA_URL}#/review/2001-01-01_Test-Talk")
+    pg.wait_for_function("document.querySelectorAll('.cell.uk').length > 0", timeout=10000)
+    assert not pg.locator("#btn-create-pr").is_visible()
+    assert not calls, "no write API calls may happen signed out"
+    ctx.close()

--- a/tests/test_spa_auth_e2e.py
+++ b/tests/test_spa_auth_e2e.py
@@ -172,3 +172,64 @@ def test_signed_out_default_shows_no_auth_ui(plain_server):
         assert pg.evaluate("getComputedStyle(document.getElementById('gh-avatar')).display") == "none"
         ctx.close()
         browser.close()
+
+
+@pytest.fixture
+def hooks_only_server():
+    # Auth hooks WITHOUT __SY_REPO: off Pages the app can only learn the repo
+    # from ?repo=, so this fixture proves the login roundtrip restores it.
+    inject = f"<head><script>window.__SY_GH_CLIENT_ID='Iv1.test';window.__SY_GH_EXCHANGE_URL='{EXCHANGE_URL}';</script>"
+    index_html = (SITE / "index.html").read_text().replace("<head>", inject, 1).encode("utf-8")
+    httpd, url = _serve(index_html)
+    yield url
+    httpd.shutdown()
+
+
+def test_callback_restores_app_params_saved_before_login(hooks_only_server):
+    """GitHub App redirect_uri is the bare app URL (exact-match rule), so
+    ?repo= must round-trip via sessionStorage — else the off-Pages app cannot
+    even boot on the callback (deriveRepo throws -> blank page)."""
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        pytest.skip("playwright not installed")
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        ctx = browser.new_context()
+        pg = ctx.new_page()
+        _route_github(pg, hooks_only_server)
+        pg.add_init_script(
+            "sessionStorage.setItem('sy_gh_state', 'st1');"
+            "sessionStorage.setItem('sy_gh_return', '?repo=sy-tools%2Fsy-subtitles');"
+        )
+        # The callback arrives WITHOUT ?repo — exactly as GitHub sends it.
+        pg.goto(f"{hooks_only_server}/index.html?code=c1&state=st1")
+        pg.wait_for_selector("#gh-avatar", state="visible", timeout=10000)
+        assert pg.evaluate("localStorage.getItem('sy_gh_token')") == "gho_e2e"
+        assert "repo=" in pg.url and "code=" not in pg.url
+        ctx.close()
+        browser.close()
+
+
+def test_login_redirect_uri_is_bare_app_url(auth_server, auth_page):
+    """The authorize URL must carry a query-less redirect_uri (GitHub Apps
+    exact-match a registered callback; ?repo= riding along is rejected with
+    'redirect_uri is not associated with this application')."""
+    page = auth_page
+    page.route(
+        "https://github.com/login/oauth/authorize*",
+        lambda r: r.fulfill(status=200, content_type="text/html", body="<title>gh</title>"),
+    )
+    page.goto(f"{auth_server}/index.html")
+    page.wait_for_selector("#gh-login-btn", state="visible", timeout=10000)
+    page.click("#gh-login-btn")
+    page.wait_for_url("**github.com/login/oauth/authorize**", timeout=5000)
+    from urllib.parse import parse_qs, urlparse
+
+    q = parse_qs(urlparse(page.url).query)
+    redirect_uri = q["redirect_uri"][0]
+    assert "?" not in redirect_uri and "index.html" not in redirect_uri
+    assert redirect_uri.endswith("/")
+    # (sessionStorage can't be asserted here: page.url is github.com now — a
+    # different origin. The stash/restore pair is proven by
+    # test_callback_restores_app_params_saved_before_login.)

--- a/tests/test_spa_auth_e2e.py
+++ b/tests/test_spa_auth_e2e.py
@@ -1,0 +1,174 @@
+"""GitHub sign-in happy path + logout, fully offline (all GitHub endpoints and
+the exchange Worker are mocked with page.route). Follows the boot-smoke server
+pattern; marker e2e only (not smoke — this is a feature test, not the boot gate).
+"""
+
+import http.server
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.e2e]
+
+SITE = Path(__file__).parent.parent / "site"
+EXCHANGE_URL = "https://oauth-exchange.test/exchange"
+
+
+def _serve(index_html: bytes):
+    directory = str(SITE)
+
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def __init__(self, *a, **k):
+            super().__init__(*a, directory=directory, **k)
+
+        def log_message(self, *a):
+            pass
+
+        def do_GET(self):
+            if self.path.split("?", 1)[0] in ("/", "/index.html"):
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(index_html)))
+                self.end_headers()
+                self.wfile.write(index_html)
+                return
+            super().do_GET()
+
+    httpd = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    port = httpd.server_address[1]
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return httpd, f"http://127.0.0.1:{port}"
+
+
+@pytest.fixture
+def auth_server():
+    # window test hooks: repo (off-Pages), client id + exchange URL (the shipped
+    # config is empty = feature disabled; the hooks enable it for the test).
+    inject = (
+        "<head><script>"
+        "window.__SY_REPO='sy-tools/sy-subtitles';"
+        "window.__SY_GH_CLIENT_ID='Iv1.test';"
+        f"window.__SY_GH_EXCHANGE_URL='{EXCHANGE_URL}';"
+        "</script>"
+    )
+    index_html = (SITE / "index.html").read_text().replace("<head>", inject, 1).encode("utf-8")
+    httpd, url = _serve(index_html)
+    yield url
+    httpd.shutdown()
+
+
+@pytest.fixture
+def plain_server():
+    # No auth hooks: the shipped default (empty APP_GH_CLIENT_ID) stays in force,
+    # so this serves the app exactly as production would before the GitHub App
+    # exists — the signed-out-default test asserts no auth UI renders.
+    inject = "<head><script>window.__SY_REPO='sy-tools/sy-subtitles';</script>"
+    index_html = (SITE / "index.html").read_text().replace("<head>", inject, 1).encode("utf-8")
+    httpd, url = _serve(index_html)
+    yield url
+    httpd.shutdown()
+
+
+def _route_github(pg, auth_server):
+    # Later-registered routes win in Playwright, so the generic API mock goes
+    # FIRST and the specific /user mock second (it must shadow the generic one).
+    pg.route(
+        "**/api.github.com/**",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            headers={"ETag": '"e2e"'},
+            body=json.dumps({"sha": "e2e", "tree": [], "truncated": False}),
+        ),
+    )
+    pg.route(
+        "**/api.github.com/user",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"login": "tester", "avatar_url": f"{auth_server}/icon.png"}),
+        ),
+    )
+    pg.route(
+        "**/raw.githubusercontent.com/**",
+        lambda r: r.fulfill(status=404, body="not found"),
+    )
+    pg.route(
+        EXCHANGE_URL,
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"token": "gho_e2e"}),
+        ),
+    )
+
+
+@pytest.fixture
+def auth_page(auth_server):
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        pytest.skip("playwright not installed")
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        ctx = browser.new_context()
+        pg = ctx.new_page()
+        _route_github(pg, auth_server)
+        yield pg
+        ctx.close()
+        browser.close()
+
+
+def test_callback_exchanges_code_and_signs_in(auth_server, auth_page):
+    page = auth_page
+    # Pre-seed the CSRF state exactly as SPA.ghLogin would before redirecting.
+    page.add_init_script("sessionStorage.setItem('sy_gh_state', 'st1');")
+    page.goto(f"{auth_server}/index.html?code=c1&state=st1")
+    page.wait_for_selector("#gh-avatar", state="visible", timeout=10000)
+    # Token persisted, avatar labeled with the login, URL scrubbed of auth params.
+    assert page.evaluate("localStorage.getItem('sy_gh_token')") == "gho_e2e"
+    assert "tester" in page.evaluate("document.getElementById('gh-avatar').title")
+    assert "code=" not in page.url and "state=" not in page.url
+    # Login button hidden while signed in.
+    assert page.evaluate("getComputedStyle(document.getElementById('gh-login-btn')).display") == "none"
+
+
+def test_avatar_menu_signs_out(auth_server, auth_page):
+    page = auth_page
+    page.add_init_script("sessionStorage.setItem('sy_gh_state', 'st1');")
+    page.goto(f"{auth_server}/index.html?code=c1&state=st1")
+    page.wait_for_selector("#gh-avatar", state="visible", timeout=10000)
+    page.click("#gh-avatar")
+    page.click(".sy-modal-btn.primary")  # confirm sign-out
+    page.wait_for_selector("#gh-login-btn", state="visible", timeout=5000)
+    assert page.evaluate("localStorage.getItem('sy_gh_token')") is None
+
+
+def test_invalid_state_does_not_sign_in(auth_server, auth_page):
+    page = auth_page
+    page.add_init_script("sessionStorage.setItem('sy_gh_state', 'OTHER');")
+    page.goto(f"{auth_server}/index.html?code=c1&state=st1")
+    page.wait_for_selector("#gh-login-btn", state="visible", timeout=10000)
+    assert page.evaluate("localStorage.getItem('sy_gh_token')") is None
+    assert "code=" not in page.url
+
+
+def test_signed_out_default_shows_no_auth_ui(plain_server):
+    """With an empty client id (the shipped default) neither button renders."""
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        pytest.skip("playwright not installed")
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        ctx = browser.new_context()
+        pg = ctx.new_page()
+        _route_github(pg, plain_server)
+        pg.goto(f"{plain_server}/index.html")
+        pg.wait_for_function("document.title.includes('Index')", timeout=10000)
+        assert pg.evaluate("getComputedStyle(document.getElementById('gh-login-btn')).display") == "none"
+        assert pg.evaluate("getComputedStyle(document.getElementById('gh-avatar')).display") == "none"
+        ctx.close()
+        browser.close()

--- a/tests/test_spa_auth_e2e.py
+++ b/tests/test_spa_auth_e2e.py
@@ -211,6 +211,24 @@ def test_callback_restores_app_params_saved_before_login(hooks_only_server):
         browser.close()
 
 
+def test_login_control_sits_left_of_branch_selector(auth_server, auth_page):
+    """The login button and avatar live in the freshness bar's LEFT group,
+    before the branch selector — placed on the right they visually split the
+    refresh button from the last-updated message."""
+    page = auth_page
+    page.goto(f"{auth_server}/index.html")
+    page.wait_for_selector("#gh-login-btn", state="visible", timeout=10000)
+    left_group = "document.getElementById('freshness-bar').children[0]"
+    for el_id in ("gh-login-btn", "gh-avatar", "branch-btn"):
+        assert page.evaluate(f"{left_group}.contains(document.getElementById('{el_id}'))"), (
+            f"#{el_id} must be in the freshness bar's left group"
+        )
+    assert page.evaluate(
+        "!!(document.getElementById('gh-login-btn').compareDocumentPosition("
+        "document.getElementById('branch-btn')) & Node.DOCUMENT_POSITION_FOLLOWING)"
+    ), "login button must precede the branch selector"
+
+
 def test_login_redirect_uri_is_bare_app_url(auth_server, auth_page):
     """The authorize URL must carry a query-less redirect_uri (GitHub Apps
     exact-match a registered callback; ?repo= riding along is rejected with

--- a/tests/test_spa_auth_e2e.py
+++ b/tests/test_spa_auth_e2e.py
@@ -61,9 +61,8 @@ def auth_server():
 
 @pytest.fixture
 def plain_server():
-    # No auth hooks: the shipped default (empty APP_GH_CLIENT_ID) stays in force,
-    # so this serves the app exactly as production would before the GitHub App
-    # exists — the signed-out-default test asserts no auth UI renders.
+    # No auth hooks: the shipped config (real APP_GH_CLIENT_ID + prod worker
+    # URL) stays in force, so this serves the app exactly as production does.
     inject = "<head><script>window.__SY_REPO='sy-tools/sy-subtitles';</script>"
     index_html = (SITE / "index.html").read_text().replace("<head>", inject, 1).encode("utf-8")
     httpd, url = _serve(index_html)
@@ -155,8 +154,9 @@ def test_invalid_state_does_not_sign_in(auth_server, auth_page):
     assert "code=" not in page.url
 
 
-def test_signed_out_default_shows_no_auth_ui(plain_server):
-    """With an empty client id (the shipped default) neither button renders."""
+def test_signed_out_default_shows_login_button(plain_server):
+    """The shipped config carries the real GitHub App client id + worker URL,
+    so a signed-out visitor sees the login button (and no avatar) by default."""
     try:
         from playwright.sync_api import sync_playwright
     except ImportError:
@@ -168,7 +168,7 @@ def test_signed_out_default_shows_no_auth_ui(plain_server):
         _route_github(pg, plain_server)
         pg.goto(f"{plain_server}/index.html")
         pg.wait_for_function("document.title.includes('Index')", timeout=10000)
-        assert pg.evaluate("getComputedStyle(document.getElementById('gh-login-btn')).display") == "none"
+        assert pg.evaluate("getComputedStyle(document.getElementById('gh-login-btn')).display") != "none"
         assert pg.evaluate("getComputedStyle(document.getElementById('gh-avatar')).display") == "none"
         ctx.close()
         browser.close()

--- a/workers/oauth-exchange/.dev.vars.example
+++ b/workers/oauth-exchange/.dev.vars.example
@@ -1,0 +1,4 @@
+# Local dev secrets for `npx wrangler dev` (copy to .dev.vars — gitignored).
+# Values come from the GitHub App (docs/github-app-setup.md, step 1).
+GH_CLIENT_ID=Iv1.xxxxxxxxxxxxxxxx
+GH_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/workers/oauth-exchange/exchange.js
+++ b/workers/oauth-exchange/exchange.js
@@ -1,0 +1,66 @@
+// OAuth code→token exchange for the review SPA (Cloudflare Worker handler).
+// The GitHub App's client_secret must never ship in the static SPA, so this
+// Worker performs the one privileged step of the login flow:
+//   POST /exchange {code} -> {token}
+// Env (wrangler vars/secrets): GH_CLIENT_ID, GH_CLIENT_SECRET, ALLOWED_ORIGINS
+// (comma-separated origins). Single source: index.mjs adapts this handler to
+// the Workers runtime; the Node test suite requires it directly. Tokens and
+// codes are never logged.
+
+function corsHeaders(origin) {
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Vary': 'Origin',
+  };
+}
+
+function allowedOrigin(request, env) {
+  var origin = request.headers.get('Origin') || '';
+  var allowed = (env.ALLOWED_ORIGINS || '').split(',')
+    .map(function (s) { return s.trim(); })
+    .filter(Boolean);
+  return allowed.indexOf(origin) !== -1 ? origin : null;
+}
+
+function json(obj, status, origin) {
+  var headers = { 'Content-Type': 'application/json' };
+  if (origin) Object.assign(headers, corsHeaders(origin));
+  return new Response(JSON.stringify(obj), { status: status, headers: headers });
+}
+
+async function handleExchange(request, env, fetchImpl) {
+  var origin = allowedOrigin(request, env);
+  if (!origin) return json({ error: 'origin not allowed' }, 403, null);
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders(origin) });
+  }
+  if (request.method !== 'POST') return json({ error: 'method not allowed' }, 405, origin);
+
+  var body = null;
+  try { body = await request.json(); } catch (e) { /* not JSON */ }
+  if (!body || typeof body.code !== 'string' || !body.code) {
+    return json({ error: 'missing code' }, 400, origin);
+  }
+
+  var ghResp = await fetchImpl('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+    body: JSON.stringify({
+      client_id: env.GH_CLIENT_ID,
+      client_secret: env.GH_CLIENT_SECRET,
+      code: body.code,
+    }),
+  });
+  var gh = null;
+  try { gh = await ghResp.json(); } catch (e) { gh = {}; }
+  if (!ghResp.ok || gh.error || !gh.access_token) {
+    return json({ error: gh.error || ('github http ' + ghResp.status) }, 502, origin);
+  }
+  return json({ token: gh.access_token }, 200, origin);
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { handleExchange: handleExchange };
+}

--- a/workers/oauth-exchange/index.mjs
+++ b/workers/oauth-exchange/index.mjs
@@ -1,0 +1,8 @@
+// Cloudflare Workers entry: adapts the Node-tested CJS handler to the runtime.
+import exchange from './exchange.js';
+
+export default {
+  fetch(request, env) {
+    return exchange.handleExchange(request, env, fetch);
+  },
+};

--- a/workers/oauth-exchange/wrangler.toml
+++ b/workers/oauth-exchange/wrangler.toml
@@ -1,0 +1,8 @@
+# Deploy: `wrangler deploy` from this directory.
+# Secrets (once): `wrangler secret put GH_CLIENT_ID`, `wrangler secret put GH_CLIENT_SECRET`
+name = "sy-subtitles-oauth"
+main = "index.mjs"
+compatibility_date = "2026-07-01"
+
+[vars]
+ALLOWED_ORIGINS = "https://sy-tools.github.io,http://localhost:8000,http://127.0.0.1:8000"


### PR DESCRIPTION
## Що це

Повна GitHub-авторизація в review SPA — **усі 4 фази в одному PR** (за рішенням користувача).

### Auth-ядро
- **GitHub App** (не OAuth App): токен діє лише на цей репозиторій, лише Issues/Contents/PRs; експірація user-токенів вимкнена — логін один раз.
- **Cloudflare Worker** `workers/oauth-exchange/` — обмін code→token (єдиний крок із client_secret). CORS-allowlist, секрети у wrangler, без логування токенів.
- Модулі `site/js/github_auth.js` (CSRF state, колбек, сховище) та `site/js/github_api.js` (клієнт із fetch-інжекцією).
- Кнопка «Увійти» / аватар у хедері; `Authorization` на Trees API (5000 req/h); 401 → тихий логаут + retry без токена.

### Дії при вході
- **«Create PR» у review-режимі**: гілка `review/<talk>--<login>--<HHMMSS>` → коміт зібраного файла (SRT з таймкодами / транскрипт byte-exact) → PR, тіло = markdown ішʼю (спільний builder). Далі підхоплює наявний sync-subtitles.yml.
- **Ішʼю через API**: «Create Issue» (review і preview) робить POST /issues — без ліміту 8000 символів URL і буфера.
- **«Take for review»** на картках індексу: асайнить наявне ішʼю або створює (`Review: <talk_id>` + `talk-review` — контракт sync-review-status.py) з оптимістичним оновленням бейджа.
- **Чип/фільтр «mine»** + акцент карток промов, призначених на користувача.
- **Add Talk → PR** однією кнопкою.

### Недеструктивність
- Порожній `APP_GH_CLIENT_ID` (як зараз) → жодного нового UI, поведінка байт-у-байт (окремий e2e-гейт).
- Без логіна всі старі флоу (префілд-ішʼю, буфер+github.com/edit) працюють без змін.

### Тести
- Node: exchange-Worker (7), github_auth (10), github_api читання+запис (20), index_url_state 'mine'. Разом 656 JS-тестів зелені.
- Playwright e2e: `test_spa_auth_e2e.py` (4 — логін/логаут/state/дефолт) + `test_spa_auth_actions_e2e.py` (6 — асайн наявного ішʼю, створення ішʼю, mine-фільтр/підсвітка, PR з редагувань із перевіркою base64-вмісту коміту, ішʼю через API, signed-out без нового UI).
- Регресія: всі 337 наявних preview/review e2e зелені (рефакторинг openEditor/createReviewIssue без змін поведінки), smoke, 652 pytest, ruff.
- Жива перевірка в браузері на реальних даних зі скриншотами.

### Активація (разово, після мерджа)
`docs/github-app-setup.md`: створити GitHub App у sy-tools → `wrangler deploy` + секрети → вписати `APP_GH_CLIENT_ID`/`APP_GH_EXCHANGE_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)