### PR TITLE
fix(vimeo): hand yt-dlp the player.vimeo.com embed URL

### DIFF
--- a/.github/workflows/new-talk.yml
+++ b/.github/workflows/new-talk.yml
@@ -328,8 +328,10 @@ jobs:
       - name: Download video
         run: |
           # Decode the obfuscated video_ref at the last moment and mask the
-          # plaintext URL from the logs.
-          VIMEO_URL=$(python3 -m tools.vimeo_codec decode "$VIDEO_REF")
+          # plaintext URL from the logs. --player emits the player.vimeo.com
+          # form: Vimeo answers 401 on the internal API yt-dlp uses for the
+          # canonical vimeo.com/<id>/<hash> links.
+          VIMEO_URL=$(python3 -m tools.vimeo_codec decode --player "$VIDEO_REF")
           echo "::add-mask::$VIMEO_URL"
           mkdir -p /tmp/whisper_work
           yt-dlp --referer "https://www.amruta.org/" -o "/tmp/whisper_work/video.mp4" "$VIMEO_URL"

--- a/.github/workflows/whisper.yml
+++ b/.github/workflows/whisper.yml
@@ -183,8 +183,10 @@ jobs:
       - name: Download video (temporary)
         run: |
           # Decode the obfuscated video_ref at the last moment and mask the
-          # plaintext URL from the logs.
-          VIMEO_URL=$(python3 -m tools.vimeo_codec decode "$VIDEO_REF")
+          # plaintext URL from the logs. --player emits the player.vimeo.com
+          # form: Vimeo answers 401 on the internal API yt-dlp uses for the
+          # canonical vimeo.com/<id>/<hash> links.
+          VIMEO_URL=$(python3 -m tools.vimeo_codec decode --player "$VIDEO_REF")
           echo "::add-mask::$VIMEO_URL"
           mkdir -p /tmp/whisper_work
           yt-dlp \

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -3,6 +3,7 @@
 import yaml
 from bs4 import BeautifulSoup
 
+from tools import download
 from tools.download import AmrutaDownloader, setup_talk
 from tools.vimeo_codec import decode_video_ref
 
@@ -346,3 +347,35 @@ def test_setup_talk_writes_obfuscated_video_ref(tmp_path):
     assert decode_video_ref(video["video_ref"]) == url
     # And the raw file text must not leak the link.
     assert "vimeo.com" not in (talk_dir / "meta.yaml").read_text(encoding="utf-8")
+
+
+# --- yt-dlp is handed the embed URL form ---
+
+
+def _capture_ytdlp_cmd(monkeypatch):
+    """Record the argv of the next subprocess.run call instead of running it."""
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append(cmd)
+        return None
+
+    monkeypatch.setattr(download.subprocess, "run", fake_run)
+    return captured
+
+
+def test_download_video_uses_player_url(monkeypatch, tmp_path):
+    """Vimeo 401s on the API yt-dlp uses for vimeo.com/<id>/<hash> links."""
+    captured = _capture_ytdlp_cmd(monkeypatch)
+    dl = AmrutaDownloader.__new__(AmrutaDownloader)
+    dl.download_video("https://vimeo.com/111111111/aaaaaaaaaa", str(tmp_path / "video.mp4"))
+    assert captured[0][-1] == "https://player.vimeo.com/video/111111111?h=aaaaaaaaaa"
+
+
+def test_download_vimeo_subs_uses_player_url(monkeypatch, tmp_path):
+    captured = _capture_ytdlp_cmd(monkeypatch)
+    monkeypatch.setattr(download.shutil, "which", lambda name: "/usr/bin/yt-dlp")
+    monkeypatch.setattr(download.globmod, "glob", lambda pattern: [])
+    dl = AmrutaDownloader.__new__(AmrutaDownloader)
+    dl.download_vimeo_subs("https://vimeo.com/111111111/aaaaaaaaaa", str(tmp_path))
+    assert captured[0][-1] == "https://player.vimeo.com/video/111111111?h=aaaaaaaaaa"

--- a/tests/test_vimeo_codec.py
+++ b/tests/test_vimeo_codec.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from tools.vimeo_codec import decode_video_ref, encode_video_ref, main
+from tools.vimeo_codec import decode_video_ref, encode_video_ref, main, to_player_url
 
 VECTORS_PATH = Path(__file__).parent / "fixtures" / "vimeo_codec_vectors.json"
 
@@ -85,6 +85,40 @@ def test_cli_encode_then_decode_round_trip(capsys):
     assert ref.startswith("r1")
     main(["decode", ref])
     assert capsys.readouterr().out.strip() == url
+
+
+def test_to_player_url_moves_private_hash_into_query():
+    """yt-dlp must be handed the embed form.
+
+    Vimeo answers 401 on the internal "macos" API that yt-dlp uses for the
+    ``vimeo.com/<id>/<hash>`` form; the ``player.vimeo.com`` form goes through
+    the player config endpoint and still works.
+    """
+    assert (
+        to_player_url("https://vimeo.com/111111111/aaaaaaaaaa")
+        == "https://player.vimeo.com/video/111111111?h=aaaaaaaaaa"
+    )
+
+
+def test_to_player_url_without_private_hash():
+    assert to_player_url("https://vimeo.com/123456789") == "https://player.vimeo.com/video/123456789"
+
+
+def test_to_player_url_is_idempotent():
+    player = "https://player.vimeo.com/video/111111111?h=aaaaaaaaaa"
+    assert to_player_url(player) == player
+
+
+def test_to_player_url_leaves_unrecognized_urls_unchanged():
+    # Never silently rewrite something we do not understand — let yt-dlp decide.
+    assert to_player_url("https://example.com/video/1") == "https://example.com/video/1"
+
+
+def test_cli_decode_player_emits_embed_url(capsys):
+    # The workflows call `python -m tools.vimeo_codec decode --player "$VIDEO_REF"`.
+    ref = encode_video_ref("https://vimeo.com/111111111/aaaaaaaaaa")
+    main(["decode", "--player", ref])
+    assert capsys.readouterr().out.strip() == "https://player.vimeo.com/video/111111111?h=aaaaaaaaaa"
 
 
 def test_cross_language_vectors_match():

--- a/tests/test_workflow_audit_regressions.py
+++ b/tests/test_workflow_audit_regressions.py
@@ -142,3 +142,16 @@ def test_sync_subtitles_commit_skips_ci_to_avoid_self_trigger() -> None:
     skip_token = re.compile(r"\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]")
     for line in commit_lines:
         assert skip_token.search(line), f"sync commit message lacks a skip-ci token (self-trigger risk): {line.strip()}"
+
+
+def test_ytdlp_steps_decode_video_ref_to_player_url() -> None:
+    """Vimeo answers 401 on the internal API yt-dlp uses for the canonical
+    `vimeo.com/<id>/<hash>` form (whisper runs 2026-07-27 downloaded nothing).
+    Every workflow that feeds a decoded video_ref to yt-dlp must ask for the
+    `player.vimeo.com` embed form, which still resolves."""
+    for name in ("whisper.yml", "new-talk.yml"):
+        text = (WORKFLOWS / name).read_text(encoding="utf-8")
+        decodes = re.findall(r"python3 -m tools\.vimeo_codec decode ([^\n]*)", text)
+        assert decodes, f"{name}: no video_ref decode found"
+        for call in decodes:
+            assert "--player" in call, f"{name}: yt-dlp needs the embed form: decode {call}"

--- a/tools/download.py
+++ b/tools/download.py
@@ -33,7 +33,7 @@ from bs4 import BeautifulSoup, Tag
 from dotenv import load_dotenv
 
 from tools.talk_slug import slugify
-from tools.vimeo_codec import encode_video_ref
+from tools.vimeo_codec import encode_video_ref, to_player_url
 
 
 def parse_amruta_url(url):
@@ -115,8 +115,9 @@ def normalize_vimeo_url(url):
     """Convert player.vimeo.com embed URL to vimeo.com direct URL.
 
     player.vimeo.com/video/ID?h=HASH&... → vimeo.com/ID/HASH
-    The direct format works reliably with yt-dlp for both subtitles and video download.
-    Non-player URLs are returned unchanged.
+    This is the canonical storage form (what ``video_ref`` encodes). Before
+    handing a link to yt-dlp, convert it back with
+    ``tools.vimeo_codec.to_player_url``. Non-player URLs are returned unchanged.
     """
     m = re.match(r"https?://player\.vimeo\.com/video/(\d+)\?h=([a-f0-9]+)", url)
     if m:
@@ -341,7 +342,7 @@ class AmrutaDownloader:
             "srt",
             "-o",
             os.path.join(output_dir, "%(id)s.%(ext)s"),
-            vimeo_url,
+            to_player_url(vimeo_url),
         ]
         subprocess.run(cmd, check=True)
 
@@ -490,7 +491,7 @@ class AmrutaDownloader:
             "https://www.amruta.org/",
             "-o",
             output_path,
-            vimeo_url,
+            to_player_url(vimeo_url),
         ]
         subprocess.run(cmd, check=True)
         return output_path

--- a/tools/vimeo_codec.py
+++ b/tools/vimeo_codec.py
@@ -37,6 +37,9 @@ _VERSION = "r1"
 # slash. The decode always reconstructs the canonical ``https://vimeo.com/...``.
 _PATH_RE = re.compile(r"^(?:https?://)?(?:www\.)?vimeo\.com/(.+?)/?$", re.IGNORECASE)
 
+# Canonical decoded form: numeric id plus an optional private hash.
+_CANONICAL_RE = re.compile(r"^(?:https?://)?(?:www\.)?vimeo\.com/(\d+)(?:/([0-9a-z]+))?/?$", re.IGNORECASE)
+
 
 def _xor(data: bytes) -> bytes:
     return bytes(b ^ _KEY[i % len(_KEY)] for i, b in enumerate(data))
@@ -71,6 +74,24 @@ def decode_video_ref(ref: str) -> str:
     return "https://vimeo.com/" + path
 
 
+def to_player_url(url: str) -> str:
+    """Convert a canonical Vimeo URL into the ``player.vimeo.com`` embed form.
+
+    ``https://vimeo.com/<id>/<hash>`` → ``https://player.vimeo.com/video/<id>?h=<hash>``
+
+    This is the form to hand to yt-dlp: for the canonical form yt-dlp goes
+    through Vimeo's internal "macos" API, which now answers ``401 Unauthorized``,
+    while the embed form resolves via the player config endpoint. URLs that do
+    not match the canonical form (including already-embed ones) are returned
+    unchanged.
+    """
+    match = _CANONICAL_RE.match((url or "").strip())
+    if not match:
+        return url
+    video_id, private_hash = match.group(1), match.group(2)
+    return f"https://player.vimeo.com/video/{video_id}" + (f"?h={private_hash}" if private_hash else "")
+
+
 def main(argv: list[str] | None = None) -> None:
     """CLI used by workflows: ``vimeo_codec encode <url>`` / ``decode <ref>``.
 
@@ -85,12 +106,18 @@ def main(argv: list[str] | None = None) -> None:
     enc.add_argument("url")
     dec = sub.add_parser("decode", help="video_ref -> vimeo url")
     dec.add_argument("ref")
+    dec.add_argument(
+        "--player",
+        action="store_true",
+        help="emit the player.vimeo.com embed form (the one yt-dlp can resolve)",
+    )
     args = parser.parse_args(argv)
 
     if args.cmd == "encode":
         print(encode_video_ref(args.url))
     else:
-        print(decode_video_ref(args.ref))
+        url = decode_video_ref(args.ref)
+        print(to_player_url(url) if args.player else url)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Every whisper job in [run 30255818640](https://github.com/sy-tools/sy-subtitles/actions/runs/30255818640) died at **Download video (temporary)** — before Whisper even started, all three videos:

```
[vimeo] Extracting URL: ***
[vimeo] Fetching macos OAuth token
ERROR: [vimeo] 336833139: Failed to fetch macos OAuth token: HTTP Error 401: Unauthorized
```

`video_ref` decoding is fine. Vimeo started returning **401** on the internal "macOS app" API that yt-dlp uses to resolve canonical `vimeo.com/<id>/<hash>` links. Not a yt-dlp regression (2026.02.21 and 2026.7.4 both fail) and not a runner-IP issue — it reproduces locally.

## Fix

The `player.vimeo.com/video/<id>?h=<hash>` embed form resolves through the player config endpoint and still works. Converted at the yt-dlp call sites only; `meta.yaml` keeps storing the canonical form.

| | before | after |
|---|---|---|
| `vimeo.com/336833139/570f2d321d` | ❌ 401 | — |
| `player.vimeo.com/video/336833139?h=570f2d321d` | — | ✅ resolves |

- `tools.vimeo_codec.to_player_url()` + a `decode --player` CLI flag
- `whisper.yml` / `new-talk.yml` download steps call `decode --player`
- `download.py` converts in `download_video` and `download_vimeo_subs` — the same 401 breaks `--what video` and `--what srt`

`normalize_vimeo_url()` in `download.py` (which does the opposite conversion) keeps its role as the *storage* normalizer; its docstring no longer claims the direct form is what yt-dlp wants.

## Tests (TDD — each watched failing first)

- `test_vimeo_codec.py`: `to_player_url` with/without private hash, idempotence, unknown URLs untouched, `decode --player` CLI
- `test_download.py`: both yt-dlp invocations get the embed URL
- `test_workflow_audit_regressions.py`: structural guard that every workflow feeding a decoded `video_ref` to yt-dlp uses `--player`

## Verification beyond the suite

Against **yt-dlp 2026.7.4** (the CI pin), all three videos from the failed run now resolve, and the shortest one downloaded in full (10 MB, `ffprobe` duration 87.34 s — matches the reported 87 s).

689 tests pass (`-m "not e2e"`), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)