### PR TITLE
fix(spa): refresh imperative i18n tooltips on language toggle

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -153,14 +153,18 @@
     return clamp(PREVIEW_SUBS_MIN_PX, h, PREVIEW_SUBS_MAX_PX);
   }
 
-  function makeDragHandle({id, className, title, onMove, onCommit, onReset}) {
+  function makeDragHandle({id, className, titleKey, onMove, onCommit, onReset}) {
     const h = document.createElement('div');
     h.id = id;
     h.className = className;
     h.setAttribute('role','separator');
     h.setAttribute('aria-orientation','horizontal');
-    h.setAttribute('aria-label', title);
-    h.title = title;
+    // Carry the i18n keys so translatePage() re-translates the tooltip/label on
+    // a UI-language toggle — the handle is built imperatively, not from markup.
+    h.setAttribute('data-i18n-title', titleKey);
+    h.setAttribute('data-i18n-aria-label', titleKey);
+    h.setAttribute('aria-label', t(titleKey));
+    h.title = t(titleKey);
     h.tabIndex = 0;
     let pid = null, startY = 0, startVal = 0, cur = 0;
     h.addEventListener('pointerdown', e => {
@@ -208,7 +212,7 @@
       const h = makeDragHandle({
         id: 'preview-player-resize',
         className: 'preview-player-resize',
-        title: t('preview.resize_player'),
+        titleKey: 'preview.resize_player',
         onMove: {
           getStart: () => {
             const cs = getComputedStyle(document.documentElement).getPropertyValue('--preview-player-h').trim();
@@ -231,7 +235,7 @@
       const h = makeDragHandle({
         id: 'preview-subs-resize',
         className: 'preview-subs-resize',
-        title: t('preview.resize_subs'),
+        titleKey: 'preview.resize_subs',
         onMove: {
           getStart: () => {
             // Prefer the live overlay height so first drag picks up the
@@ -5153,6 +5157,10 @@ SPA.toggleLang = function() {
   var btn = document.getElementById('lang-btn');
   if (btn) btn.textContent = currentLang.toUpperCase();
   translatePage();
+  // The avatar tooltip is set imperatively (translated "signed in as" prefix +
+  // the login), so translatePage() — which only touches data-i18n* elements —
+  // can't refresh it. updateAuthUI() re-applies it in the current language.
+  updateAuthUI();
   // Re-render dynamic content
   if (manifest) {
     updateLastModifiedUI();

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -4913,6 +4913,29 @@ class TestClipboardCopyDialog:
         )
 
 
+class TestPreviewResizeHandleI18n:
+    """The preview resize handles are built imperatively (makeDragHandle), so
+    their title/aria-label must carry data-i18n* keys — otherwise a UI language
+    toggle leaves the tooltip stuck in the previous language."""
+
+    def test_resize_handle_tooltip_refreshes_on_language_toggle(self, server, page):
+        page.add_init_script("localStorage.setItem('sy_lang', 'en');")
+        page.set_viewport_size({"width": 1600, "height": 900})
+        goto_spa(page, server, "#/preview/2001-01-01_Test-Talk/Test-Video")
+        page.wait_for_selector("#mock-player", state="visible", timeout=10000)
+        page.wait_for_selector("#preview-player-resize", timeout=10000)
+        before = page.evaluate("document.getElementById('preview-player-resize').title")
+        assert before == "Drag to resize the player"
+        page.click("#lang-btn")
+        handle = "document.getElementById('preview-player-resize')"
+        after_title = page.evaluate(f"{handle}.title")
+        after_aria = page.evaluate(f"{handle}.getAttribute('aria-label')")
+        assert after_title != before, "resize-handle tooltip must refresh on language toggle"
+        expected = page.evaluate("t('preview.resize_player')")
+        assert after_title == expected
+        assert after_aria == expected
+
+
 class TestSubtitleOverlaySize:
     """Subtitle overlay font sizing: width-bound formula, fs-mode baseline,
     and the bidirectional handle→fs-mode mirror."""

--- a/tests/test_spa_auth_e2e.py
+++ b/tests/test_spa_auth_e2e.py
@@ -134,6 +134,23 @@ def test_callback_exchanges_code_and_signs_in(auth_server, auth_page):
     assert page.evaluate("getComputedStyle(document.getElementById('gh-login-btn')).display") == "none"
 
 
+def test_avatar_tooltip_refreshes_on_language_toggle(auth_server, auth_page):
+    """The avatar tooltip carries the translated "signed in as" prefix, but it
+    is set imperatively (the avatar has no data-i18n* attribute), so a UI
+    language toggle must refresh it — otherwise it sticks in the old language."""
+    page = auth_page
+    page.add_init_script("localStorage.setItem('sy_lang', 'en');")
+    page.add_init_script("sessionStorage.setItem('sy_gh_state', 'st1');")
+    page.goto(f"{auth_server}/index.html?code=c1&state=st1")
+    page.wait_for_selector("#gh-avatar", state="visible", timeout=10000)
+    before = page.evaluate("document.getElementById('gh-avatar').title")
+    assert before == "Signed in as tester"
+    page.click("#lang-btn")
+    after = page.evaluate("document.getElementById('gh-avatar').title")
+    assert after != before, "avatar tooltip must refresh on language toggle"
+    assert after == page.evaluate("t('auth.signed_in')") + " tester"
+
+
 def test_avatar_menu_signs_out(auth_server, auth_page):
     page = auth_page
     page.add_init_script("sessionStorage.setItem('sy_gh_state', 'st1');")

--- a/tests/test_spa_i18n_guard.py
+++ b/tests/test_spa_i18n_guard.py
@@ -1,0 +1,122 @@
+"""CI guard against the "sticky tooltip on language toggle" anti-pattern.
+
+``SPA.toggleLang()`` refreshes the UI by calling ``translatePage()``, which
+only rewrites elements carrying a ``data-i18n``/``data-i18n-title``/
+``data-i18n-aria-label``/``data-i18n-placeholder`` attribute. A tooltip or
+label assigned *imperatively* from ``t(...)`` (e.g. ``el.title = t('key')``)
+is invisible to that pass, so unless it is refreshed some other way it sticks
+in the previous language after a toggle — the exact bug this guard prevents.
+
+An imperative ``t(...)`` title/label is allowed only when it is kept fresh by
+one of two established patterns:
+
+* **self-synced** — the same block also sets the matching ``data-i18n-*``
+  attribute (see ``updateToggleBtn`` / ``applyPreviewMode`` / ``makeDragHandle``),
+  so the next ``translatePage()`` re-translates it; or
+* **handler-refreshed / transient** — an explicit ``ALLOWLIST`` entry, each with
+  a reason for why the string stays correct across a language toggle.
+
+Anything else fails this test, forcing a conscious choice: wire ``data-i18n-*``
+(preferred) or justify an allowlist entry.
+
+Scope: this catches the common *direct* form (``.title =``/``aria-label``/
+``.placeholder =`` assigned from ``t(...)`` on one line). It does not chase
+``t(...)`` passed through a helper's arguments — those helpers must set the
+``data-i18n-*`` attributes themselves (``makeDragHandle`` now does).
+
+Runs under the normal ``python -m pytest tests/`` step in ci.yml.
+"""
+
+from pathlib import Path
+
+import pytest
+
+INDEX = Path(__file__).resolve().parent.parent / "site" / "index.html"
+
+# `.title =`, `.placeholder =`, or setAttribute('aria-label', ...) whose RHS
+# calls t(...) on the same line.
+_SURFACES = (".title =", ".placeholder =", "setAttribute('aria-label',", 'setAttribute("aria-label",')
+_DATA_I18N = ("data-i18n-title", "data-i18n-aria-label", "data-i18n-placeholder")
+_WINDOW = 6
+
+# Imperative translated titles/labels that translatePage() never sees but that
+# stay correct across a language toggle for the stated reason. Keys are the
+# stripped source line; keep each reason accurate if you touch the code.
+ALLOWLIST = {
+    # Avatar tooltip is composite ("signed in as" + the GitHub login), so it
+    # can't be a plain data-i18n-title. SPA.toggleLang() calls updateAuthUI(),
+    # which re-applies it in the current language. (test_spa_auth_e2e.py:
+    # test_avatar_tooltip_refreshes_on_language_toggle)
+    "avatar.title = t('auth.signed_in') + ' ' + user.login;",
+    # Theme button title mirrors the current theme mode; SPA.toggleLang()
+    # re-applies it via the themeBtn.title line below.
+    "if (btn) { btn.textContent = icons[mode]; btn.title = t('title.theme.' + mode); }",
+    "if (btn) { btn.textContent = icons[initMode]; btn.title = t('title.theme.' + initMode); }",
+    "if (themeBtn) themeBtn.title = t('title.theme.' + themeMode);",
+    # Passphrase-gate reveal button lives in a modal shown BEFORE the app UI, so
+    # the language toggle isn't reachable while it's up, and it's rebuilt each
+    # time the gate opens.
+    "reveal.setAttribute('aria-label', t('gate.reveal'));",
+    "reveal.title = t('gate.reveal');",
+    "reveal.setAttribute('aria-label', show ? t('gate.hide') : t('gate.reveal'));",
+    "reveal.title = show ? t('gate.hide') : t('gate.reveal');",
+}
+
+
+def _is_imperative_translation(line: str) -> bool:
+    if "t(" not in line:
+        return False
+    if not any(s in line for s in _SURFACES):
+        return False
+    # translatePage() itself IS the engine: it feeds data-i18n-* keys to t().
+    if "t(el.getAttribute(" in line:
+        return False
+    # document.title is the browser-tab title, a different surface re-set on
+    # every view render — not a persistent on-page tooltip/label.
+    return "document.title" not in line
+
+
+def find_violations(text: str):
+    """Return (line_no, stripped_line) for each unguarded imperative t() title."""
+    lines = text.splitlines()
+    out = []
+    for i, line in enumerate(lines):
+        if not _is_imperative_translation(line):
+            continue
+        window = lines[max(0, i - _WINDOW) : i + _WINDOW + 1]
+        if any(key in w for w in window for key in _DATA_I18N):
+            continue  # self-synced: a sibling data-i18n-* keeps it fresh
+        if line.strip() in ALLOWLIST:
+            continue  # documented handler-refreshed / transient exception
+        out.append((i + 1, line.strip()))
+    return out
+
+
+def test_no_unguarded_imperative_translation():
+    violations = find_violations(INDEX.read_text(encoding="utf-8"))
+    assert not violations, (
+        "Imperative t() title/label(s) that translatePage() won't refresh on a "
+        "language toggle (they'd stick in the old language). Wire a matching "
+        "data-i18n-* attribute, or add to ALLOWLIST with a reason:\n"
+        + "\n".join(f"  index.html:{n}: {ln}" for n, ln in violations)
+    )
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        "  avatar.title = t('auth.signed_in');",  # bare title, no data-i18n, not allowlisted
+        "  h.setAttribute('aria-label', t('some.key'));",
+        '  el.placeholder = t("search.placeholder");',
+    ],
+)
+def test_detector_flags_bare_imperative_title(snippet):
+    """The detector must not be vacuous: an unguarded imperative t() title is
+    flagged when it has no sibling data-i18n-* and isn't allowlisted."""
+    assert find_violations(snippet) == [(1, snippet.strip())]
+
+
+def test_detector_accepts_self_synced_block():
+    """A sibling data-i18n-* within the window clears the same imperative line."""
+    block = "  btn.title = t('title.show_video');\n  btn.setAttribute('data-i18n-title', 'title.show_video');\n"
+    assert find_violations(block) == []


### PR DESCRIPTION
## Problem

The user account avatar's tooltip (top-left) **stuck in the previous language** after toggling the UI language.

Root cause: the avatar tooltip is set **imperatively** in `updateAuthUI()` —
`avatar.title = t('auth.signed_in') + ' ' + user.login` — a composite of a
translated prefix + the GitHub login. `SPA.toggleLang()` refreshes the UI via
`translatePage()`, which only rewrites elements carrying a `data-i18n*`
attribute. The avatar has none (and can't, since the string is composite), so
its tooltip was never re-translated. The theme button — also imperative — was
already refreshed by hand in `toggleLang`; the avatar was simply overlooked.

## Second case of the same class

The preview resize handles (`makeDragHandle`) took an already-resolved
`t('preview.resize_player')` string and set `title`/`aria-label` once, without
any `data-i18n*` attribute — so they stuck too. (The other imperative titles —
`updateToggleBtn`, `applyPreviewMode`, "Show video" — already keep their
`data-i18n*` keys in sync, so they were fine.)

## Fixes (`site/index.html`)

1. **Avatar** — `SPA.toggleLang()` now calls `updateAuthUI()`, the single source
   of the avatar tooltip, so it is re-applied in the current language.
2. **`makeDragHandle`** — now takes an i18n `titleKey` and sets
   `data-i18n-title` + `data-i18n-aria-label`, so `translatePage()`
   re-translates the handles on a toggle (both call sites updated).

## Tests (TDD — red first, then fix)

- `test_spa_auth_e2e.py::test_avatar_tooltip_refreshes_on_language_toggle` —
  sign in, toggle, assert the tooltip flips `Signed in as tester` → `Ви увійшли як tester`.
- `test_preview_spa.py::TestPreviewResizeHandleI18n` — same, for the resize handle.
- **New static guard** `tests/test_spa_i18n_guard.py` — fails the build when a
  `t(...)` is assigned imperatively to `.title`/`aria-label`/`.placeholder`
  without either a sibling `data-i18n*` attribute or a documented `ALLOWLIST`
  entry. Includes self-tests proving the detector is not vacuous.

## Verification

- New tests: **RED** before the fix (`'Signed in as tester' != 'Signed in as tester'`) → **GREEN** after.
- Full suites: auth e2e 8/8, preview e2e 334/334, boot smoke 1/1, JS modules 664/664, guard 5/5; ruff clean.
- Live browser (local server): simulated a signed-in user — tooltip went
  `Signed in as slava` → `Ви увійшли як slava`; layout intact, language fully switched (no regression from the `toggleLang` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)