### PR TITLE
feat(spa): default the preview page to edit mode

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -339,7 +339,7 @@
       <select id="preview-video-select" class="select-chip" style="display:none;margin-left:8px;vertical-align:middle" onchange="SPA.switchPreviewVideo(this.value)"></select>
     </h1>
     <div class="preview-mode-toggle" role="group">
-      <button type="button" data-mode="marker" class="chip active" onclick="SPA.setPreviewMode('marker')" data-i18n="preview.mode_marker">&#x1F4CC; Marker</button><button type="button" data-mode="edit" class="chip" onclick="SPA.setPreviewMode('edit')" data-i18n="preview.mode_edit">&#x270E; Edit</button>
+      <button type="button" data-mode="marker" class="chip" onclick="SPA.setPreviewMode('marker')" data-i18n="preview.mode_marker">&#x1F4CC; Marker</button><button type="button" data-mode="edit" class="chip active" onclick="SPA.setPreviewMode('edit')" data-i18n="preview.mode_edit">&#x270E; Edit</button>
     </div>
     <div class="header-actions">
       <button id="btn-copy-all" class="btn" onclick="SPA.copyMarkers()" data-i18n="btn.copy_all">Copy all</button>
@@ -3004,7 +3004,7 @@ function savePreviewState() {
   if (!previewState || !previewState.talkId) return;
   var key = 'preview_' + previewState.talkId + '_' + previewState.videoSlug;
   var payload = {
-    mode: previewState.mode || 'marker',
+    mode: previewState.mode || 'edit',
     markers: previewState.markers || [],
     edits: previewState.edits || {},
   };
@@ -3039,7 +3039,7 @@ function flushPreviewPos() {
 // action). Called from applyPreviewMode (mode flips) AND updateAuthUI
 // (login/logout while the preview is open).
 function updatePreviewSubmitButtons() {
-  var mode = (typeof previewState !== 'undefined' && previewState.mode) || 'marker';
+  var mode = (typeof previewState !== 'undefined' && previewState.mode) || 'edit';
   var signedIn = !!getAuthUser();
   var editorBtn = document.getElementById('btn-preview-editor');
   if (editorBtn) editorBtn.style.display = (mode === 'edit' && !signedIn) ? 'inline-block' : 'none';
@@ -3048,7 +3048,7 @@ function updatePreviewSubmitButtons() {
 }
 
 function applyPreviewMode() {
-  var mode = previewState.mode || 'marker';
+  var mode = previewState.mode || 'edit';
   document.querySelectorAll('.preview-mode-toggle button').forEach(function(b) {
     if (b.dataset.mode === mode) b.classList.add('active');
     else b.classList.remove('active');

--- a/site/index.html
+++ b/site/index.html
@@ -339,7 +339,7 @@
       <select id="preview-video-select" class="select-chip" style="display:none;margin-left:8px;vertical-align:middle" onchange="SPA.switchPreviewVideo(this.value)"></select>
     </h1>
     <div class="preview-mode-toggle" role="group">
-      <button type="button" data-mode="marker" class="chip" onclick="SPA.setPreviewMode('marker')" data-i18n="preview.mode_marker">&#x1F4CC; Marker</button><button type="button" data-mode="edit" class="chip active" onclick="SPA.setPreviewMode('edit')" data-i18n="preview.mode_edit">&#x270E; Edit</button>
+      <button type="button" data-mode="edit" class="chip active" onclick="SPA.setPreviewMode('edit')" data-i18n="preview.mode_edit">&#x270E; Edit</button><button type="button" data-mode="marker" class="chip" onclick="SPA.setPreviewMode('marker')" data-i18n="preview.mode_marker">&#x1F4CC; Marker</button>
     </div>
     <div class="header-actions">
       <button id="btn-copy-all" class="btn" onclick="SPA.copyMarkers()" data-i18n="btn.copy_all">Copy all</button>

--- a/site/js/preview_state.js
+++ b/site/js/preview_state.js
@@ -3,7 +3,10 @@
 // by the Node test suite — no inline mirror.
 
 function defaultPreviewState() {
-  return { mode: 'marker', markers: [], edits: {} };
+  // Edit is the primary action on the preview page, so a fresh video opens in
+  // edit mode. (Legacy markers-only storage is migrated back to marker mode in
+  // loadPreviewState so existing markers aren't hidden.)
+  return { mode: 'edit', markers: [], edits: {} };
 }
 
 function newKeyFor(talkId, videoSlug) {
@@ -54,6 +57,9 @@ function loadPreviewState(talkId, videoSlug, storage) {
     }
     if (!Array.isArray(legacyMarkers)) legacyMarkers = [];
     var migrated = defaultPreviewState();
+    // Legacy storage only ever held markers, so land the migrated state in
+    // marker mode — don't hide those markers behind the new edit default.
+    migrated.mode = 'marker';
     migrated.markers = legacyMarkers;
     storage.setItem(newKey, JSON.stringify(migrated));
     storage.removeItem(legacyKey);

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -695,6 +695,9 @@ class TestMarkers:
         goto_spa(page, server, "#/preview/2001-01-01_Test-Talk/Test-Video")
         page.wait_for_selector("#mock-player", state="visible", timeout=10000)
         page.wait_for_timeout(1000)
+        # Edit is the default mode now; these tests exercise markers, so opt in.
+        page.click('.preview-mode-toggle [data-mode="marker"]')
+        page.wait_for_timeout(100)
 
     def test_marker_persists_in_localStorage(self, server, page):
         """Markers should be saved to localStorage."""
@@ -2241,6 +2244,7 @@ class TestBranchSelector:
         pg.add_init_script("localStorage.clear();")
         pg.goto(f"{server}{SPA_URL}#/preview/2001-01-01_Test-Talk/Test-Video")
         pg.wait_for_selector("#subtitle-overlay", timeout=10000)
+        pg.click('.preview-mode-toggle [data-mode="marker"]')
         pg.click("#btn-mark")
         pg.wait_for_selector(".marker-item", timeout=5000)
         assert pg.locator(".marker-item").count() == 1
@@ -2780,15 +2784,19 @@ def _goto_preview_video(page, server, video_slug="Test-Video"):
 
 
 class TestPreviewModeDefaults:
-    def test_default_mode_is_marker(self, server, page):
+    def test_default_mode_is_edit(self, server, page):
         _goto_preview_video(page, server)
         mode = page.evaluate(
-            "document.querySelector('.preview-mode-toggle [data-mode=\"marker\"]').classList.contains('active')"
+            "document.querySelector('.preview-mode-toggle [data-mode=\"edit\"]').classList.contains('active')"
         )
         assert mode is True
 
-    def test_default_new_key_shape_on_first_mutation(self, server, page):
+    def test_marker_new_key_shape_on_first_mutation(self, server, page):
+        # Marker mode is now opt-in (edit is the default); switch to it, then
+        # the first mark writes the well-formed new-key shape.
         _goto_preview_video(page, server)
+        page.click('.preview-mode-toggle [data-mode="marker"]')
+        page.wait_for_timeout(100)
         page.evaluate("window._vimeoPlayer._setTime(2)")
         page.wait_for_timeout(200)
         page.click("#btn-mark")
@@ -2801,17 +2809,20 @@ class TestPreviewModeDefaults:
 
     def test_mode_persisted_across_reload(self, server, page):
         _goto_preview_video(page, server)
-        page.click('.preview-mode-toggle [data-mode="edit"]')
+        # Switch away from the edit default so the reload actually proves the
+        # choice was persisted (re-selecting the default would save nothing).
+        page.click('.preview-mode-toggle [data-mode="marker"]')
         page.wait_for_timeout(100)
         _goto_preview_video(page, server)
         mode = page.evaluate(
-            "document.querySelector('.preview-mode-toggle [data-mode=\"edit\"]').classList.contains('active')"
+            "document.querySelector('.preview-mode-toggle [data-mode=\"marker\"]').classList.contains('active')"
         )
         assert mode is True
 
     def test_mode_independent_per_video(self, server, page):
         _goto_preview_video(page, server, "Test-Video")
-        page.click('.preview-mode-toggle [data-mode="edit"]')
+        # v1 → marker (non-default); v2 must still open on the edit default.
+        page.click('.preview-mode-toggle [data-mode="marker"]')
         page.wait_for_timeout(100)
         _goto_preview_video(page, server, "Test-Video-2")
         debug = page.evaluate("""
@@ -2824,12 +2835,12 @@ class TestPreviewModeDefaults:
           })
         """)
         mode2 = page.evaluate(
-            "document.querySelector('.preview-mode-toggle [data-mode=\"marker\"]').classList.contains('active')"
+            "document.querySelector('.preview-mode-toggle [data-mode=\"edit\"]').classList.contains('active')"
         )
         assert mode2 is True, f"debug: {debug}"
         _goto_preview_video(page, server, "Test-Video")
         mode1 = page.evaluate(
-            "document.querySelector('.preview-mode-toggle [data-mode=\"edit\"]').classList.contains('active')"
+            "document.querySelector('.preview-mode-toggle [data-mode=\"marker\"]').classList.contains('active')"
         )
         assert mode1 is True
 
@@ -2909,12 +2920,14 @@ class TestPreviewLayoutButtons:
 
     def test_copy_btn_only_visible_in_marker_mode(self, server, page):
         _goto_preview_video(page, server)
+        page.click('.preview-mode-toggle [data-mode="marker"]')
         assert page.locator("#btn-copy-all").is_visible() is True
         page.click('.preview-mode-toggle [data-mode="edit"]')
         assert page.locator("#btn-copy-all").is_visible() is False
 
     def test_open_editor_btn_only_visible_in_edit_mode(self, server, page):
         _goto_preview_video(page, server)
+        page.click('.preview-mode-toggle [data-mode="marker"]')
         assert page.locator("#btn-preview-editor").is_visible() is False
         page.click('.preview-mode-toggle [data-mode="edit"]')
         assert page.locator("#btn-preview-editor").is_visible() is True
@@ -3856,6 +3869,9 @@ class TestPreviewMarkerIssueAndCopy:
     markdown tables or wrong file paths slip through silently."""
 
     def _seed_markers(self, page):
+        # Markers live in marker mode; edit is the default now, so switch first.
+        page.click('.preview-mode-toggle [data-mode="marker"]')
+        page.wait_for_timeout(50)
         page.evaluate(
             """
             previewState.markers = [

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -2905,6 +2905,15 @@ class TestPreviewLayoutButtons:
         btns = page.locator(".preview-mode-toggle button").count()
         assert btns == 2
 
+    def test_edit_chip_comes_first(self, server, page):
+        """Edit is the default mode, so its chip is the leftmost in the toggle."""
+        _goto_preview_video(page, server)
+        modes = page.evaluate(
+            "Array.from(document.querySelectorAll('.preview-mode-toggle button'))"
+            ".map(function(b){ return b.getAttribute('data-mode'); })"
+        )
+        assert modes == ["edit", "marker"]
+
     def test_clear_btn_hidden_when_empty(self, server, page):
         _goto_preview_video(page, server)
         visible = page.locator("#btn-clear-all").is_visible()

--- a/tests/test_preview_state.js
+++ b/tests/test_preview_state.js
@@ -32,9 +32,9 @@ function makeStorage(initial) {
 }
 
 describe('defaultPreviewState', () => {
-  it('has marker mode and empty collections', () => {
+  it('has edit mode and empty collections', () => {
     const s = defaultPreviewState();
-    assert.strictEqual(s.mode, 'marker');
+    assert.strictEqual(s.mode, 'edit');
     assert.deepStrictEqual(s.markers, []);
     assert.deepStrictEqual(s.edits, {});
   });
@@ -79,7 +79,7 @@ describe('loadPreviewState — migration and precedence', () => {
   it('returns default when neither key is present', () => {
     const storage = makeStorage();
     const state = loadPreviewState(talkId, videoSlug, storage);
-    assert.strictEqual(state.mode, 'marker');
+    assert.strictEqual(state.mode, 'edit');
     assert.deepStrictEqual(state.markers, []);
     assert.deepStrictEqual(state.edits, {});
     // Default is not written back to storage until user mutates.
@@ -135,7 +135,7 @@ describe('loadPreviewState — migration and precedence', () => {
   it('falls back to default on corrupted new key', () => {
     const storage = makeStorage({ [newKey]: '{not-json' });
     const state = loadPreviewState(talkId, videoSlug, storage);
-    assert.strictEqual(state.mode, 'marker');
+    assert.strictEqual(state.mode, 'edit');
     assert.deepStrictEqual(state.markers, []);
   });
 


### PR DESCRIPTION
## What

The preview page now opens a fresh video in **edit mode** instead of marker mode — editing is the primary action there.

## How

Single source of truth in `site/js/preview_state.js`:
- `defaultPreviewState()` returns `mode: 'edit'`.
- The initial mode-toggle active chip (`index.html`) and the three `previewState.mode || …` fallbacks follow suit.

**Legacy preserved:** the old markers-only storage (`markers_preview_*`) is still migrated back to **marker** mode, so existing markers aren't hidden behind the new default. A persisted per-video mode still wins — the change only affects videos with no saved preference.

## Tests

- `tests/test_preview_state.js`: default-mode assertions → `edit`; the legacy-migration assertions stay `marker`.
- `tests/test_preview_spa.py::TestPreviewModeDefaults`: rewritten for the edit default (and marker becomes the explicitly-selected, non-default case that proves persistence/independence).
- Marker-specific suites (`TestMarkers`, `TestPreviewMarkerIssueAndCopy`, the two `TestPreviewLayoutButtons` mode-visibility tests, the branch-switch marker test) now opt into marker mode explicitly instead of inheriting it.
- Verified green locally: full `tests/test_preview_spa.py` (334), `node --test` (664), `pytest -m smoke`, ruff.
- Verified live in Chrome on a real talk: the preview opens with the **Edit** chip active and the edit list shown.

Split out of #745 (modal close-X) per review — kept independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)