### PR TITLE
fix(ci): serialize review-status syncs (job-level concurrency, no cancel)

### DIFF
--- a/.github/workflows/sync-review-status.yml
+++ b/.github/workflows/sync-review-status.yml
@@ -14,6 +14,16 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    # Serialize syncs: rapid issue events (e.g. claiming two talks seconds
+    # apart) used to spawn parallel runs that raced bot-pr.sh from the same
+    # base into duplicate stuck PRs (#728/#729). Job-level on purpose —
+    # workflow-level concurrency is ignored when this file runs via
+    # workflow_call. cancel-in-progress stays false: an in-flight sync is a
+    # multi-step sequence (label edits → regenerate → PR → merge) and must
+    # finish; new runs queue behind it.
+    concurrency:
+      group: review-status-sync
+      cancel-in-progress: false
     # For 'unlabeled' the issue's label list reflects the state AFTER removal,
     # so removing the last review:* label would skip the sync — also check the
     # removed label itself (github.event.label.name).

--- a/tests/test_sync_review_status_concurrency.py
+++ b/tests/test_sync_review_status_concurrency.py
@@ -1,0 +1,42 @@
+"""Structural guard: review-status syncs are serialized, never cancelled.
+
+Claiming two talks seconds apart fires two `issues` events; the parallel
+sync runs raced bot-pr.sh from the same base and produced duplicate stuck
+"Update review status" PRs (#728/#729). A concurrency group must queue the
+second run behind the first.
+
+Two properties matter:
+
+* The group must be on the JOB, not the workflow: this file also runs via
+  ``workflow_call`` (subtitle-pipeline's sync-status job), and top-level
+  ``concurrency`` of a called workflow is ignored in that context.
+* ``cancel-in-progress`` must stay off: an in-flight sync is a multi-step
+  sequence (label edits -> regenerate -> PR -> merge) and killing it midway
+  leaves half-applied state — the very race this guard exists to prevent.
+"""
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+
+
+def _sync_job() -> dict:
+    wf = yaml.safe_load((WORKFLOWS / "sync-review-status.yml").read_text(encoding="utf-8"))
+    return wf["jobs"]["sync"]
+
+
+def test_sync_job_has_concurrency_group() -> None:
+    conc = _sync_job().get("concurrency")
+    assert conc, "sync job must declare a job-level concurrency group (workflow-level is ignored under workflow_call)"
+    assert isinstance(conc, dict) and conc.get("group"), f"concurrency must name a group, got: {conc!r}"
+
+
+def test_sync_concurrency_never_cancels_in_progress() -> None:
+    conc = _sync_job().get("concurrency") or {}
+    cancel = conc.get("cancel-in-progress", False)
+    assert cancel is False, (
+        "cancel-in-progress must be false: an in-flight sync is a multi-step "
+        f"process and must finish; queue new runs instead. Got: {cancel!r}"
+    )


### PR DESCRIPTION
## What
The `sync` job in `sync-review-status.yml` gets a concurrency group `review-status-sync`:
- **job-level, not workflow-level** — workflow-level concurrency is ignored when this file runs via `workflow_call` (sync-status from subtitle-pipeline), and the race is also possible between direct and called runs;
- **`cancel-in-progress: false`** — an in-flight sync is a multi-step sequence (label edits → regenerate → PR → merge) and must run to completion; new runs queue behind it. GitHub keeps at most 1 running + 1 pending per group: extra **pending** runs (not yet started) are superseded by newer ones, which is safe here by construction — every run regenerates the full state from all issues, so the last queued run sees the freshest state.

## Why
Today's race: claiming two talks seconds apart → two parallel sync runs → two identical stuck PRs #728/#729 from the same base (closed as duplicates; the content landed via a third run).

## Tests
TDD (RED→GREEN): `tests/test_sync_review_status_concurrency.py` — 2 guards: (1) a job-level group exists; (2) `cancel-in-progress` is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)