### PR TITLE
style(pipeline): English comments/messages for the oauth_token feature

### DIFF
--- a/.github/workflows/subtitle-pipeline.yml
+++ b/.github/workflows/subtitle-pipeline.yml
@@ -59,7 +59,7 @@ on:
           - claude-sonnet-5
         default: same-as-model
       oauth_token:
-        description: 'Claude account: default = CLAUDE_CODE_OAUTH_TOKEN, інше значення X = CLAUDE_CODE_OAUTH_TOKEN_X (порожній секрет відкочується на default)'
+        description: 'Claude account: default = CLAUDE_CODE_OAUTH_TOKEN; any other value X = CLAUDE_CODE_OAUTH_TOKEN_X (missing/empty named secret fails the run)'
         type: choice
         options:
           - default
@@ -101,7 +101,7 @@ on:
         type: string
         default: ''
       oauth_token:
-        description: 'Claude account: default = CLAUDE_CODE_OAUTH_TOKEN, інше значення X = CLAUDE_CODE_OAUTH_TOKEN_X'
+        description: 'Claude account: default = CLAUDE_CODE_OAUTH_TOKEN; any other value X = CLAUDE_CODE_OAUTH_TOKEN_X'
         type: string
         default: default
 
@@ -118,13 +118,14 @@ env:
   # than review (e.g. review=Fable, build=Opus). The 'same-as-model'
   # sentinel (choice inputs can't default to '') follows MODEL_HEAVY.
   MODEL_BUILD: ${{ (inputs.build_model != 'same-as-model' && inputs.build_model) || inputs.model || 'claude-opus-4-8' }}
-  # Обліковий запис Claude для LLM-кроків. Конвенція: oauth_token=X бере
-  # секрет CLAUDE_CODE_OAUTH_TOKEN_X (значення опції = суфікс, верхній
-  # регістр — у виразах нема upper()). Дефолтний секрет — ЛИШЕ для
-  # 'default'/порожнього інпуту (push): якщо іменований секрет відсутній
-  # чи порожній, значення лишається '' і guard-кроки валять запуск — тихий
-  # відкат непомітно палив би ліміти основного акаунта. Хвіст || '' щоб
-  # false-гілка не стала літеральним рядком 'false' у ролі токена.
+  # Claude account for the LLM steps. Convention: oauth_token=X reads
+  # secrets.CLAUDE_CODE_OAUTH_TOKEN_X (option value is the literal
+  # uppercase suffix — expressions have no upper()). The default secret is
+  # used ONLY for 'default' / empty input (push runs): when the named
+  # secret is missing or empty the value stays '' and the guard steps fail
+  # the run — a silent fallback would burn the primary account's weekly
+  # limits unnoticed. The || '' tail keeps a false branch from
+  # stringifying into a literal 'false' token.
   OAUTH_TOKEN: ${{ (inputs.oauth_token && inputs.oauth_token != 'default' && secrets[format('CLAUDE_CODE_OAUTH_TOKEN_{0}', inputs.oauth_token)]) || ((!inputs.oauth_token || inputs.oauth_token == 'default') && secrets.CLAUDE_CODE_OAUTH_TOKEN) || '' }}
 
 jobs:
@@ -282,14 +283,15 @@ jobs:
           echo "claude=$(which claude)" >> "$GITHUB_OUTPUT"
 
       - name: Verify Claude token selection
-        # Fail-fast: обраний акаунт без секрета НЕ відкочується на дефолтний
-        # (тихий відкат палив би ліміти основного акаунта непомітно).
+        # Fail-fast: a selected account whose secret is missing must NOT
+        # fall back to the default token (that would silently burn the
+        # primary account's limits).
         if: inputs.dry_run != true
         env:
           SELECTED: ${{ inputs.oauth_token }}
         run: |
           if [ -z "$OAUTH_TOKEN" ]; then
-            echo "::error::oauth_token='${SELECTED}' не резолвиться: секрет CLAUDE_CODE_OAUTH_TOKEN_${SELECTED} відсутній або порожній — відкату на default немає, додайте секрет або запустіть з oauth_token=default"
+            echo "::error::oauth_token='${SELECTED}' did not resolve: secret CLAUDE_CODE_OAUTH_TOKEN_${SELECTED} is missing or empty — there is no fallback to default; add the secret or rerun with oauth_token=default"
             exit 1
           fi
 
@@ -710,13 +712,14 @@ jobs:
           echo "claude=$(which claude)" >> "$GITHUB_OUTPUT"
 
       - name: Verify Claude token selection
-        # Fail-fast: обраний акаунт без секрета НЕ відкочується на дефолтний.
+        # Fail-fast: a selected account whose secret is missing must NOT
+        # fall back to the default token.
         if: inputs.dry_run != true
         env:
           SELECTED: ${{ inputs.oauth_token }}
         run: |
           if [ -z "$OAUTH_TOKEN" ]; then
-            echo "::error::oauth_token='${SELECTED}' не резолвиться: секрет CLAUDE_CODE_OAUTH_TOKEN_${SELECTED} відсутній або порожній — відкату на default немає, додайте секрет або запустіть з oauth_token=default"
+            echo "::error::oauth_token='${SELECTED}' did not resolve: secret CLAUDE_CODE_OAUTH_TOKEN_${SELECTED} is missing or empty — there is no fallback to default; add the secret or rerun with oauth_token=default"
             exit 1
           fi
 


### PR DESCRIPTION
Cherry-pick з гілки #723: англомовна зачистка приїхала в гілку вже ПІСЛЯ мерджу PR (мертва гілка), тож на main лишилась українська версія коментарів/повідомлень oauth_token-фічі. Тут — лише переклад коментарів, описів інпутів і ::error::-повідомлень англійською за конвенцією репо. Український контент промптів перекладача не змінено. Поведінка без змін.

🤖 Generated with [Claude Code](https://claude.com/claude-code)