### PR TITLE
fix(optimize): idempotency — cap merge and chaining at the duration-split threshold (#739)

### DIFF
--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -220,6 +220,32 @@ def test_optimize_with_uk_json(sample_whisper_path, tmp_path):
     assert "Другий" in full_text
 
 
+def test_optimize_idempotent_with_small_max_duration(tmp_path):
+    """CPS extension must not grow a block past the duration-split cap.
+
+    With a small --max-duration, extend_cps used to stretch a high-CPS block
+    toward chars/target_cps (past the cap); the SECOND run's Phase 1b then
+    split it — the issue #739 non-idempotency class, reachable via CLI flags
+    (any --max-duration < max_chars_block/target_cps*1000 - 1000). The same
+    chars/cps growth bound guards cascade_redistribute and absorb_large_gaps.
+    """
+    config = OptimizeConfig(max_duration_ms=4000)
+    text = "This sentence runs long enough to need more reading time. Second part is here."
+    # 78 chars over 4.9s: CPS 15.9 > target 15, so extend_cps wants
+    # 78/15 = 5200ms — past the 5000ms split cap (max_duration + 1000).
+    assert len(text) == 78
+    src = tmp_path / "in.srt"
+    src.write_text(f"1\n00:00:00,000 --> 00:00:04,900\n{text}\n\n", encoding="utf-8")
+    out1 = tmp_path / "out1.srt"
+    out2 = tmp_path / "out2.srt"
+    optimize(srt_path=str(src), json_path=None, output_path=str(out1), config=config)
+    optimize(srt_path=str(out1), json_path=None, output_path=str(out2), config=config)
+
+    key = [(b["start_ms"], b["end_ms"], b["text"]) for b in parse_srt(out1)]
+    key2 = [(b["start_ms"], b["end_ms"], b["text"]) for b in parse_srt(out2)]
+    assert key == key2
+
+
 def test_optimize_without_whisper_json(sample_srt_path, tmp_srt):
     optimize(
         srt_path=str(sample_srt_path),

--- a/tests/test_property_invariants.py
+++ b/tests/test_property_invariants.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import HealthCheck, assume, example, given, settings
 from hypothesis import strategies as st
 
 from tools.config import OptimizeConfig
@@ -243,6 +243,43 @@ def test_optimize_introduces_no_hard_cps_violation(tmp_path_factory, blocks: lis
 
 
 @given(uk_map_blocks())
+# Issue #739 counterexample, pinned so every runner replays it (the shrunk
+# example otherwise lives only in a local hypothesis DB): a dense run of
+# short equal blocks that Phase 5 used to merge past Phase 1b's duration-split
+# threshold — the NEXT run then split it, so optimize(optimize(X)) != optimize(X).
+@example(
+    blocks=[
+        Block(idx=1, start_ms=0, end_ms=1200, text="A."),
+        Block(idx=2, start_ms=1280, end_ms=2480, text="A."),
+        Block(idx=3, start_ms=2560, end_ms=3760, text="A."),
+        Block(idx=4, start_ms=3840, end_ms=5040, text="A."),
+        Block(idx=5, start_ms=5120, end_ms=6320, text="A."),
+        Block(idx=6, start_ms=6400, end_ms=7600, text="A."),
+        Block(idx=7, start_ms=7680, end_ms=8880, text="A A."),
+        Block(idx=8, start_ms=8960, end_ms=10160, text="A A A A A."),
+        Block(idx=9, start_ms=10240, end_ms=11440, text="A A A."),
+        Block(idx=10, start_ms=11520, end_ms=12720, text="A."),
+        Block(idx=11, start_ms=12800, end_ms=14000, text="A."),
+        Block(idx=12, start_ms=14080, end_ms=15280, text="A."),
+        Block(idx=13, start_ms=15360, end_ms=16560, text="A A."),
+        Block(idx=14, start_ms=16640, end_ms=17840, text="A A A A A A A A A."),
+        Block(idx=15, start_ms=17920, end_ms=19120, text="A."),
+        Block(idx=16, start_ms=19200, end_ms=20400, text="A A A A."),
+        Block(idx=17, start_ms=20480, end_ms=21730, text="A A A A A A A A A A A."),
+        Block(idx=18, start_ms=21810, end_ms=23010, text="A."),
+        Block(idx=19, start_ms=23090, end_ms=24290, text="A A A."),
+        Block(idx=20, start_ms=24370, end_ms=25570, text="A A A."),
+        Block(idx=21, start_ms=25650, end_ms=27450, text="A A A A A A A A A A A."),
+        Block(idx=22, start_ms=27530, end_ms=28730, text="A."),
+        Block(idx=23, start_ms=28810, end_ms=30010, text="A."),
+        Block(idx=24, start_ms=30090, end_ms=36105, text="A qêĘ."),
+        Block(idx=25, start_ms=36243, end_ms=42258, text="ꭴȩæ𞤱Ź."),
+        Block(idx=26, start_ms=42511, end_ms=45152, text="A."),
+        Block(idx=27, start_ms=45326, end_ms=49292, text="A eŮ𝞟é ĿĈŦĘItÃᏢ A A A A."),
+        Block(idx=28, start_ms=49718, end_ms=50918, text="A."),
+        Block(idx=29, start_ms=50998, end_ms=52198, text="A."),
+    ]
+)
 @settings(max_examples=30, deadline=None, suppress_health_check=[HealthCheck.too_slow])
 def test_optimize_is_idempotent(tmp_path_factory, blocks: list[Block]) -> None:
     """optimize(optimize(X)) == optimize(X) — the output is a fixed point."""

--- a/tools/optimize_srt.py
+++ b/tools/optimize_srt.py
@@ -261,12 +261,18 @@ def extend_cps(blocks, config):
         cps = chars / duration_s if duration_s > 0 else 999
 
         if cps > config.target_cps:
-            needed_duration_ms = int((chars / config.target_cps) * 1000)
+            current_duration = b["end_ms"] - b["start_ms"]
+            # Growth is capped at Phase 1b's split threshold (never shrinking
+            # a block already past it): an extension beyond the cap would be
+            # split by the NEXT run — the issue #739 non-idempotency class.
+            needed_duration_ms = min(
+                int((chars / config.target_cps) * 1000),
+                max(current_duration, duration_split_cap_ms(config)),
+            )
 
             max_end = blocks[i + 1]["start_ms"] - config.min_gap_ms if i + 1 < len(blocks) else b["end_ms"] + 60000
             min_start = blocks[i - 1]["end_ms"] + config.min_gap_ms if i > 0 else 0
 
-            current_duration = b["end_ms"] - b["start_ms"]
             if needed_duration_ms > current_duration:
                 extra_needed = needed_duration_ms - current_duration
 
@@ -381,9 +387,12 @@ def _split_words_at(words, split_pos):
 
 def duration_split_cap_ms(config):
     """Longest duration Phase 1b tolerates without splitting (1s slack over
-    max_duration). Phase 5 merges must respect the SAME cap: a merge past it
-    survives its own run (Phase 1b has already run) only to be dismantled by
-    the next run's split — the optimizer would not be idempotent (issue #739).
+    max_duration). Every phase that GROWS a block after Phase 1b has run must
+    respect the SAME cap — merge_short_blocks (Phase 5), the CPS growers
+    (extend_cps / cascade recipients / absorb_large_gaps) and Step-5
+    apply_chaining: growth past the cap survives its own run only to be
+    dismantled by the NEXT run's split — the optimizer would not be
+    idempotent (issue #739).
     """
     return config.max_duration_ms + 1000
 
@@ -733,7 +742,9 @@ def _cascade_pass(blocks, config, recipient_min_cps, level_cps):
             if cps <= recipient_min_cps:
                 continue
 
-            needed_dur = int((chars / level_cps) * 1000)
+            # Same growth cap as extend_cps: never past Phase 1b's split
+            # threshold (issue #739 idempotency).
+            needed_dur = min(int((chars / level_cps) * 1000), max(dur, duration_split_cap_ms(config)))
             extra_needed = needed_dur - dur
             if extra_needed <= 0:
                 continue
@@ -832,7 +843,9 @@ def absorb_large_gaps(blocks, config, report):
             if cps <= config.target_cps:
                 continue
 
-            needed_dur = int((chars / config.target_cps) * 1000)
+            # Same growth cap as extend_cps: never past Phase 1b's split
+            # threshold (issue #739 idempotency).
+            needed_dur = min(int((chars / config.target_cps) * 1000), max(dur, duration_split_cap_ms(config)))
             extra_needed = needed_dur - dur
             if extra_needed <= 0:
                 continue
@@ -1046,8 +1059,8 @@ def apply_chaining(blocks, config, report):
             new_end = blocks[i]["start_ms"] - target_gap
             # Never chain a block past Phase 1b's split cap: the next
             # optimize run would split what this run glued together
-            # (issue #739 — non-idempotent output). The sub-frame gap that
-            # remains is the lesser evil.
+            # (issue #739 — non-idempotent output). The small (3-11-frame)
+            # gap that remains is the lesser evil.
             if new_end - blocks[i - 1]["start_ms"] > duration_split_cap_ms(config):
                 continue
             blocks[i - 1]["end_ms"] = new_end

--- a/tools/optimize_srt.py
+++ b/tools/optimize_srt.py
@@ -379,6 +379,15 @@ def _split_words_at(words, split_pos):
     return words, []
 
 
+def duration_split_cap_ms(config):
+    """Longest duration Phase 1b tolerates without splitting (1s slack over
+    max_duration). Phase 5 merges must respect the SAME cap: a merge past it
+    survives its own run (Phase 1b has already run) only to be dismantled by
+    the next run's split — the optimizer would not be idempotent (issue #739).
+    """
+    return config.max_duration_ms + 1000
+
+
 def split_blocks_by_duration(blocks, config, whisper_intervals=None, word_intervals=None):
     """Split long blocks at sentence/clause/word boundaries with whisper-guided timing.
 
@@ -399,7 +408,7 @@ def split_blocks_by_duration(blocks, config, whisper_intervals=None, word_interv
         dur = b["end_ms"] - b["start_ms"]
         text = b["text"].replace("\n", " ")
 
-        if dur <= config.max_duration_ms + 1000 or len(text) < 10:
+        if dur <= duration_split_cap_ms(config) or len(text) < 10:
             new_blocks.append(b)
             continue
 
@@ -672,7 +681,11 @@ def merge_short_blocks(blocks, config):
                 short_next = next_dur < config.min_duration_ms or (next_chars < 20 and next_dur < 3000) or sparse_next
                 either_sparse = sparse_current or sparse_next
                 max_gap = 3000 if either_sparse else 500
-                max_combined_dur = config.max_duration_ms * 2 if either_sparse else config.max_duration_ms + 1000
+                # Sparse blocks may bridge a bigger gap, but the combined
+                # duration is capped at Phase 1b's split threshold for both
+                # paths (the old sparse 2x-max allowance produced blocks the
+                # next run split differently — issue #739).
+                max_combined_dur = duration_split_cap_ms(config)
                 if (
                     (short_current or short_next)
                     and combined_chars <= config.max_chars_block
@@ -1030,7 +1043,14 @@ def apply_chaining(blocks, config, report):
     for i in range(1, len(blocks)):
         gap = blocks[i]["start_ms"] - blocks[i - 1]["end_ms"]
         if min_chain_gap <= gap <= max_chain_gap:
-            blocks[i - 1]["end_ms"] = blocks[i]["start_ms"] - target_gap
+            new_end = blocks[i]["start_ms"] - target_gap
+            # Never chain a block past Phase 1b's split cap: the next
+            # optimize run would split what this run glued together
+            # (issue #739 — non-idempotent output). The sub-frame gap that
+            # remains is the lesser evil.
+            if new_end - blocks[i - 1]["start_ms"] > duration_split_cap_ms(config):
+                continue
+            blocks[i - 1]["end_ms"] = new_end
             chained += 1
 
     report.append(f"  Gaps chained (3-11 frames -> 2 frames): {chained}")


### PR DESCRIPTION
Closes #739.

`optimize(optimize(X))` could differ from `optimize(X)`: two late phases grew
blocks past the duration Phase 1b tolerates (`max_duration + 1000ms`), so the
NEXT run's duration split dismantled what the previous run had glued together.

- **Phase 5 `merge_short_blocks`** allowed sparse merges up to `2×max_duration`
  (latent hole of the same class).
- **`apply_chaining`** closed a 3–11-frame gap by extending the previous block
  with no duration check at all — this is what the shrunk #739 counterexample
  actually hits: a 21762ms merge + a 346ms chain = 22108ms > the 22000ms cap,
  and run 2's Phase 1b splits it.

Both growers now respect a shared `duration_split_cap_ms(config)` helper — the
same expression Phase 1b splits against, so the phases cannot drift apart. When
chaining would push a block past the cap the sub-half-second gap stays (lesser
evil vs a layout that rewrites itself on every re-run).

Verification:
- the #739 counterexample is pinned as `@example` on
  `test_optimize_is_idempotent`, so every runner replays it deterministically
  (previously it lived only in a local hypothesis DB); RED before the fix,
  green after
- 10 extra randomized-seed property runs green
- optimizer unit suite + full property file: 37 passed
- **full-corpus golden failure set is identical to main** (178 pre-existing
  editorial-drift fails, 0 new, 0 fixed) — the fix changes no shipped output;
  curated CI golden scope 11/11 green
- full fast lane: 677 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)