### PR TITLE
fix(spa): corner close (X) on info dialogs; open GitHub only on confirm

### DIFF
--- a/site/css/components.css
+++ b/site/css/components.css
@@ -822,6 +822,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   animation: sy-fade-in .14s ease-out;
 }
 .sy-modal {
+  position: relative;
   background: var(--bg);
   color: var(--fg);
   border: 1px solid var(--border);
@@ -837,9 +838,25 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-size: 20px;
   font-weight: 500;
   margin: 0 0 10px;
+  padding-right: 28px; /* clear the corner close (X) */
   color: var(--fg);
   line-height: 1.3;
 }
+.sy-modal-close {
+  position: absolute;
+  top: 10px; right: 10px;
+  display: flex; align-items: center; justify-content: center;
+  width: 30px; height: 30px;
+  padding: 0; margin: 0;
+  background: none; border: 0; border-radius: var(--radius-sm);
+  color: var(--fg5);
+  cursor: pointer;
+  transition: color .12s ease, background-color .12s ease;
+}
+.sy-modal-close svg { width: 18px; height: 18px; display: block; }
+.sy-modal-close:hover { color: var(--fg2); background: var(--bg4); }
+.sy-modal-close:active { transform: scale(.9); }
+.sy-modal-close:focus-visible { outline: 2px solid var(--border3); outline-offset: 1px; color: var(--fg2); }
 .sy-modal-body {
   font-size: 14px;
   line-height: 1.5;

--- a/site/index.html
+++ b/site/index.html
@@ -775,6 +775,7 @@ var I18N = {
     'confirm.revert_all': '\u0421\u043A\u0430\u0441\u0443\u0432\u0430\u0442\u0438 {n} {word}?',
     'modal.cancel': '\u0421\u043A\u0430\u0441\u0443\u0432\u0430\u0442\u0438',
     'modal.confirm': '\u041F\u0456\u0434\u0442\u0432\u0435\u0440\u0434\u0438\u0442\u0438',
+    'modal.close': '\u0417\u0430\u043A\u0440\u0438\u0442\u0438',
     'modal.clear': '\u041E\u0447\u0438\u0441\u0442\u0438\u0442\u0438',
     'modal.discard': '\u0412\u0456\u0434\u043A\u0438\u043D\u0443\u0442\u0438',
     'modal.revert': '\u0421\u043A\u0430\u0441\u0443\u0432\u0430\u0442\u0438',
@@ -922,6 +923,7 @@ var I18N = {
     'confirm.revert_all': 'Revert {n} {word}?',
     'modal.cancel': 'Cancel',
     'modal.confirm': 'Confirm',
+    'modal.close': 'Close',
     'modal.clear': 'Clear',
     'modal.discard': 'Discard',
     'modal.revert': 'Revert',
@@ -1722,6 +1724,16 @@ SPA.confirm = function(opts) {
     modal.setAttribute('role', 'dialog');
     modal.setAttribute('aria-modal', 'true');
 
+    // Corner close (X): a dismiss affordance present on every dialog. It
+    // resolves the promise with `false` — same as Escape/Cancel — so callers
+    // that guard on the resolved value never treat a dismiss as a confirm.
+    var closeBtn = document.createElement('button');
+    closeBtn.className = 'sy-modal-close';
+    closeBtn.type = 'button';
+    closeBtn.setAttribute('aria-label', t('modal.close') || 'Close');
+    closeBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/></svg>';
+    modal.appendChild(closeBtn);
+
     var h = document.createElement('h3');
     h.className = 'sy-modal-title';
     h.textContent = opts.title || '';
@@ -1771,6 +1783,7 @@ SPA.confirm = function(opts) {
     backdrop.addEventListener('click', function(e) {
       if (e.target === backdrop && !opts.singleButton) close(false);
     });
+    closeBtn.addEventListener('click', function() { close(false); });
     if (cancelBtn) cancelBtn.addEventListener('click', function() { close(false); });
     okBtn.addEventListener('click', function() { close(true); });
     document.addEventListener('keydown', onKey, true);
@@ -3526,7 +3539,7 @@ SPA.openPreviewEditor = function() {
         body: t('modal.copied_body_srt'),
         confirmLabel: t('modal.open_github'),
         singleButton: true
-      }).then(function() { window.open(url); });
+      }).then(function(ok) { if (ok) window.open(url); });
     }).catch(function() {
       window.open(url);
     });
@@ -4233,7 +4246,7 @@ function ghCreatedDialog(titleKey, res) {
     body: '<a href="' + safeHref(res.html_url) + '" target="_blank">#' + res.number + '</a>',
     confirmLabel: t('modal.open_github'),
     singleButton: true
-  }).then(function() { window.open(res.html_url); });
+  }).then(function(ok) { if (ok) window.open(res.html_url); });
 }
 
 // Shared failure path for signed-in write calls. 401 = revoked token → silent
@@ -4333,7 +4346,7 @@ function openIssuePage(issueTitle, issueBody) {
         body: t('modal.copied_body_issue'),
         confirmLabel: t('modal.open_github'),
         singleButton: true
-      }).then(function() { window.open(shortUrl); });
+      }).then(function(ok) { if (ok) window.open(shortUrl); });
     }).catch(function() {
       window.open(shortUrl);
     });
@@ -4429,7 +4442,7 @@ SPA.openEditor = function() {
         body: t('modal.copied_body_srt'),
         confirmLabel: t('modal.open_github'),
         singleButton: true
-      }).then(function() { window.open(url); });
+      }).then(function(ok) { if (ok) window.open(url); });
     }).catch(function() {
       // Clipboard can reject (document not focused, permission denied) —
       // the edits are NOT exported then; say so instead of a dead button.
@@ -5097,7 +5110,7 @@ SPA.submitAddTalk = function() {
         body: t('modal.copied_body_meta'),
         confirmLabel: t('modal.open_github'),
         singleButton: true
-      }).then(function() { window.open(shortUrl); });
+      }).then(function(ok) { if (ok) window.open(shortUrl); });
     }).catch(function() {
       window.open(shortUrl);
     });

--- a/site/index.html
+++ b/site/index.html
@@ -1731,6 +1731,10 @@ SPA.confirm = function(opts) {
     closeBtn.className = 'sy-modal-close';
     closeBtn.type = 'button';
     closeBtn.setAttribute('aria-label', t('modal.close') || 'Close');
+    // Self-synced: translatePage() re-applies this on a language toggle, so the
+    // label doesn't stick in the old language if the UI language changes while
+    // a dialog is open. (tests/test_spa_i18n_guard.py)
+    closeBtn.setAttribute('data-i18n-aria-label', 'modal.close');
     closeBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/></svg>';
     modal.appendChild(closeBtn);
 

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -4912,6 +4912,53 @@ class TestClipboardCopyDialog:
             "don't explicitly clear it get the direct window.open path."
         )
 
+    # --- Dismiss affordance: a corner close (X) + Escape/backdrop must NOT
+    # open a GitHub tab. The primary "Open GitHub" button is the ONLY path
+    # that opens. Regression for: Escape (and a missing cancel button) still
+    # firing window.open because the .then() callback ignored the resolved
+    # value.
+    def _open_preview_editor_dialog(self, page, server):
+        """Drive openPreviewEditor with one edit so the clipboard-copy
+        confirm dialog renders, and wait for it."""
+        _goto_preview_video(page, server)
+        page.click('.preview-mode-toggle [data-mode="edit"]')
+        page.wait_for_timeout(50)
+        page.evaluate("window._vimeoPlayer._setTime(2)")
+        page.wait_for_timeout(200)
+        page.click("#btn-mark")
+        page.evaluate("""
+          var el = document.activeElement;
+          el.innerText = 'DIALOG_DISMISS_EDIT';
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+        """)
+        page.wait_for_timeout(50)
+        page.evaluate(self._STUBS)
+        page.evaluate("SPA.openPreviewEditor()")
+        page.wait_for_selector(".sy-modal", timeout=2000)
+
+    def test_info_dialog_has_corner_close_button(self, server, page):
+        """The info dialog must offer a corner close (X) so the user can
+        dismiss it without triggering the primary Open-GitHub action."""
+        self._open_preview_editor_dialog(page, server)
+        assert page.locator(".sy-modal-close").count() == 1, "Info dialog must render a corner close (X) button."
+
+    def test_escape_dismisses_without_opening_tab(self, server, page):
+        """Escape closes the dialog and must NOT open a GitHub tab."""
+        self._open_preview_editor_dialog(page, server)
+        page.keyboard.press("Escape")
+        page.wait_for_selector(".sy-modal", state="detached", timeout=2000)
+        assert page.evaluate("window._openCount") == 0, "Escape must dismiss the dialog WITHOUT opening a GitHub tab."
+
+    def test_corner_close_dismisses_without_opening_tab(self, server, page):
+        """Clicking the corner close (X) closes the dialog and must NOT open
+        a GitHub tab."""
+        self._open_preview_editor_dialog(page, server)
+        page.locator(".sy-modal-close").click()
+        page.wait_for_selector(".sy-modal", state="detached", timeout=2000)
+        assert page.evaluate("window._openCount") == 0, (
+            "Clicking the corner close (X) must dismiss the dialog WITHOUT opening a GitHub tab."
+        )
+
 
 class TestPreviewResizeHandleI18n:
     """The preview resize handles are built imperatively (makeDragHandle), so


### PR DESCRIPTION
## Problem

The "Open GitHub" info dialogs chained `.then(function(){ window.open(...) })`, which ignored the promise's resolved value. Two defects:

1. **Escape still opened a tab.** Escape resolves the confirm to `false`, but the `.then` callback ran regardless → a new GitHub tab opened anyway.
2. **No visible dismiss control.** These `singleButton` dialogs had only the primary "Open GitHub" button — nothing to cancel with.

Affects all five info dialogs, all driven by the shared `SPA.confirm`: `ghCreatedDialog` (issue/PR created, and `pr.finalized` "PR marked ready for review" on the autosync branch), `openPreviewEditor`, `openEditor`, `openIssuePage`, and the add-talk flow.

## Fix

- **Corner close (X)** added to `SPA.confirm` — stroke-SVG icon, `aria-label`, design-system tokens only (no palette; passes the components-css palette guard). It resolves the promise with `false`, same as Escape / Cancel / backdrop.
- **Guard every call site**: `.then(function(ok){ if (ok) window.open(...) })`. Now only the primary "Open GitHub" button (or Enter) opens a tab.

`SPA.passphrasePrompt` is untouched (separate function, already has a working Cancel button).

## Tests

- New regressions in `TestClipboardCopyDialog`: the corner X exists; neither Escape nor the X opens a tab.
- Existing "primary click → opens" contract stays green (6 tests).
- Verified green: `pytest -m smoke`, `test_spa_theme_tokens` (palette guard), `node --test` (664), `test_spa_auth_actions_e2e` (12, relies on the retained `singleButton` auto-confirm hook), ruff.
- Verified live in Chrome (light + dark): X and Escape dismiss without opening; only "Open GitHub" opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)