### PR TITLE
sec(worker): prod OAuth Worker trusts only the Pages origin

### DIFF
--- a/tests/test_worker_origins.py
+++ b/tests/test_worker_origins.py
@@ -1,0 +1,48 @@
+"""Guards for the OAuth-exchange Worker's CORS origin allowlist.
+
+The DEPLOYED (production) Worker must only trust the GitHub Pages origin: the
+CI deploy reads ALLOWED_ORIGINS from wrangler.toml's [vars], so a localhost
+entry there would let a page served from any localhost:8000 use the production
+Worker to exchange codes. Local development never hits the production Worker
+(the injected SPA points at `wrangler dev` on localhost:8787), so localhost
+belongs only in .dev.vars — read by `wrangler dev`, never shipped.
+"""
+
+import re
+from pathlib import Path
+
+WORKER = Path(__file__).resolve().parents[1] / "workers" / "oauth-exchange"
+WRANGLER = WORKER / "wrangler.toml"
+DEV_VARS_EXAMPLE = WORKER / ".dev.vars.example"
+
+PROD_ORIGIN = "https://sy-tools.github.io"
+LOCAL_ORIGINS = ("localhost", "127.0.0.1")
+
+
+def _wrangler_allowed_origins() -> list[str]:
+    text = WRANGLER.read_text(encoding="utf-8")
+    m = re.search(r'^\s*ALLOWED_ORIGINS\s*=\s*"([^"]*)"', text, re.MULTILINE)
+    assert m, "wrangler.toml must set ALLOWED_ORIGINS in [vars]"
+    return [o.strip() for o in m.group(1).split(",") if o.strip()]
+
+
+def test_prod_wrangler_allows_only_the_pages_origin() -> None:
+    origins = _wrangler_allowed_origins()
+    assert origins == [PROD_ORIGIN], f"the deployed Worker must trust only {PROD_ORIGIN}, got {origins}"
+
+
+def test_prod_wrangler_has_no_localhost_origin() -> None:
+    joined = ",".join(_wrangler_allowed_origins())
+    for local in LOCAL_ORIGINS:
+        assert local not in joined, f"{local} must not be a trusted origin on the prod Worker"
+
+
+def test_dev_vars_example_documents_localhost_for_local_dev() -> None:
+    """`wrangler dev` needs localhost trusted — .dev.vars.example must show how,
+    including the prod origin so a dev can test against either."""
+    text = DEV_VARS_EXAMPLE.read_text(encoding="utf-8")
+    m = re.search(r"^\s*ALLOWED_ORIGINS\s*=\s*(.+)$", text, re.MULTILINE)
+    assert m, ".dev.vars.example must show ALLOWED_ORIGINS for local dev"
+    value = m.group(1).strip()
+    assert "localhost:8000" in value
+    assert PROD_ORIGIN in value

--- a/workers/oauth-exchange/.dev.vars.example
+++ b/workers/oauth-exchange/.dev.vars.example
@@ -2,3 +2,9 @@
 # Values come from the GitHub App (docs/github-app-setup.md, step 1).
 GH_CLIENT_ID=Iv1.xxxxxxxxxxxxxxxx
 GH_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Local-only origin allowlist: adds localhost to the prod origin so the
+# injected SPA (serve_auth_local.py, exchange URL -> localhost:8787) is
+# trusted by `wrangler dev`. The deployed Worker uses wrangler.toml's value
+# (prod origin only) — this override never ships.
+ALLOWED_ORIGINS=https://sy-tools.github.io,http://localhost:8000,http://127.0.0.1:8000

--- a/workers/oauth-exchange/wrangler.toml
+++ b/workers/oauth-exchange/wrangler.toml
@@ -4,5 +4,7 @@ name = "sy-subtitles-oauth"
 main = "index.mjs"
 compatibility_date = "2026-07-01"
 
+# Production trusts only the GitHub Pages origin. Local dev overrides this
+# with localhost via .dev.vars (read by `wrangler dev`, never deployed).
 [vars]
-ALLOWED_ORIGINS = "https://sy-tools.github.io,http://localhost:8000,http://127.0.0.1:8000"
+ALLOWED_ORIGINS = "https://sy-tools.github.io"


### PR DESCRIPTION
## Що і навіщо

Розгорнутий exchange-воркер читає `ALLOWED_ORIGINS` із `wrangler.toml`, і там був `localhost:8000`/`127.0.0.1:8000`. Це означало, що будь-яка сторінка на цих локальних origin могла використати **продакшн**-воркер для обміну `code→token`. Локальна розробка прод-воркера не торкається (injected-SPA спрямовує `wrangler dev` на `localhost:8787`), тож localhost має жити лише в `.dev.vars`.

## Зміни
- `wrangler.toml` `[vars]` тепер довіряє **тільки** `https://sy-tools.github.io`.
- `.dev.vars.example` документує localhost-override для `wrangler dev` (read-only локально, ніколи не деплоїться).
- Новий guard `tests/test_worker_origins.py` (3 тести): прод-allowlist = лише Pages-origin, без localhost; `.dev.vars.example` показує localhost для локалки.

## Наслідки деплою
Мердж у `main` торкається `workers/oauth-exchange/**` → `deploy-worker.yml` перерозгорне воркер уже з prod-only origin-гейтом.

🤖 Generated with [Claude Code](https://claude.com/claude-code)