### PR TITLE
ci(sync-subtitles): skip-ci on bot sync commit to stop self-trigger

### DIFF
--- a/.github/workflows/sync-subtitles.yml
+++ b/.github/workflows/sync-subtitles.yml
@@ -48,7 +48,13 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add talks/*/*/final/uk.srt talks/*/transcript_uk.txt
           git diff --cached --quiet && { echo "No changes to commit"; exit 0; }
-          git commit -m "Sync subtitles and transcript edits"
+          # [skip ci]: this commit is the RESULT of the sync. Pushing it back
+          # re-triggers this same pull_request workflow (paths match
+          # final/uk.srt); that second run sees both transcript and SRT
+          # changed vs the PR base and runs the reverse SRT->transcript pass,
+          # which conflicts with the just-applied edit and fails red. The
+          # skip-ci token stops the bot commit from recursively triggering us.
+          git commit -m "Sync subtitles and transcript edits [skip ci]"
           git push
 
       - name: Fail if sync had errors

--- a/tests/test_workflow_audit_regressions.py
+++ b/tests/test_workflow_audit_regressions.py
@@ -110,3 +110,19 @@ def test_sync_review_status_unlabeled_checks_removed_label() -> None:
     data = yaml.safe_load((WORKFLOWS / "sync-review-status.yml").read_text(encoding="utf-8"))
     cond = data["jobs"]["sync"]["if"]
     assert "github.event.label.name" in cond, f"gate ignores the removed label: {cond}"
+
+
+def test_sync_subtitles_commit_skips_ci_to_avoid_self_trigger() -> None:
+    """The sync job commits the synced uk.srt/transcript as github-actions[bot]
+    and pushes to the PR branch. That push re-triggers this same pull_request
+    workflow (its paths include final/uk.srt); the second run then sees BOTH
+    transcript and SRT changed vs the PR base and runs the reverse
+    SRT->transcript pass, which conflicts with the already-applied edit and
+    fails red. The bot's own sync commit must carry a skip-ci token so it does
+    not recursively trigger the workflow."""
+    text = (WORKFLOWS / "sync-subtitles.yml").read_text(encoding="utf-8")
+    commit_lines = [line for line in text.splitlines() if "git commit -m" in line]
+    assert commit_lines, "no `git commit -m` line found in sync-subtitles.yml"
+    skip_token = re.compile(r"\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]")
+    for line in commit_lines:
+        assert skip_token.search(line), f"sync commit message lacks a skip-ci token (self-trigger risk): {line.strip()}"


### PR DESCRIPTION
## Проблема

`sync-subtitles.yml` на review-PR синкає правки `transcript_uk.txt` ↔ `final/uk.srt`, **комітить результат від імені `github-actions[bot]` і пушить у гілку PR**. Цей бот-коміт сам ре-тригерить той самий `pull_request`-воркфлоу (його `paths` містять `final/uk.srt`).

Другий (самотригернутий) запуск бачить, що vs база PR змінені **обидва** файли → запускає **зворотний** прохід `SRT→transcript` і падає 🔴:

```
Block 6: cannot find «…зв'язку між цими дв» in transcript
```

бо правку вже застосовано в транскрипті. Патерн повторюваний (напр. 06-23/06-28/06-30, і свіже #720).

## Фікс

Додаю нативний `[skip ci]` у коміт-меседж бота — коміт-**результат** синку більше не породжує запуск воркфлоу, тож зворотного проходу й червоного не буде. На `main` немає required status checks, тож пропущений запуск нічого не лишає в «pending».

Альтернативу (step-гард) відкинуто як важчу; за відсутності required-чеків `[skip ci]` — найчистіша коренева причина.

## Тест (TDD)

`test_sync_subtitles_commit_skips_ci_to_avoid_self_trigger` — структурний гард: коміт-меседж у `sync-subtitles.yml` мусить містити skip-ci токен. RED до фіксу, GREEN після.

🤖 Generated with [Claude Code](https://claude.com/claude-code)