### PR TITLE
fix(spa): OAuth login returns to the pre-login page; deflake fs-mode font probes

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -717,9 +717,12 @@ function deriveRepo(hostname, pathname, search) {
     if (saved == null) return;
     if (!new URLSearchParams(location.search).get('state')) return;
     sessionStorage.removeItem('sy_gh_return');
+    var savedHash = sessionStorage.getItem('sy_gh_return_hash');
+    sessionStorage.removeItem('sy_gh_return_hash');
     var merged = mergeAuthReturn(location.search, saved);
-    if (merged !== location.search) {
-      history.replaceState(null, '', location.pathname + merged + location.hash);
+    var hash = mergeAuthReturnHash(location.hash, savedHash);
+    if (merged !== location.search || hash !== location.hash) {
+      history.replaceState(null, '', location.pathname + merged + hash);
     }
   } catch (e) {}
 })();
@@ -5125,8 +5128,10 @@ SPA.ghLogin = function() {
   try {
     sessionStorage.setItem('sy_gh_state', state);
     // App params can't ride in redirect_uri (exact-match rule) — they are
-    // restored from here on the way back, before deriveRepo runs.
+    // restored from here on the way back, before deriveRepo runs. The hash
+    // route rides along too, so login returns to the page the user left.
     sessionStorage.setItem('sy_gh_return', location.search);
+    sessionStorage.setItem('sy_gh_return_hash', location.hash);
   } catch (e) {}
   location.href = buildAuthorizeUrl(ghClientId(), state,
     buildRedirectUri(location.origin, location.pathname));

--- a/site/index.html
+++ b/site/index.html
@@ -715,7 +715,13 @@ function deriveRepo(hostname, pathname, search) {
   try {
     var saved = sessionStorage.getItem('sy_gh_return');
     if (saved == null) return;
-    if (!new URLSearchParams(location.search).get('state')) return;
+    var cbState = new URLSearchParams(location.search).get('state');
+    // Only OUR callback may consume the stash: GitHub echoes back the exact
+    // state we generated (on both the success and the error path), so a
+    // foreign ?state= URL (pasted link, unrelated App-install callback after
+    // an abandoned login) must not teleport the user to a stale pre-login
+    // route. On mismatch the stash is left intact for the real callback.
+    if (!cbState || cbState !== sessionStorage.getItem('sy_gh_state')) return;
     sessionStorage.removeItem('sy_gh_return');
     var savedHash = sessionStorage.getItem('sy_gh_return_hash');
     sessionStorage.removeItem('sy_gh_return_hash');

--- a/site/js/github_auth.js
+++ b/site/js/github_auth.js
@@ -78,6 +78,15 @@ function mergeAuthReturn(currentSearch, savedSearch) {
   return s ? '?' + s : '';
 }
 
+// Restore the pre-login hash route on the callback. The current hash wins
+// when present (never clobber a live route); a saved value that is not a
+// '#...' fragment is ignored — it gets concatenated into the URL by
+// history.replaceState, so junk must not leak in.
+function mergeAuthReturnHash(currentHash, savedHash) {
+  if (currentHash) return currentHash;
+  return (savedHash && savedHash.charAt(0) === '#') ? savedHash : '';
+}
+
 function saveAuth(token, user, storage) {
   var s = storage || localStorage;
   s.setItem(GH_TOKEN_KEY, token);
@@ -117,6 +126,7 @@ if (typeof module !== 'undefined' && module.exports) {
     stripAuthParams: stripAuthParams,
     buildRedirectUri: buildRedirectUri,
     mergeAuthReturn: mergeAuthReturn,
+    mergeAuthReturnHash: mergeAuthReturnHash,
     saveAuth: saveAuth,
     getAuthToken: getAuthToken,
     getAuthUser: getAuthUser,

--- a/tests/test_github_auth.js
+++ b/tests/test_github_auth.js
@@ -119,6 +119,31 @@ describe('mergeAuthReturn', () => {
   });
 });
 
+// The hash route (#/preview/...) cannot ride in redirect_uri either — it
+// round-trips via sessionStorage next to the saved search and is restored
+// on the callback, so login returns the user to the page they left.
+const { mergeAuthReturnHash } = require('../site/js/github_auth');
+
+describe('mergeAuthReturnHash', () => {
+  it('restores the saved hash when the callback arrives with none', () => {
+    assert.strictEqual(
+      mergeAuthReturnHash('', '#/preview/1979_Talk/Video-HD'),
+      '#/preview/1979_Talk/Video-HD');
+  });
+  it('keeps a non-empty current hash (never clobbers a live route)', () => {
+    assert.strictEqual(
+      mergeAuthReturnHash('#/review/other', '#/preview/1979_Talk/Video-HD'),
+      '#/review/other');
+  });
+  it('is a no-op for an empty or missing saved hash', () => {
+    assert.strictEqual(mergeAuthReturnHash('', ''), '');
+    assert.strictEqual(mergeAuthReturnHash('', null), '');
+  });
+  it('ignores a saved value that is not a hash fragment', () => {
+    assert.strictEqual(mergeAuthReturnHash('', 'garbage-no-hash'), '');
+  });
+});
+
 describe('stripAuthParams also clears GitHub error-callback params', () => {
   it('drops error/error_description/error_uri while keeping app params', () => {
     assert.strictEqual(

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -5140,6 +5140,20 @@ class TestSubtitleOverlaySize:
         chain after hashchange — a fixed sleep is unreliable across machines."""
         page.wait_for_selector("#preview-subs-resize", timeout=10000)
 
+    def _wait_fs_engaged(self, page):
+        """Wait until requestFullscreen has actually engaged. Best-effort:
+        some headless environments never grant native fullscreen, in which
+        case there is no pending request to race and the synchronous .fs-mode
+        class (added by toggleFullscreen itself) is already in effect, so a
+        timeout here is benign."""
+        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+        with contextlib.suppress(PlaywrightTimeoutError):
+            page.wait_for_function(
+                "document.fullscreenElement === document.getElementById('view-preview')",
+                timeout=2000,
+            )
+
     def _enter_fs(self, page):
         """Enter REAL native fullscreen and wait until requestFullscreen has
         actually engaged. requestFullscreen is async: without this wait a
@@ -5148,20 +5162,9 @@ class TestSubtitleOverlaySize:
         next enter is then misread as an exit and the font is measured in the
         embedded (non-fs) state. Waiting for the native state to settle keeps
         the enter/exit probe sequence deterministic while still exercising the
-        real Fullscreen API.
-
-        Best-effort: some headless environments never grant native fullscreen,
-        in which case there is no pending request to race and the synchronous
-        .fs-mode class (added by toggleFullscreen itself) is already in effect,
-        so a timeout here is benign."""
-        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
-
+        real Fullscreen API."""
         page.evaluate("SPA.toggleFullscreen()")
-        with contextlib.suppress(PlaywrightTimeoutError):
-            page.wait_for_function(
-                "document.fullscreenElement === document.getElementById('view-preview')",
-                timeout=2000,
-            )
+        self._wait_fs_engaged(page)
 
     def _exit_fs(self, page):
         """Exit native fullscreen and wait until it has fully released, so the
@@ -5188,18 +5191,12 @@ class TestSubtitleOverlaySize:
         gated on `!fs-mode`), the long-standing `big=59.6 < baseline=64`
         flake. With no gap the stray timer can only fire after .fs-mode is on,
         where it is gated out."""
-        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
-
         if drag_to_h is not None:
             page.evaluate(
                 f"(h) => {{ const setHandle = {self._SET_HANDLE_JS}; setHandle(h); SPA.toggleFullscreen(); }}",
                 drag_to_h,
             )
-            with contextlib.suppress(PlaywrightTimeoutError):
-                page.wait_for_function(
-                    "document.fullscreenElement === document.getElementById('view-preview')",
-                    timeout=2000,
-                )
+            self._wait_fs_engaged(page)
         else:
             self._enter_fs(page)
         return page.evaluate("parseFloat(getComputedStyle(document.getElementById('subtitle-overlay')).fontSize)")

--- a/tests/test_preview_spa.py
+++ b/tests/test_preview_spa.py
@@ -5176,10 +5176,32 @@ class TestSubtitleOverlaySize:
     def _read_fs_font_px_via_toggle(self, page, drag_to_h=None):
         """Enter real fullscreen (optionally after dragging the embedded handle,
         which sets --preview-subs-scale via JS) and read the resulting subtitle
-        overlay font size."""
+        overlay font size.
+
+        The tune and the fullscreen toggle run in ONE evaluate. Two separate
+        evaluates leave an event-loop gap between them, and the preview boot's
+        pending `setTimeout(maybeInstallResize, 50)` chain could fire in that
+        gap — still in EMBEDDED mode — re-applying the just-persisted height
+        through computeSubsMaxPx's narrow embedded clamp (~115px on this
+        layout), silently shrinking the scale the probe just set; entering
+        fullscreen then locked the shrunken value in (maybeInstallResize is
+        gated on `!fs-mode`), the long-standing `big=59.6 < baseline=64`
+        flake. With no gap the stray timer can only fire after .fs-mode is on,
+        where it is gated out."""
+        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
         if drag_to_h is not None:
-            page.evaluate(f"({self._SET_HANDLE_JS})({drag_to_h})")
-        self._enter_fs(page)
+            page.evaluate(
+                f"(h) => {{ const setHandle = {self._SET_HANDLE_JS}; setHandle(h); SPA.toggleFullscreen(); }}",
+                drag_to_h,
+            )
+            with contextlib.suppress(PlaywrightTimeoutError):
+                page.wait_for_function(
+                    "document.fullscreenElement === document.getElementById('view-preview')",
+                    timeout=2000,
+                )
+        else:
+            self._enter_fs(page)
         return page.evaluate("parseFloat(getComputedStyle(document.getElementById('subtitle-overlay')).fontSize)")
 
     def test_fs_mode_default_matches_baseline(self, server, page):

--- a/tests/test_spa_auth_e2e.py
+++ b/tests/test_spa_auth_e2e.py
@@ -277,6 +277,26 @@ def test_login_roundtrip_returns_to_the_page_the_user_left(hooks_only_server):
         browser.close()
 
 
+def test_foreign_state_url_does_not_consume_the_return_stash(auth_server, auth_page):
+    """An abandoned login leaves the return stash in sessionStorage. A later
+    URL carrying an UNRELATED ?state= (a pasted link, a foreign App-install
+    callback) must not consume it and teleport the user to the stale
+    pre-login route — only a state matching the saved CSRF state (which
+    GitHub echoes back on both success and error paths) may restore."""
+    page = auth_page
+    page.add_init_script(
+        "sessionStorage.setItem('sy_gh_state', 'st1');"
+        "sessionStorage.setItem('sy_gh_return', '?repo=sy-tools%2Fsy-subtitles');"
+        "sessionStorage.setItem('sy_gh_return_hash', '#/preview/1979-09-27_Talk/Video-HD');"
+    )
+    page.goto(f"{auth_server}/index.html?state=UNRELATED")
+    page.wait_for_selector("#gh-login-btn", state="visible", timeout=10000)
+    assert "#/preview/" not in page.url, f"stale route must not be restored, got {page.url}"
+    assert "repo=" not in page.url
+    # The stash survives for the real callback that may still arrive.
+    assert page.evaluate("sessionStorage.getItem('sy_gh_return_hash')") == ("#/preview/1979-09-27_Talk/Video-HD")
+
+
 def test_login_control_sits_left_of_branch_selector(auth_server, auth_page):
     """The login button and avatar live in the freshness bar's LEFT group,
     before the branch selector — placed on the right they visually split the

--- a/tests/test_spa_auth_e2e.py
+++ b/tests/test_spa_auth_e2e.py
@@ -238,6 +238,45 @@ def test_callback_restores_app_params_saved_before_login(hooks_only_server):
         browser.close()
 
 
+def test_login_roundtrip_returns_to_the_page_the_user_left(hooks_only_server):
+    """Full circle: clicking login on a preview page must land back ON that
+    preview page. redirect_uri is the bare app URL (exact-match rule), so BOTH
+    the query (?repo=) and the hash route (#/preview/...) round-trip via
+    sessionStorage; losing the hash strands the user on the index after login."""
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        pytest.skip("playwright not installed")
+    from urllib.parse import parse_qs, urlparse
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        ctx = browser.new_context()
+        pg = ctx.new_page()
+        _route_github(pg, hooks_only_server)
+
+        # GitHub authorize bounces straight back to redirect_uri with a code —
+        # the shape of a real approval, so the SPA's stash/restore pair runs
+        # exactly as in production.
+        def authorize(route):
+            q = parse_qs(urlparse(route.request.url).query)
+            target = q["redirect_uri"][0] + "?code=c1&state=" + q["state"][0]
+            route.fulfill(status=302, headers={"Location": target})
+
+        pg.route("https://github.com/login/oauth/authorize*", authorize)
+
+        route_hash = "#/preview/1979-09-27_Talk/Video-HD"
+        pg.goto(f"{hooks_only_server}/index.html?repo=sy-tools%2Fsy-subtitles{route_hash}")
+        pg.wait_for_selector("#gh-login-btn", state="visible", timeout=10000)
+        pg.click("#gh-login-btn")
+        pg.wait_for_selector("#gh-avatar", state="visible", timeout=10000)
+        assert pg.evaluate("localStorage.getItem('sy_gh_token')") == "gho_e2e"
+        assert "repo=" in pg.url and "code=" not in pg.url
+        assert pg.url.endswith(route_hash), f"login must return to the page the user left, got {pg.url}"
+        ctx.close()
+        browser.close()
+
+
 def test_login_control_sits_left_of_branch_selector(auth_server, auth_page):
     """The login button and avatar live in the freshness bar's LEFT group,
     before the branch selector — placed on the right they visually split the


### PR DESCRIPTION
Two follow-ups from the #740 live sessions.

## 1. OAuth login lost the hash route

`SPA.ghLogin` stashed only `location.search` before redirecting, so the
`#/preview/...` / `#/review/...` route was gone after the GitHub roundtrip —
login always dumped the user on the index and they had to navigate back to
the talk they were on.

Fix: the hash rides along in `sessionStorage` (`sy_gh_return_hash`) next to
the saved search, and the boot restore applies both. New pure helper
`mergeAuthReturnHash` (current hash wins; a saved value that is not a `#...`
fragment is ignored so junk can't leak into `history.replaceState`).

- node: 4 new `mergeAuthReturnHash` tests (23 total in test_github_auth.js)
- e2e: `test_login_roundtrip_returns_to_the_page_the_user_left` drives the
  FULL circle — click login on a preview page, a mocked GitHub authorize
  302-bounces back with `code`+`state`, assert we land on the same preview
  URL with `?repo=` restored and auth params scrubbed
- live-verified on the local stand with a real GitHub OAuth roundtrip:
  signed out on the 1979 Kundalini preview, logged back in, landed on the
  same preview with the sync engine re-attached

## 2. fs-mode font probe flake (64 vs 59.6)

`test_fs_mode_taller_block_enlarges_proportionally` flaked on CI: the
probe's `setHandle(600)` and `SPA.toggleFullscreen()` ran as two evaluates,
and the preview boot's pending `maybeInstallResize` timer could fire in the
event-loop gap between them — still in embedded mode — re-applying the
just-persisted height through `computeSubsMaxPx`'s narrow embedded clamp
and shrinking the scale before fullscreen locked it in.

Fix (test-only): tune + toggle run in ONE evaluate, so the stray timer can
only fire after `.fs-mode` is on, where the resizer install is gated out.
24 consecutive local runs of both fs-mode probes green.

Suites: 834 node, 676 python fast lane, 470 e2e, boot smoke — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)