### PR TITLE
feat(pipeline): oauth_token input — selectable Claude account per run

### DIFF
--- a/.github/workflows/subtitle-pipeline.yml
+++ b/.github/workflows/subtitle-pipeline.yml
@@ -120,9 +120,12 @@ env:
   MODEL_BUILD: ${{ (inputs.build_model != 'same-as-model' && inputs.build_model) || inputs.model || 'claude-opus-4-8' }}
   # Обліковий запис Claude для LLM-кроків. Конвенція: oauth_token=X бере
   # секрет CLAUDE_CODE_OAUTH_TOKEN_X (значення опції = суфікс, верхній
-  # регістр — у виразах нема upper()). Порожній інпут (push) або
-  # відсутній/порожній іменований секрет відкочуються на дефолтний токен.
-  OAUTH_TOKEN: ${{ (inputs.oauth_token && inputs.oauth_token != 'default' && secrets[format('CLAUDE_CODE_OAUTH_TOKEN_{0}', inputs.oauth_token)]) || secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+  # регістр — у виразах нема upper()). Дефолтний секрет — ЛИШЕ для
+  # 'default'/порожнього інпуту (push): якщо іменований секрет відсутній
+  # чи порожній, значення лишається '' і guard-кроки валять запуск — тихий
+  # відкат непомітно палив би ліміти основного акаунта. Хвіст || '' щоб
+  # false-гілка не стала літеральним рядком 'false' у ролі токена.
+  OAUTH_TOKEN: ${{ (inputs.oauth_token && inputs.oauth_token != 'default' && secrets[format('CLAUDE_CODE_OAUTH_TOKEN_{0}', inputs.oauth_token)]) || ((!inputs.oauth_token || inputs.oauth_token == 'default') && secrets.CLAUDE_CODE_OAUTH_TOKEN) || '' }}
 
 jobs:
   discover:
@@ -277,6 +280,18 @@ jobs:
         run: |
           echo "bun=$(which bun)" >> "$GITHUB_OUTPUT"
           echo "claude=$(which claude)" >> "$GITHUB_OUTPUT"
+
+      - name: Verify Claude token selection
+        # Fail-fast: обраний акаунт без секрета НЕ відкочується на дефолтний
+        # (тихий відкат палив би ліміти основного акаунта непомітно).
+        if: inputs.dry_run != true
+        env:
+          SELECTED: ${{ inputs.oauth_token }}
+        run: |
+          if [ -z "$OAUTH_TOKEN" ]; then
+            echo "::error::oauth_token='${SELECTED}' не резолвиться: секрет CLAUDE_CODE_OAUTH_TOKEN_${SELECTED} відсутній або порожній — відкату на default немає, додайте секрет або запустіть з oauth_token=default"
+            exit 1
+          fi
 
       - name: Translate (dry-run fake)
         if: inputs.translate != false && inputs.dry_run == true
@@ -693,6 +708,17 @@ jobs:
         run: |
           echo "bun=$(which bun)" >> "$GITHUB_OUTPUT"
           echo "claude=$(which claude)" >> "$GITHUB_OUTPUT"
+
+      - name: Verify Claude token selection
+        # Fail-fast: обраний акаунт без секрета НЕ відкочується на дефолтний.
+        if: inputs.dry_run != true
+        env:
+          SELECTED: ${{ inputs.oauth_token }}
+        run: |
+          if [ -z "$OAUTH_TOKEN" ]; then
+            echo "::error::oauth_token='${SELECTED}' не резолвиться: секрет CLAUDE_CODE_OAUTH_TOKEN_${SELECTED} відсутній або порожній — відкату на default немає, додайте секрет або запустіть з oauth_token=default"
+            exit 1
+          fi
 
       - name: Build timecodes (dry-run fake)
         if: inputs.dry_run == true

--- a/.github/workflows/subtitle-pipeline.yml
+++ b/.github/workflows/subtitle-pipeline.yml
@@ -58,6 +58,13 @@ on:
           - claude-fable-5
           - claude-sonnet-5
         default: same-as-model
+      oauth_token:
+        description: 'Claude account: default = CLAUDE_CODE_OAUTH_TOKEN, інше значення X = CLAUDE_CODE_OAUTH_TOKEN_X (порожній секрет відкочується на default)'
+        type: choice
+        options:
+          - default
+          - EXTRA
+        default: default
   workflow_call:
     inputs:
       talk_id:
@@ -93,6 +100,10 @@ on:
         description: 'Override model for the build step only; empty or same-as-model follows `model`'
         type: string
         default: ''
+      oauth_token:
+        description: 'Claude account: default = CLAUDE_CODE_OAUTH_TOKEN, інше значення X = CLAUDE_CODE_OAUTH_TOKEN_X'
+        type: string
+        default: default
 
 permissions:
   contents: write
@@ -107,6 +118,11 @@ env:
   # than review (e.g. review=Fable, build=Opus). The 'same-as-model'
   # sentinel (choice inputs can't default to '') follows MODEL_HEAVY.
   MODEL_BUILD: ${{ (inputs.build_model != 'same-as-model' && inputs.build_model) || inputs.model || 'claude-opus-4-8' }}
+  # Обліковий запис Claude для LLM-кроків. Конвенція: oauth_token=X бере
+  # секрет CLAUDE_CODE_OAUTH_TOKEN_X (значення опції = суфікс, верхній
+  # регістр — у виразах нема upper()). Порожній інпут (push) або
+  # відсутній/порожній іменований секрет відкочуються на дефолтний токен.
+  OAUTH_TOKEN: ${{ (inputs.oauth_token && inputs.oauth_token != 'default' && secrets[format('CLAUDE_CODE_OAUTH_TOKEN_{0}', inputs.oauth_token)]) || secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
 jobs:
   discover:
@@ -279,7 +295,7 @@ jobs:
         if: inputs.translate != false && inputs.dry_run != true
         uses: anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a  # v1.0.165
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ env.OAUTH_TOKEN }}
           path_to_bun_executable: ${{ steps.tools.outputs.bun }}
           path_to_claude_code_executable: ${{ steps.tools.outputs.claude }}
           claude_args: "--max-turns 80 --dangerously-skip-permissions --effort xhigh --model ${{ env.MODEL_HEAVY }}"
@@ -386,7 +402,7 @@ jobs:
         if: inputs.review != false && inputs.dry_run != true
         uses: anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a  # v1.0.165
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ env.OAUTH_TOKEN }}
           path_to_bun_executable: ${{ steps.tools.outputs.bun }}
           path_to_claude_code_executable: ${{ steps.tools.outputs.claude }}
           claude_args: "--max-turns 60 --dangerously-skip-permissions --effort xhigh --model ${{ env.MODEL_HEAVY }}"
@@ -694,7 +710,7 @@ jobs:
         env:
           CLAUDE_CODE_MAX_OUTPUT_TOKENS: "128000"
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ env.OAUTH_TOKEN }}
           path_to_bun_executable: ${{ steps.tools.outputs.bun }}
           path_to_claude_code_executable: ${{ steps.tools.outputs.claude }}
           claude_args: "--max-turns 80 --dangerously-skip-permissions --effort high --model ${{ env.MODEL_BUILD }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,11 @@ Source language: English. Target language: Ukrainian.
 3. Trigger pipeline: `gh workflow run subtitle-pipeline.yml -f talk_id={date}_{slug}`
    Optional inputs: `model=claude-opus-4-8|claude-fable-5|claude-sonnet-5`
    (default `claude-opus-4-8`), `build_model=...` (build-step-only override,
-   default `same-as-model`), `timing_source=auto|whisper|en-srt` (default `auto` —
-   en-srt if present, else whisper), `dry_run=true` (replay snapshots via
-   `tools.fake_llm`, no commit).
+   default `same-as-model`), `oauth_token=default|EXTRA` (Claude account:
+   value `X` → secret `CLAUDE_CODE_OAUTH_TOKEN_X`, empty/missing secret falls
+   back to `CLAUDE_CODE_OAUTH_TOKEN`), `timing_source=auto|whisper|en-srt`
+   (default `auto` — en-srt if present, else whisper), `dry_run=true` (replay
+   snapshots via `tools.fake_llm`, no commit).
 4. Pipeline runs automatically:
    - **Whisper**: speech detection → `whisper.json` (word-level timestamps)
    - **Translate**: Claude agent translates EN → UK → `transcript_uk.txt`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,10 +21,11 @@ Source language: English. Target language: Ukrainian.
    Optional inputs: `model=claude-opus-4-8|claude-fable-5|claude-sonnet-5`
    (default `claude-opus-4-8`), `build_model=...` (build-step-only override,
    default `same-as-model`), `oauth_token=default|EXTRA` (Claude account:
-   value `X` → secret `CLAUDE_CODE_OAUTH_TOKEN_X`, empty/missing secret falls
-   back to `CLAUDE_CODE_OAUTH_TOKEN`), `timing_source=auto|whisper|en-srt`
-   (default `auto` — en-srt if present, else whisper), `dry_run=true` (replay
-   snapshots via `tools.fake_llm`, no commit).
+   value `X` → secret `CLAUDE_CODE_OAUTH_TOKEN_X`; missing/empty named secret
+   FAILS the run — no silent fallback to the default account),
+   `timing_source=auto|whisper|en-srt` (default `auto` — en-srt if present,
+   else whisper), `dry_run=true` (replay snapshots via `tools.fake_llm`,
+   no commit).
 4. Pipeline runs automatically:
    - **Whisper**: speech detection → `whisper.json` (word-level timestamps)
    - **Translate**: Claude agent translates EN → UK → `transcript_uk.txt`

--- a/tests/test_pipeline_token_input.py
+++ b/tests/test_pipeline_token_input.py
@@ -4,8 +4,13 @@ Convention: the ``oauth_token`` input names the account. ``default`` (or an
 empty value on push-triggered runs) uses ``secrets.CLAUDE_CODE_OAUTH_TOKEN``;
 any other value ``X`` uses ``secrets.CLAUDE_CODE_OAUTH_TOKEN_X`` (option
 values are literal uppercase suffixes — GH expressions have no upper()).
-An unset/empty named secret must fall back to the default token, so a typo
-or missing secret degrades gracefully instead of running token-less.
+
+Fail-fast: when a named account is selected and its secret is missing or
+empty, the run must FAIL before any LLM step — silently falling back to the
+default account would burn the primary account's weekly limits unnoticed.
+The env expression resolves to '' in that case and explicit guard steps
+abort; it must also never leak a boolean (a bare ``a && b`` expression that
+evaluates false would stringify to ``'false'`` and be sent as the token).
 """
 
 from pathlib import Path
@@ -46,15 +51,33 @@ def test_oauth_token_input_on_dispatch_and_call() -> None:
     assert call["oauth_token"].get("default") == "default"
 
 
-def test_oauth_token_env_convention_and_fallback() -> None:
+def test_oauth_token_env_no_silent_fallback() -> None:
     env = _load()["env"]
     expr = str(env.get("OAUTH_TOKEN", ""))
     assert "CLAUDE_CODE_OAUTH_TOKEN_{0}" in expr, (
         f"OAUTH_TOKEN must resolve the named secret via format('CLAUDE_CODE_OAUTH_TOKEN_{{0}}', …), got: {expr!r}"
     )
     assert "inputs.oauth_token" in expr, f"OAUTH_TOKEN must be driven by inputs.oauth_token, got: {expr!r}"
-    assert "secrets.CLAUDE_CODE_OAUTH_TOKEN" in expr, (
-        f"OAUTH_TOKEN must fall back to the default secret (push runs, empty named secret), got: {expr!r}"
+    # the default secret may be used ONLY behind the explicit == 'default' /
+    # empty-input condition — a bare `|| secrets.CLAUDE_CODE_OAUTH_TOKEN`
+    # tail after the named lookup is the silent-fallback bug shape
+    assert "inputs.oauth_token == 'default'" in expr, (
+        f"default secret must be gated by an explicit == 'default' condition, got: {expr!r}"
+    )
+    tail = expr[expr.index("CLAUDE_CODE_OAUTH_TOKEN_{0}") :]
+    assert not tail.rstrip("}' ").rstrip().endswith("secrets.CLAUDE_CODE_OAUTH_TOKEN"), (
+        f"named-secret miss must NOT fall back to the default secret: {expr!r}"
+    )
+    # boolean-false must never stringify into the token value
+    assert "|| ''" in expr, f"expression must end with || '' so a false branch yields empty, got: {expr!r}"
+
+
+def test_token_guard_steps_fail_on_empty() -> None:
+    text = (WORKFLOWS / "subtitle-pipeline.yml").read_text(encoding="utf-8")
+    guards = [line for line in text.splitlines() if '-z "$OAUTH_TOKEN"' in line]
+    assert len(guards) >= 2, (
+        "expected explicit empty-token guard steps in both LLM jobs "
+        f"(translate-and-review, build-timecodes), found {len(guards)}"
     )
 
 

--- a/tests/test_pipeline_token_input.py
+++ b/tests/test_pipeline_token_input.py
@@ -1,0 +1,66 @@
+"""Structural guard: the pipeline's OAuth token is selectable per run.
+
+Convention: the ``oauth_token`` input names the account. ``default`` (or an
+empty value on push-triggered runs) uses ``secrets.CLAUDE_CODE_OAUTH_TOKEN``;
+any other value ``X`` uses ``secrets.CLAUDE_CODE_OAUTH_TOKEN_X`` (option
+values are literal uppercase suffixes — GH expressions have no upper()).
+An unset/empty named secret must fall back to the default token, so a typo
+or missing secret degrades gracefully instead of running token-less.
+"""
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+
+
+def _load() -> dict:
+    return yaml.safe_load((WORKFLOWS / "subtitle-pipeline.yml").read_text(encoding="utf-8"))
+
+
+def _on(wf: dict) -> dict:
+    # PyYAML parses the bare `on:` key as boolean True.
+    return wf.get("on", wf.get(True))
+
+
+def test_oauth_token_input_on_dispatch_and_call() -> None:
+    on = _on(_load())
+
+    dispatch = on["workflow_dispatch"]["inputs"]
+    assert "oauth_token" in dispatch, "workflow_dispatch is missing the `oauth_token` input"
+    assert dispatch["oauth_token"].get("type") == "choice"
+    assert dispatch["oauth_token"].get("default") == "default"
+    options = dispatch["oauth_token"].get("options", [])
+    assert "default" in options
+    assert "EXTRA" in options
+    # non-default options are literal secret-name suffixes; expressions have
+    # no upper(), so lowercase options would silently miss the secret
+    for opt in options:
+        if opt != "default":
+            assert opt == opt.upper(), f"non-default option must be an uppercase suffix: {opt!r}"
+
+    call = on["workflow_call"]["inputs"]
+    assert "oauth_token" in call, "workflow_call is missing the `oauth_token` input"
+    assert call["oauth_token"].get("type") == "string"
+    assert call["oauth_token"].get("default") == "default"
+
+
+def test_oauth_token_env_convention_and_fallback() -> None:
+    env = _load()["env"]
+    expr = str(env.get("OAUTH_TOKEN", ""))
+    assert "CLAUDE_CODE_OAUTH_TOKEN_{0}" in expr, (
+        f"OAUTH_TOKEN must resolve the named secret via format('CLAUDE_CODE_OAUTH_TOKEN_{{0}}', …), got: {expr!r}"
+    )
+    assert "inputs.oauth_token" in expr, f"OAUTH_TOKEN must be driven by inputs.oauth_token, got: {expr!r}"
+    assert "secrets.CLAUDE_CODE_OAUTH_TOKEN" in expr, (
+        f"OAUTH_TOKEN must fall back to the default secret (push runs, empty named secret), got: {expr!r}"
+    )
+
+
+def test_all_claude_steps_use_selected_token() -> None:
+    text = (WORKFLOWS / "subtitle-pipeline.yml").read_text(encoding="utf-8")
+    lines = [line.strip() for line in text.splitlines() if "claude_code_oauth_token:" in line]
+    assert len(lines) >= 3, f"expected 3+ claude-code-action steps, found {len(lines)}"
+    for line in lines:
+        assert "env.OAUTH_TOKEN" in line, f"step must use the selected token (env.OAUTH_TOKEN): {line}"


### PR DESCRIPTION
## Що
- Інпут `oauth_token` (dispatch: choice `default`/`EXTRA`; call: string, default `default`) → `env.OAUTH_TOKEN`.
- Конвенція: значення `X` → секрет `CLAUDE_CODE_OAUTH_TOKEN_X` (динамічний лукап `secrets[format(...)]`; значення опції = суфікс у верхньому регістрі, бо у виразах GH нема `upper()`).
- **Fail-fast (за ревю):** відсутній/порожній іменований секрет → `OAUTH_TOKEN=''` → guard-кроки в обох LLM-джобах валять запуск з явною помилкою **до** будь-якого LLM-кроку. Жодного тихого відкату на дефолтний акаунт (він непомітно палив би ліміти основного). Дефолтний секрет — лише за явної умови `== 'default'`/порожнього інпуту (push). Хвіст `|| ''` — щоб false-гілка виразу не стала літеральним `'false'` у ролі токена.
- Усі 3 LLM-кроки читають `env.OAUTH_TOKEN`; CLAUDE.md задокументовано.

## Навіщо
Тижневі scoped-ліміти — пер-акаунт. Другий акаунт дозволяє продовжити корпусний свіп після вичерпання вікна основного (зараз fable 97%).

## Використання
1. Додати секрет `CLAUDE_CODE_OAUTH_TOKEN_EXTRA` (з `claude setup-token` під другим акаунтом).
2. `gh workflow run subtitle-pipeline.yml -f talk_id=… -f oauth_token=EXTRA …`
Новий акаунт = новий секрет + нова опція у списку.

## Тести
TDD (RED→GREEN×2): `tests/test_pipeline_token_input.py` — інпути dispatch+call; вираз без тихого відкату (default лише за `== 'default'`, хвіст `|| ''`); guard-кроки в обох джобах; всі кроки на `env.OAUTH_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)