### PR TITLE
feat(spa): read-only mode for signed-in users without repo write access

### DIFF
--- a/site/css/components.css
+++ b/site/css/components.css
@@ -939,3 +939,30 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 @keyframes sy-toast-out {
   to { opacity: 0; transform: translateY(8px); }
 }
+
+/* --- GitHub avatar: read-only state (signed in, no repo write access) ---- */
+.gh-avatar-wrap {
+  position: relative;
+  display: inline-flex;
+  line-height: 0;
+}
+.gh-avatar-wrap.gh-avatar--readonly #gh-avatar {
+  filter: grayscale(1);
+  opacity: .85;
+}
+.gh-avatar-badge {
+  display: none;
+  position: absolute;
+  right: -4px;
+  bottom: -4px;
+  width: 11px;
+  height: 11px;
+  padding: 1px;
+  color: var(--accent-orange);
+  background: var(--bg);
+  border: 1px solid var(--border2);
+  border-radius: var(--radius-pill);
+}
+.gh-avatar-wrap.gh-avatar--readonly .gh-avatar-badge {
+  display: block;
+}

--- a/site/index.html
+++ b/site/index.html
@@ -302,7 +302,7 @@
 <!-- === FRESHNESS BAR (global, all views) === -->
 <div id="freshness-bar" style="background:var(--bg2);border-bottom:1px solid var(--border);padding:4px 20px;display:flex;align-items:center;justify-content:space-between;font-size:12px;color:var(--fg6);position:sticky;top:0;z-index:30;">
   <div style="display:flex;align-items:center;gap:8px;">
-    <img id="gh-avatar" src="" alt="" onclick="SPA.ghAccountMenu()" style="display:none;width:20px;height:20px;border-radius:50%;cursor:pointer;border:1px solid var(--border2);vertical-align:middle;">
+    <span id="gh-avatar-wrap" class="gh-avatar-wrap"><img id="gh-avatar" src="" alt="" onclick="SPA.ghAccountMenu()" style="display:none;width:20px;height:20px;border-radius:50%;cursor:pointer;border:1px solid var(--border2);vertical-align:middle;"><svg id="gh-avatar-badge" class="gh-avatar-badge" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m19 5 3-3"/><path d="m2 22 3-3"/><path d="M6.3 20.3a2.4 2.4 0 0 0 3.4 0L12 18l-6-6-2.3 2.3a2.4 2.4 0 0 0 0 3.4Z"/><path d="M7.5 13.5 10 11"/><path d="M13.5 7.5 11 10"/><path d="m12 6 6 6 2.3-2.3a2.4 2.4 0 0 0 0-3.4l-2.6-2.6a2.4 2.4 0 0 0-3.4 0Z"/></svg></span>
     <button id="gh-login-btn" onclick="SPA.ghLogin()" data-i18n="auth.login" data-i18n-title="auth.login_title" style="display:none;background:none;color:var(--fg5);border:1px solid var(--border2);border-radius:4px;padding:2px 6px;font-size:11px;cursor:pointer;">GitHub</button>
     <div class="branch-selector">
       <button class="branch-btn" id="branch-btn" onclick="SPA.toggleBranches()">main &#x25BE;</button>
@@ -898,6 +898,10 @@ var I18N = {
     'review.taken': '\u041F\u0440\u043E\u043C\u043E\u0432\u0443 \u0432\u0437\u044F\u0442\u043E \u043D\u0430 \u0440\u0435\u0432\u02BC\u044E',
     'gh.error': '\u041F\u043E\u043C\u0438\u043B\u043A\u0430 GitHub',
     'gh.no_app_access': 'GitHub App \u043D\u0435 \u043C\u0430\u0454 \u0434\u043E\u0441\u0442\u0443\u043F\u0443 \u0434\u043E \u0440\u0435\u043F\u043E\u0437\u0438\u0442\u043E\u0440\u0456\u044E \u2014 \u0430\u0434\u043C\u0456\u043D\u0456\u0441\u0442\u0440\u0430\u0442\u043E\u0440 \u043C\u0430\u0454 \u0432\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u0438 \u0437\u0430\u0441\u0442\u043E\u0441\u0443\u043D\u043E\u043A \u043D\u0430 \u043D\u044C\u043E\u043C\u0443',
+    'gh.no_repo_access': '\u0412\u0430\u0441 \u0449\u0435 \u043D\u0435 \u0434\u043E\u0434\u0430\u043D\u043E \u0434\u043E \u0440\u0435\u043F\u043E\u0437\u0438\u0442\u043E\u0440\u0456\u044E \u2014 \u0437\u0432\u0435\u0440\u043D\u0456\u0442\u044C\u0441\u044F \u0434\u043E \u0430\u0434\u043C\u0456\u043D\u0456\u0441\u0442\u0440\u0430\u0442\u043E\u0440\u0430. \u0414\u043E\u0441\u0442\u0443\u043F\u043D\u0456 \u043B\u0438\u0448\u0435 \u0444\u0443\u043D\u043A\u0446\u0456\u0457 \u043F\u0435\u0440\u0435\u0433\u043B\u044F\u0434\u0443',
+    'auth.no_write': '\u0412\u0445\u0456\u0434 \u0432\u0438\u043A\u043E\u043D\u0430\u043D\u043E, \u0430\u043B\u0435 \u0434\u043E\u0441\u0442\u0443\u043F\u0443 \u043D\u0430 \u0437\u0430\u043F\u0438\u0441 \u043D\u0435\u043C\u0430\u0454 \u2014 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u0456 \u043B\u0438\u0448\u0435 \u0444\u0443\u043D\u043A\u0446\u0456\u0457 \u043F\u0435\u0440\u0435\u0433\u043B\u044F\u0434\u0443',
+    'auth.write_granted': '\u0414\u043E\u0441\u0442\u0443\u043F \u043D\u0430 \u0437\u0430\u043F\u0438\u0441 \u043D\u0430\u0434\u0430\u043D\u043E \u2014 \u0432\u0441\u0456 \u0444\u0443\u043D\u043A\u0446\u0456\u0457 \u0443\u0432\u0456\u043C\u043A\u043D\u0435\u043D\u043E',
+    'auth.readonly_title': '(\u0431\u0435\u0437 \u0434\u043E\u0441\u0442\u0443\u043F\u0443 \u043D\u0430 \u0437\u0430\u043F\u0438\u0441)',
     'title.lang': '\u041C\u043E\u0432\u0430 \u0456\u043D\u0442\u0435\u0440\u0444\u0435\u0439\u0441\u0443'
   },
   en: {
@@ -1046,6 +1050,10 @@ var I18N = {
     'review.taken': 'Talk taken for review',
     'gh.error': 'GitHub error',
     'gh.no_app_access': 'The GitHub App has no access to this repository — an admin must install the app on it',
+    'gh.no_repo_access': 'You have not been added to the repository yet — ask an administrator. Read-only features are available',
+    'auth.no_write': 'Signed in, but without write access — read-only features available',
+    'auth.write_granted': 'Write access granted — all features enabled',
+    'auth.readonly_title': '(no write access)',
     'title.lang': 'Interface language'
   }
 };
@@ -2286,7 +2294,7 @@ function buildManifest(tree) {
 function computeStats(talks, statuses, query) {
   var total = { talks: 0, needs_review: 0, in_review: 0, approved: 0, pending: 0, mine: 0 };
   var filtered = { talks: 0, needs_review: 0, in_review: 0, approved: 0, pending: 0, mine: 0 };
-  var authLogin = (getAuthUser() || {}).login || null;
+  var authLogin = (ghWriteUser() || {}).login || null;
   talks.forEach(function(t) {
     var matchesSearch = !query || ((t.title || '') + ' ' + (t.date || '') + ' ' + t.id).toLowerCase().indexOf(query) !== -1;
     var st = statuses[t.id] || null;
@@ -2339,8 +2347,8 @@ function renderStats() {
       { f: s.filtered.in_review, t: s.total.in_review, label: t('stat.in_review'), cls: 'info', filter: 'in-review' },
     ];
   }
-  // Signed-in reviewers get a "mine" chip in both modes.
-  if (getAuthUser()) {
+  // Reviewers with write access get a "mine" chip in both modes.
+  if (ghWriteUser()) {
     cards.push({ f: s.filtered.mine, t: s.total.mine, label: t('stat.mine'), cls: 'good', filter: 'mine' });
   }
   bar.innerHTML = '';
@@ -2472,7 +2480,7 @@ function renderIndex(el) {
   document.getElementById('index-toolbar').style.display = 'block';
   var statuses = (reviewStatus && reviewStatus.talks) || {};
   var query = (document.getElementById('search-input').value || '').toLowerCase();
-  var authLogin = (getAuthUser() || {}).login || null;
+  var authLogin = (ghWriteUser() || {}).login || null;
 
   manifest.talks.forEach(function(tk) {
     var st = statuses[tk.id] || null;
@@ -2618,6 +2626,10 @@ SPA.filterTalks = function(filter) {
 document.addEventListener('DOMContentLoaded', function() {
   handleAuthCallback();
   updateAuthUI();
+  // Restored sessions: verify write access (on a callback boot the token is
+  // not saved yet — handleAuthCallback probes after the exchange instead).
+  checkWriteAccess();
+  setInterval(function() { if (hasNoWrite()) checkWriteAccess(); }, WRITE_RECHECK_MS);
   var searchEl = document.getElementById('search-input');
   if (searchEl) {
     var debounce;
@@ -3057,7 +3069,7 @@ function flushPreviewPos() {
 // (login/logout while the preview is open).
 function updatePreviewSubmitButtons() {
   var mode = (typeof previewState !== 'undefined' && previewState.mode) || 'edit';
-  var signedIn = !!getAuthUser();
+  var signedIn = !!ghWriteUser();
   var editorBtn = document.getElementById('btn-preview-editor');
   if (editorBtn) editorBtn.style.display = (mode === 'edit' && !signedIn) ? 'inline-block' : 'none';
   var prBtn = document.getElementById('btn-preview-pr');
@@ -3495,7 +3507,7 @@ function buildPreviewIssueContent() {
 
 SPA.createPreviewIssue = function() {
   var content = buildPreviewIssueContent();
-  if (getAuthUser() && getAuthToken()) {
+  if (ghWriteUser() && getAuthToken()) {
     submitIssueViaApi(content.title, content.body);
     return;
   }
@@ -3506,7 +3518,7 @@ SPA.createPreviewIssue = function() {
 // BRANCH, commit the rebuilt final/<lang>.srt, open the PR (whose body = the
 // preview issue body). sync-subtitles.yml then reconciles SRT\u2194transcript.
 SPA.createPreviewPr = function() {
-  var user = getAuthUser(), token = getAuthToken();
+  var user = ghWriteUser(), token = getAuthToken();
   if (!user || !token) return;
   var s = previewState;
   var lang = s.srtLang || 'uk';
@@ -4264,11 +4276,25 @@ function ghWriteError(err) {
     showToast(t('auth.expired'));
     return;
   }
-  // 403 "Resource not accessible by integration": the GitHub App is not
-  // installed on the repo (or lacks a permission) — name the fix, don't echo
-  // the opaque API message.
+  // 403 "Resource not accessible by integration" covers TWO distinct causes;
+  // the permissions probe tells them apart: push=false → the USER has not
+  // been added to the repo (degrade to read-only mode); push=true → the App
+  // itself is missing a permission / not installed. Name the right fix
+  // instead of echoing the opaque API message (or blaming the wrong party).
   if (isIntegrationAccessError(err)) {
-    showToast(t('gh.no_app_access'), 6000);
+    getRepoPermissions(API, getAuthToken())
+      .then(function(p) {
+        if (!p.push) {
+          if (!hasNoWrite()) {
+            saveNoWrite();
+            updateAuthUI();
+          }
+          showToast(t('gh.no_repo_access'), 6000);
+        } else {
+          showToast(t('gh.no_app_access'), 6000);
+        }
+      })
+      .catch(function() { showToast(t('gh.no_app_access'), 6000); });
     return;
   }
   var msg = t('gh.error') + (err && err.message ? ': ' + err.message : '');
@@ -4361,7 +4387,7 @@ function openIssuePage(issueTitle, issueBody) {
 
 SPA.createReviewIssue = function() {
   var content = buildReviewIssueContent();
-  if (getAuthUser() && getAuthToken()) {
+  if (ghWriteUser() && getAuthToken()) {
     submitIssueViaApi(content.title, content.body);
     return;
   }
@@ -4372,7 +4398,7 @@ SPA.createReviewIssue = function() {
 // commit the rebuilt file, open the PR (whose body = the review issue body).
 // The existing sync-subtitles.yml then reconciles transcript↔SRT on the PR.
 SPA.createReviewPr = function() {
-  var user = getAuthUser(), token = getAuthToken();
+  var user = ghWriteUser(), token = getAuthToken();
   if (!user || !token) return;
   if (!Object.keys(reviewState.edits).length) { showToast(t('pr.no_edits')); return; }
   var file = reviewFilePath();
@@ -4479,15 +4505,26 @@ function fmtTime(sec) {
 // js/github_api.js (Node-tested); this block only wires URL, storage,
 // header UI and toasts together.
 // ============================================================
+// Effective user for write-gated UI: null while the no-write flag is set, so
+// a signed-in user WITHOUT repo write access gets exactly the signed-out
+// feature set (prefilled-issue / editor-buffer fallbacks) — only the avatar
+// (grayscale + disconnect badge) betrays the session.
+function ghWriteUser() {
+  return hasNoWrite() ? null : getAuthUser();
+}
+
 function updateAuthUI() {
   var loginBtn = document.getElementById('gh-login-btn');
   var avatar = document.getElementById('gh-avatar');
   if (!loginBtn || !avatar) return;
   var user = getAuthUser();
+  var writeUser = ghWriteUser(); // null while read-only (no repo write access)
   loginBtn.style.display = (ghClientId() && !user) ? '' : 'none';
+  var wrap = document.getElementById('gh-avatar-wrap');
+  if (wrap) wrap.classList.toggle('gh-avatar--readonly', !!user && !writeUser);
   if (user) {
     avatar.src = user.avatar_url;
-    avatar.title = t('auth.signed_in') + ' ' + user.login;
+    avatar.title = t('auth.signed_in') + ' ' + user.login + (writeUser ? '' : ' ' + t('auth.readonly_title'));
     avatar.alt = user.login;
     avatar.style.display = '';
   } else {
@@ -4495,22 +4532,52 @@ function updateAuthUI() {
   }
   // Signed-in-only controls (e.g. the review view's Create PR button) and
   // their signed-out twins (data-gh-hide, e.g. Open in GitHub Editor): the
-  // API action REPLACES the manual flow — never both at once.
+  // API action REPLACES the manual flow — never both at once. Read-only
+  // sessions count as signed out here (writeUser, not user).
   var ghOnly = document.querySelectorAll('[data-gh-only]');
-  for (var i = 0; i < ghOnly.length; i++) ghOnly[i].style.display = user ? '' : 'none';
+  for (var i = 0; i < ghOnly.length; i++) ghOnly[i].style.display = writeUser ? '' : 'none';
   var ghHide = document.querySelectorAll('[data-gh-hide]');
-  for (var j = 0; j < ghHide.length; j++) ghHide[j].style.display = user ? 'none' : '';
+  for (var j = 0; j < ghHide.length; j++) ghHide[j].style.display = writeUser ? 'none' : '';
   // The preview's pair also depends on the marker/edit mode — delegate.
   updatePreviewSubmitButtons();
   // Index cards/chips render auth-dependent bits ("take for review", the
   // 'mine' chip, own-talk highlight) — refresh them on login/logout.
   if (manifest && document.getElementById('index-content')) {
-    // A saved 'mine' filter is meaningless signed out — fall back to 'all'.
-    if (!user && activeFilter === 'mine') activeFilter = 'all';
+    // A saved 'mine' filter is meaningless without write access — fall back.
+    if (!writeUser && activeFilter === 'mine') activeFilter = 'all';
     renderStats();
     renderIndex(document.getElementById('index-content'));
   }
 }
+
+// Probe the viewer's repo write right and keep the no-write flag + UI in
+// sync. Only an authoritative 200 flips state — transient failures (network,
+// rate limit) keep the current mode; a 401 means the token died (sign out).
+function checkWriteAccess() {
+  var token = getAuthToken();
+  if (!token) return Promise.resolve();
+  return getRepoPermissions(API, token).then(function(p) {
+    var had = hasNoWrite();
+    if (p.push && had) {
+      clearNoWrite();
+      updateAuthUI();
+      showToast(t('auth.write_granted'));
+    } else if (!p.push && !had) {
+      saveNoWrite();
+      updateAuthUI();
+      showToast(t('auth.no_write'), 6000);
+    }
+  }).catch(function(err) {
+    if (err && err.status === 401) {
+      clearAuth();
+      updateAuthUI();
+      showToast(t('auth.expired'));
+    }
+  });
+}
+// While read-only, re-probe on this cadence so the UI upgrades itself soon
+// after an admin adds the user — no re-login needed.
+var WRITE_RECHECK_MS = 30 * 60 * 1000;
 
 // "Take for review": assign the talk's review issue to the signed-in user,
 // creating the issue first when none exists (title/label contract of
@@ -4518,7 +4585,7 @@ function updateAuthUI() {
 // The workflow then flips labels/review-status.json; the UI updates
 // optimistically so the badge doesn't lag behind the bot commit.
 SPA.takeForReview = function(talkId) {
-  var user = getAuthUser(), token = getAuthToken();
+  var user = ghWriteUser(), token = getAuthToken();
   if (!user || !token) return Promise.resolve();
   var st = (reviewStatus && reviewStatus.talks && reviewStatus.talks[talkId]) || null;
   var done = function(issueNumber) {
@@ -4572,7 +4639,8 @@ SPA.ghAccountMenu = function() {
   var user = getAuthUser() || {};
   SPA.confirm({
     title: t('auth.logout_confirm'),
-    body: esc(user.login || ''),
+    body: esc(user.login || '')
+      + (hasNoWrite() ? '<br><br>' + esc(t('gh.no_repo_access')) : ''),
     confirmLabel: t('auth.logout')
   }).then(function(ok) {
     if (!ok) return;
@@ -4612,6 +4680,7 @@ function handleAuthCallback() {
         saveAuth(token, user);
         updateAuthUI();
         showToast(t('auth.signed_in') + ' ' + user.login);
+        checkWriteAccess();
       });
     })
     .catch(function(err) {
@@ -5084,7 +5153,7 @@ SPA.submitAddTalk = function() {
 
   // Signed-in path: branch + commit + PR in one click. sync-subtitles /
   // new-talk automation then picks the PR up exactly as a hand-made one.
-  var user = getAuthUser(), token = getAuthToken();
+  var user = ghWriteUser(), token = getAuthToken();
   if (user && token) {
     submitFilesPr(API, token, {
       branch: makeBranchName('add-talk/' + talkId, user.login),

--- a/site/js/github_api.js
+++ b/site/js/github_api.js
@@ -73,6 +73,16 @@ function ghJson(url, token, opts, fetchImpl) {
   });
 }
 
+// GET the repo root and report the viewer's effective write right. With a
+// user-to-server token, permissions reflects the USER — push=false means
+// "not added to the repo" (read-only mode), regardless of the App's own
+// installation. Missing permissions (defensive) counts as no access.
+function getRepoPermissions(api, token, fetchImpl) {
+  return ghJson(api, token, null, fetchImpl).then(function (r) {
+    return { push: !!(r.permissions && r.permissions.push) };
+  });
+}
+
 // A 403 "Resource not accessible by integration" from ghJson means the
 // GitHub App is not installed on the repository (or lacks a permission) —
 // an admin-fixable configuration problem the UI should name explicitly
@@ -193,6 +203,7 @@ if (typeof module !== 'undefined' && module.exports) {
     authHeaders: authHeaders,
     exchangeCode: exchangeCode,
     getViewer: getViewer,
+    getRepoPermissions: getRepoPermissions,
     isIntegrationAccessError: isIntegrationAccessError,
     utf8ToBase64: utf8ToBase64,
     makeBranchName: makeBranchName,

--- a/site/js/github_auth.js
+++ b/site/js/github_auth.js
@@ -10,6 +10,9 @@
 
 var GH_TOKEN_KEY = 'sy_gh_token';
 var GH_USER_KEY = 'sy_gh_user';
+// Present ⇔ the last authoritative permissions check said push=false; lets
+// boot render the read-only UI immediately, before the async re-check.
+var GH_NO_WRITE_KEY = 'sy_gh_no_write';
 
 // One-shot CSRF state: 16 random bytes as 32 hex chars. The RNG is injectable
 // for deterministic tests; production uses WebCrypto.
@@ -92,6 +95,17 @@ function clearAuth(storage) {
   var s = storage || localStorage;
   s.removeItem(GH_TOKEN_KEY);
   s.removeItem(GH_USER_KEY);
+  s.removeItem(GH_NO_WRITE_KEY);
+}
+
+function saveNoWrite(storage) {
+  (storage || localStorage).setItem(GH_NO_WRITE_KEY, '1');
+}
+function clearNoWrite(storage) {
+  (storage || localStorage).removeItem(GH_NO_WRITE_KEY);
+}
+function hasNoWrite(storage) {
+  return (storage || localStorage).getItem(GH_NO_WRITE_KEY) === '1';
 }
 
 if (typeof module !== 'undefined' && module.exports) {
@@ -107,7 +121,11 @@ if (typeof module !== 'undefined' && module.exports) {
     getAuthToken: getAuthToken,
     getAuthUser: getAuthUser,
     clearAuth: clearAuth,
+    saveNoWrite: saveNoWrite,
+    clearNoWrite: clearNoWrite,
+    hasNoWrite: hasNoWrite,
     GH_TOKEN_KEY: GH_TOKEN_KEY,
     GH_USER_KEY: GH_USER_KEY,
+    GH_NO_WRITE_KEY: GH_NO_WRITE_KEY,
   };
 }

--- a/site/sw.js
+++ b/site/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for SPA caching
 // Browser detects changes by comparing sw.js byte-for-byte.
 // CACHE_VERSION: bump when cache format changes or to force purge.
-var CACHE_VERSION = 7;
+var CACHE_VERSION = 8;
 var CACHE_NAME = 'sy-subtitles-c' + CACHE_VERSION;
 
 // Routing predicates (isImmutable / isApiOrRaw / isNavigation / pickStrategy) are

--- a/tests/test_github_api.js
+++ b/tests/test_github_api.js
@@ -250,3 +250,37 @@ describe('submitFilesPr', () => {
     }, f), (e) => e.status === 401 && !e.branch);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Repo write-access probe: GET the repo root and read permissions.push.
+// A user-to-server token reflects the USER's effective rights, so push=false
+// means "not added to the repo" — the read-only-mode trigger.
+// ---------------------------------------------------------------------------
+const { getRepoPermissions } = require('../site/js/github_api');
+
+describe('getRepoPermissions', () => {
+  it('GETs the repo api root with the Bearer header and resolves {push:true}', async () => {
+    const capture = {};
+    const p = await getRepoPermissions('https://api.github.com/repos/o/r', 'gho_x',
+      fetchDouble(200, { permissions: { push: true, pull: true } }, capture));
+    assert.deepStrictEqual(p, { push: true });
+    assert.strictEqual(capture.url, 'https://api.github.com/repos/o/r');
+    assert.strictEqual(capture.init.headers.Authorization, 'Bearer gho_x');
+  });
+  it('resolves {push:false} when the user has read-only access', async () => {
+    const p = await getRepoPermissions('https://api.github.com/repos/o/r', 'gho_x',
+      fetchDouble(200, { permissions: { push: false, pull: true } }));
+    assert.deepStrictEqual(p, { push: false });
+  });
+  it('resolves {push:false} when permissions are absent from the payload', async () => {
+    const p = await getRepoPermissions('https://api.github.com/repos/o/r', 'gho_x',
+      fetchDouble(200, { full_name: 'o/r' }));
+    assert.deepStrictEqual(p, { push: false });
+  });
+  it('rejects with Error{status} on a non-OK reply (rate limit, bad token)', async () => {
+    await assert.rejects(
+      getRepoPermissions('https://api.github.com/repos/o/r', 'gho_x',
+        fetchDouble(403, { message: 'API rate limit exceeded' })),
+      (e) => e.status === 403 && /rate limit/.test(e.message));
+  });
+});

--- a/tests/test_github_auth.js
+++ b/tests/test_github_auth.js
@@ -126,3 +126,34 @@ describe('stripAuthParams also clears GitHub error-callback params', () => {
       '?repo=a%2Fb');
   });
 });
+
+// ---------------------------------------------------------------------------
+// No-write flag: present in storage ⇔ the last authoritative permissions
+// check said push=false. Lets boot render the degraded (read-only) UI
+// immediately, before the async re-check returns.
+// ---------------------------------------------------------------------------
+const { saveNoWrite, clearNoWrite, hasNoWrite, GH_NO_WRITE_KEY } = require('../site/js/github_auth');
+
+describe('no-write flag storage', () => {
+  it('round-trips the flag', () => {
+    const s = fakeStorage();
+    assert.strictEqual(hasNoWrite(s), false);
+    saveNoWrite(s);
+    assert.strictEqual(hasNoWrite(s), true);
+    clearNoWrite(s);
+    assert.strictEqual(hasNoWrite(s), false);
+  });
+  it('uses the sy_gh_no_write key', () => {
+    const s = fakeStorage();
+    saveNoWrite(s);
+    assert.strictEqual(s.getItem(GH_NO_WRITE_KEY), '1');
+    assert.strictEqual(GH_NO_WRITE_KEY, 'sy_gh_no_write');
+  });
+  it('clearAuth drops the flag with the session', () => {
+    const s = fakeStorage();
+    saveAuth('gho_x', { login: 'ira', avatar_url: 'u' }, s);
+    saveNoWrite(s);
+    clearAuth(s);
+    assert.strictEqual(hasNoWrite(s), false);
+  });
+});

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -27,7 +27,7 @@ from tests.test_preview_spa import (  # noqa: F401  — re-exported fixtures
 # only the scheduling is not — so retry rather than widen the timeout forever.
 pytestmark = [pytest.mark.e2e, pytest.mark.flaky(reruns=2, reruns_delay=2)]
 
-CACHE = "sy-subtitles-c7"  # CACHE_NAME in sw.js (CACHE_VERSION = 7)
+CACHE = "sy-subtitles-c8"  # CACHE_NAME in sw.js (CACHE_VERSION = 8)
 SW_WAIT_MS = 15000
 
 
@@ -48,7 +48,7 @@ class TestServiceWorker:
         _register_sw(page, server)
         page.evaluate("() => fetch('icon.png')")
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c7');"
+            "async () => { const c = await caches.open('sy-subtitles-c8');"
             " return !!(await c.match(location.origin + '/icon.png')); }",
             timeout=10000,
         )
@@ -59,7 +59,7 @@ class TestServiceWorker:
         # Seed a sentinel under the icon.png key; cache-first must return it
         # without going to the network.
         page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c7');"
+            "async () => { const c = await caches.open('sy-subtitles-c8');"
             " await c.put(location.origin + '/icon.png',"
             " new Response('SENTINEL', {headers: {'content-type': 'text/plain'}})); }"
         )
@@ -71,7 +71,7 @@ class TestServiceWorker:
         # Seed a stale sentinel for index.html; network-first must prefer the
         # live response when the network is reachable.
         page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c7');"
+            "async () => { const c = await caches.open('sy-subtitles-c8');"
             " await c.put(location.origin + '/index.html',"
             " new Response('STALE', {headers: {'content-type': 'text/html'}})); }"
         )
@@ -100,14 +100,14 @@ class TestServiceWorker:
         # with a sentinel before activation; it (and its entry) must survive.
         page.goto(f"{server}/index.html")
         page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c7');"
+            "async () => { const c = await caches.open('sy-subtitles-c8');"
             " await c.put(location.origin + '/keep', new Response('KEEP')); }"
         )
         page.evaluate("() => navigator.serviceWorker.register('sw.js')")
         page.wait_for_function("() => !!navigator.serviceWorker.controller", timeout=SW_WAIT_MS)
         assert CACHE in page.evaluate("() => caches.keys()")
         survived = page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c7');"
+            "async () => { const c = await caches.open('sy-subtitles-c8');"
             " const r = await c.match(location.origin + '/keep'); return r ? await r.text() : null; }"
         )
         assert survived == "KEEP", "activate wrongly purged the current-version cache"
@@ -129,7 +129,7 @@ class TestServiceWorker:
         # so they would not otherwise be cached).
         _register_sw(page, server)
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c7');"
+            "async () => { const c = await caches.open('sy-subtitles-c8');"
             " const us = (await c.keys()).map(r => r.url);"
             " return us.some(u => u.split('?')[0].endsWith('/index.html'))"
             " && us.filter(u => u.includes('/js/')).length >= 11"
@@ -137,7 +137,7 @@ class TestServiceWorker:
             timeout=10000,
         )
         shell = page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c7');"
+            "async () => { const c = await caches.open('sy-subtitles-c8');"
             " const us = (await c.keys()).map(r => r.url);"
             " return { index: us.some(u => u.split('?')[0].endsWith('/index.html')),"
             " js: us.filter(u => u.includes('/js/')).length,"
@@ -168,17 +168,17 @@ class TestServiceWorkerOffline:
         # icon.png, so delete it first to exercise the genuine miss path.)
         _register_sw(page, server)
         page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c7');"
+            "async () => { const c = await caches.open('sy-subtitles-c8');"
             " await c.delete(location.origin + '/icon.png'); }"
         )
         miss = page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c7');"
+            "async () => { const c = await caches.open('sy-subtitles-c8');"
             " return !!(await c.match(location.origin + '/icon.png')); }"
         )
         assert miss is False, "precondition: icon.png must not be cached yet"
         page.evaluate("() => fetch('icon.png')")
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c7');"
+            "async () => { const c = await caches.open('sy-subtitles-c8');"
             " return !!(await c.match(location.origin + '/icon.png')); }",
             timeout=10000,
         )
@@ -197,7 +197,7 @@ class TestServiceWorkerOffline:
         _register_sw(page, server)
         page.evaluate("() => fetch('index.html')")
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c7');"
+            "async () => { const c = await caches.open('sy-subtitles-c8');"
             " return !!(await c.match(location.origin + '/index.html')); }",
             timeout=10000,
         )
@@ -216,7 +216,7 @@ class TestServiceWorkerOffline:
         # Seed a cached asset so we can prove the SW is still alive afterwards.
         page.evaluate("() => fetch('icon.png')")
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c7');"
+            "async () => { const c = await caches.open('sy-subtitles-c8');"
             " return !!(await c.match(location.origin + '/icon.png')); }",
             timeout=10000,
         )
@@ -240,7 +240,7 @@ class TestServiceWorkerOffline:
         status = page.evaluate("async () => (await fetch('definitely-missing-asset.js')).status")
         assert status == 404, f"expected a 404 from the test server, got {status}"
         cached = page.evaluate(
-            "async () => { const c = await caches.open('sy-subtitles-c7');"
+            "async () => { const c = await caches.open('sy-subtitles-c8');"
             " return !!(await c.match(location.origin + '/definitely-missing-asset.js')); }"
         )
         assert cached is False, "a 404 response was wrongly written to the cache"
@@ -251,7 +251,7 @@ class TestServiceWorkerOffline:
         _register_sw(page, server)
         page.evaluate("() => fetch('js/sw_routing.js')")
         page.wait_for_function(
-            "async () => { const c = await caches.open('sy-subtitles-c7');"
+            "async () => { const c = await caches.open('sy-subtitles-c8');"
             " return !!(await c.match(location.origin + '/js/sw_routing.js')); }",
             timeout=10000,
         )
@@ -270,7 +270,7 @@ class TestServiceWorkerOffline:
         _register_sw(page, server)
         srt_url = "https://raw.githubusercontent.com/o/r/main/talks/x/uk/final/uk.srt?v=ab12cd34"
         page.evaluate(
-            "async (u) => { const c = await caches.open('sy-subtitles-c7');"
+            "async (u) => { const c = await caches.open('sy-subtitles-c8');"
             " await c.put(u, new Response('CACHED-SRT',"
             " {status: 200, headers: {'content-type': 'text/plain'}})); }",
             srt_url,
@@ -286,7 +286,7 @@ class TestServiceWorkerOffline:
         _register_sw(page, server)
         url = "https://raw.githubusercontent.com/o/r/main/talks/x/meta.yaml"
         page.evaluate(
-            "async (u) => { const c = await caches.open('sy-subtitles-c7');"
+            "async (u) => { const c = await caches.open('sy-subtitles-c8');"
             " await c.put(u, new Response('CACHED-META',"
             " {status: 200, headers: {'content-type': 'text/plain'}})); }",
             url,
@@ -308,7 +308,7 @@ class TestServiceWorkerOffline:
         _register_sw(page, server)
         api = "https://api.github.com/git/trees/main?recursive=1"
         page.evaluate(
-            "async (u) => { const c = await caches.open('sy-subtitles-c7');"
+            "async (u) => { const c = await caches.open('sy-subtitles-c8');"
             " await c.put(u, new Response('SHOULD-NOT-BE-SERVED', {status: 200})); }",
             api,
         )

--- a/tests/test_spa_auth_actions_e2e.py
+++ b/tests/test_spa_auth_actions_e2e.py
@@ -153,6 +153,16 @@ def _wire(pg, calls, review_status):
             body=json.dumps(MOCK_TREE),
         ),
     )
+    # Repo root: the write-access probe — full access, so the signed-in write
+    # UI (the subject of these tests) stays enabled.
+    pg.route(
+        "**/api.github.com/repos/sy-tools/sy-subtitles",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"permissions": {"push": True, "pull": True}}),
+        ),
+    )
     pg.route("**/raw.githubusercontent.com/**", lambda r: r.fulfill(status=404, body="not found"))
     pg.route(
         "**/raw.githubusercontent.com/**/meta.yaml",

--- a/tests/test_spa_auth_e2e.py
+++ b/tests/test_spa_auth_e2e.py
@@ -90,6 +90,16 @@ def _route_github(pg, auth_server):
             body=json.dumps({"login": "tester", "avatar_url": f"{auth_server}/icon.png"}),
         ),
     )
+    # Repo root: the write-access probe. Default = full access (a collaborator),
+    # matching what the API returns for users who have been added to the repo.
+    pg.route(
+        "**/api.github.com/repos/sy-tools/sy-subtitles",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"permissions": {"push": True, "pull": True}}),
+        ),
+    )
     pg.route(
         "**/raw.githubusercontent.com/**",
         lambda r: r.fulfill(status=404, body="not found"),
@@ -268,3 +278,79 @@ def test_login_redirect_uri_is_bare_app_url(auth_server, auth_page):
     # (sessionStorage can't be asserted here: page.url is github.com now — a
     # different origin. The stash/restore pair is proven by
     # test_callback_restores_app_params_saved_before_login.)
+
+
+# ---------------------------------------------------------------------------
+# Read-only mode: signed in WITHOUT repo write access (permissions.push=false
+# — the user has not been added to the repo; the repo itself is public-read).
+# The UI must collapse to the signed-out feature set, keeping only the avatar
+# (grayscale + disconnect badge) as evidence of the session.
+# ---------------------------------------------------------------------------
+
+
+def _seed_session(pg):
+    pg.add_init_script(
+        "localStorage.setItem('sy_gh_token', 'gho_e2e');"
+        "localStorage.setItem('sy_gh_user',"
+        " JSON.stringify({login: 'tester', avatar_url: 'icon.png'}));"
+    )
+
+
+def _route_repo_permissions(pg, push):
+    # Registered after the fixture's default push=true route — later wins.
+    pg.route(
+        "**/api.github.com/repos/sy-tools/sy-subtitles",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"permissions": {"push": push, "pull": True}}),
+        ),
+    )
+
+
+def test_readonly_user_gets_signed_out_ui_with_badge(auth_server, auth_page):
+    page = auth_page
+    _route_repo_permissions(page, False)
+    _seed_session(page)
+    page.goto(f"{auth_server}/index.html")
+    page.wait_for_function("localStorage.getItem('sy_gh_no_write') === '1'", timeout=10000)
+    # Avatar stays (still signed in), marked grayscale + badge.
+    assert page.evaluate("getComputedStyle(document.getElementById('gh-avatar')).display") != "none"
+    assert page.evaluate("document.getElementById('gh-avatar-wrap').classList.contains('gh-avatar--readonly')")
+    assert "grayscale" in page.evaluate("getComputedStyle(document.getElementById('gh-avatar')).filter")
+    assert page.evaluate("getComputedStyle(document.getElementById('gh-avatar-badge')).display") != "none"
+    # Write-gated controls behave exactly as for a signed-out visitor.
+    assert page.evaluate("document.getElementById('btn-create-pr').style.display") == "none"
+    assert page.evaluate("document.getElementById('btn-review-editor').style.display") != "none"
+    # The login button must NOT reappear — the user IS signed in.
+    assert page.evaluate("getComputedStyle(document.getElementById('gh-login-btn')).display") == "none"
+
+
+def test_write_access_return_clears_flag_and_restores_ui(auth_server, auth_page):
+    """Once an admin adds the user, the next probe (boot here; the 30-min
+    re-check while the page is open) lifts read-only mode automatically."""
+    page = auth_page  # fixture default: push=true
+    _seed_session(page)
+    page.add_init_script("localStorage.setItem('sy_gh_no_write', '1');")
+    page.goto(f"{auth_server}/index.html")
+    page.wait_for_function("localStorage.getItem('sy_gh_no_write') === null", timeout=10000)
+    assert not page.evaluate("document.getElementById('gh-avatar-wrap').classList.contains('gh-avatar--readonly')")
+    assert page.evaluate("document.getElementById('btn-create-pr').style.display") != "none"
+
+
+def test_integration_403_blames_missing_repo_access_not_the_app(auth_server, auth_page):
+    """GitHub returns the SAME 403 'Resource not accessible by integration'
+    for app-not-installed AND user-without-write. ghWriteError must consult
+    permissions and blame the right cause instead of always blaming the App."""
+    page = auth_page
+    _route_repo_permissions(page, False)
+    _seed_session(page)
+    page.goto(f"{auth_server}/index.html")
+    # Let the boot probe finish first so the toast assertion is race-free.
+    page.wait_for_function("localStorage.getItem('sy_gh_no_write') === '1'", timeout=10000)
+    page.evaluate("ghWriteError({status: 403, message: 'Resource not accessible by integration'})")
+    page.wait_for_function(
+        "document.getElementById('toast').textContent === t('gh.no_repo_access')",
+        timeout=5000,
+    )
+    assert page.evaluate("localStorage.getItem('sy_gh_no_write')") == "1"

--- a/tests/test_spa_i18n_guard.py
+++ b/tests/test_spa_i18n_guard.py
@@ -43,11 +43,12 @@ _WINDOW = 6
 # stay correct across a language toggle for the stated reason. Keys are the
 # stripped source line; keep each reason accurate if you touch the code.
 ALLOWLIST = {
-    # Avatar tooltip is composite ("signed in as" + the GitHub login), so it
-    # can't be a plain data-i18n-title. SPA.toggleLang() calls updateAuthUI(),
-    # which re-applies it in the current language. (test_spa_auth_e2e.py:
+    # Avatar tooltip is composite ("signed in as" + the GitHub login + the
+    # read-only suffix), so it can't be a plain data-i18n-title.
+    # SPA.toggleLang() calls updateAuthUI(), which re-applies it in the
+    # current language. (test_spa_auth_e2e.py:
     # test_avatar_tooltip_refreshes_on_language_toggle)
-    "avatar.title = t('auth.signed_in') + ' ' + user.login;",
+    "avatar.title = t('auth.signed_in') + ' ' + user.login + (writeUser ? '' : ' ' + t('auth.readonly_title'));",
     # Theme button title mirrors the current theme mode; SPA.toggleLang()
     # re-applies it via the themeBtn.title line below.
     "if (btn) { btn.textContent = icons[mode]; btn.title = t('title.theme.' + mode); }",


### PR DESCRIPTION
## Problem

The repo is public-read and the GitHub App is now public, so anyone can sign in — but users who have not been added to the repo got a misleading toast on "Take for review": the SPA blamed the **App installation** ("GitHub App has no access…"), while the real cause was the **user's missing write access**. GitHub returns the same `403 "Resource not accessible by integration"` for both.

## Solution (read-only mode)

- **Probe**: `getRepoPermissions` (`GET /repos/{owner}/{repo}` → `permissions.push`; a user-to-server token reflects the *user's* effective right). Runs after login, on boot, and every 30 min while degraded. Only an authoritative 200 flips state — network/rate-limit failures keep the current mode; 401 signs out.
- **Flag**: `sy_gh_no_write` in localStorage ⇒ the next boot renders degraded instantly (no flash of write controls).
- **Degraded UI = signed-out feature set**: `ghWriteUser()` (null while flagged) now gates `data-gh-only`/`data-gh-hide`, preview submit buttons, "Take for review", the *mine* chip/filter, Create PR/Issue paths and the Add-Talk API path — all fallback flows (prefilled issue, editor buffer) work exactly as for visitors.
- **Avatar stays** as the only session evidence: grayscale + orange stroke-SVG unplug badge (bottom-right) + tooltip suffix "(no write access)"; the logout dialog explains the cause.
- **Self-healing 403**: `ghWriteError` consults the probe on integration 403s → blames missing repo access (and auto-degrades) vs. App-not-installed, each with its own message.
- **Auto-upgrade**: once an admin adds the user, the ≤30-min re-probe clears the flag, restores the full UI and toasts "Write access granted".

## Tests (TDD, red→green)

- Node: `getRepoPermissions` (4), no-write flag storage + `clearAuth` clears it (3)
- Playwright e2e: degraded UI + badge/grayscale, auto-upgrade on regained access, integration-403 blames the right cause (3 new; existing auth suites extended with a default `push:true` repo-root mock)
- `pytest -m smoke`, full `-m "not e2e"` lane (673), node suite (671), theme-token guard — all green
- Verified visually on a local stand (light/dark, readonly/full)

`CACHE_VERSION` 7→8 (lockstep guard updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)