### PR TITLE
ci(sync-subtitles): skip draft PRs

### DIFF
--- a/.github/workflows/sync-subtitles.yml
+++ b/.github/workflows/sync-subtitles.yml
@@ -3,6 +3,9 @@ run-name: "Sync: ${{ github.event.pull_request.title }}"
 
 on:
   pull_request:
+    # Default types (opened, synchronize, reopened) don't fire when a draft is
+    # marked ready — add ready_for_review so that transition runs the sync once.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths:
       - 'talks/*/transcript_uk.txt'
@@ -13,6 +16,10 @@ permissions:
 
 jobs:
   sync:
+    # Skip draft PRs: the author is still editing, so don't let the bot sync
+    # and commit back over half-finished transcript/SRT work. Runs once the PR
+    # is marked ready for review (see ready_for_review trigger above).
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/tests/test_workflow_audit_regressions.py
+++ b/tests/test_workflow_audit_regressions.py
@@ -112,6 +112,22 @@ def test_sync_review_status_unlabeled_checks_removed_label() -> None:
     assert "github.event.label.name" in cond, f"gate ignores the removed label: {cond}"
 
 
+def test_sync_subtitles_skips_draft_prs() -> None:
+    """A draft PR is work-in-progress: the author is still editing the
+    transcript/SRT, so the bot must not race in, sync, and commit back over
+    half-finished edits. The sync job gates on the PR not being a draft, and
+    the trigger adds `ready_for_review` so marking a draft ready fires exactly
+    one sync (the default types don't include that transition)."""
+    data = yaml.safe_load((WORKFLOWS / "sync-subtitles.yml").read_text(encoding="utf-8"))
+    on = data.get("on") or data.get(True)  # yaml 1.1 parses bare `on` as True
+    types = on["pull_request"].get("types") or []
+    assert "ready_for_review" in types, (
+        f"pull_request.types must include ready_for_review so a draft->ready transition triggers the sync: {types}"
+    )
+    cond = data["jobs"]["sync"]["if"]
+    assert "draft" in cond, f"sync job must skip draft PRs via an `if` gate: {cond}"
+
+
 def test_sync_subtitles_commit_skips_ci_to_avoid_self_trigger() -> None:
     """The sync job commits the synced uk.srt/transcript as github-actions[bot]
     and pushes to the PR branch. That push re-triggers this same pull_request


### PR DESCRIPTION
## What

The **Sync Subtitles** workflow now skips draft PRs and runs once a PR is marked ready for review.

## Why

A draft PR is work-in-progress — the author is still editing `transcript_uk.txt` / `final/uk.srt`. Today the sync bot triggers on every push to those paths regardless of draft state, so it can run, sync, and commit back **over half-finished edits**, racing with the author.

## How

- Gate the `sync` job on `if: ${{ !github.event.pull_request.draft }}`.
- Add `ready_for_review` to `pull_request.types` (alongside the defaults `opened`, `synchronize`, `reopened`) so that marking a draft ready fires exactly one sync — the default types don't cover the draft→ready transition, so without this the sync would otherwise never run until the next push.

No change to the sync logic itself, permissions, or the `[skip ci]` self-trigger guard.

## Test

`tests/test_workflow_audit_regressions.py::test_sync_subtitles_skips_draft_prs` (TDD: red → green) asserts the `if` gate references `draft` and that the trigger types include `ready_for_review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)