### PR TITLE
Backfill EN SRT for 2000-07-23 Guru Puja: Shraddha

### DIFF
--- a/talks/2000-07-23_Guru-Puja-Shraddha/Guru-Puja-1st-Talk-after-Puja/source/en.srt
+++ b/talks/2000-07-23_Guru-Puja-Shraddha/Guru-Puja-1st-Talk-after-Puja/source/en.srt
@@ -1,0 +1,108 @@
+1
+00:00:02,205 --> 00:00:03,956
+Yesterday,
+
+2
+00:00:04,603 --> 00:00:09,277
+we saw the beautiful drama of Shri Rama.
+
+3
+00:00:10,070 --> 00:00:12,542
+It was done so beautifully
+
+4
+00:00:13,009 --> 00:00:18,212
+that my heart was filled with admiration.
+
+5
+00:00:19,006 --> 00:00:21,271
+I couldn't say anything
+
+6
+00:00:22,326 --> 00:00:26,872
+Is a very good work,
+
+7
+00:00:27,549 --> 00:00:29,704
+and that's what happens to you
+
+8
+00:00:29,886 --> 00:00:34,813
+when you become the spirit, you become creative.
+You have to be creators.
+
+9
+00:00:35,237 --> 00:00:39,881
+You create Sahaja Yogis,
+you create all kinds of beautiful things.
+
+10
+00:00:40,164 --> 00:00:46,874
+And this was so much, so much done in the name of Self.
+
+11
+00:00:47,532 --> 00:00:50,489
+I'm very happy they have made this drama,
+
+12
+00:00:50,671 --> 00:00:52,902
+And I'll organize somehow
+
+13
+00:00:53,058 --> 00:00:57,386
+that it goes to India and to America as well.
+Is very well done.
+
+14
+00:00:57,652 --> 00:01:00,269
+So, give them a hand...
+
+15
+00:01:16,916 --> 00:01:21,199
+Also, I very much admire
+
+16
+00:01:21,392 --> 00:01:24,859
+the work put in by the Italian Sahaja Yogis
+
+17
+00:01:25,488 --> 00:01:33,558
+and others who have been of help to him, to Mr. Guido
+
+18
+00:01:33,926 --> 00:01:35,802
+and also to others
+
+19
+00:01:36,018 --> 00:01:42,421
+that they have created
+such a tremendous effect in this
+
+20
+00:01:43,426 --> 00:01:45,869
+enorm big
+
+21
+00:01:48,546 --> 00:01:55,763
+structure, that I used to think
+how can it be a puja in such a structure
+
+22
+00:01:56,537 --> 00:02:04,686
+But it has been now become so beautiful and so nice
+that I really thank the Italians for that.
+
+23
+00:02:05,117 --> 00:02:09,491
+One thing about Italians is, they are very large hearted people.
+
+24
+00:02:09,929 --> 00:02:16,593
+And I wish all of you develope
+that large heartedness and work out evereything
+
+25
+00:02:16,945 --> 00:02:22,827
+to enjoy your large heartedness.
+Thank you.
+

--- a/talks/2000-07-23_Guru-Puja-Shraddha/Guru-Puja-2nd-Talk-after-Puja/source/en.srt
+++ b/talks/2000-07-23_Guru-Puja-Shraddha/Guru-Puja-2nd-Talk-after-Puja/source/en.srt
@@ -1,0 +1,62 @@
+1
+00:00:00,428 --> 00:00:02,222
+On a Guru Puja
+
+2
+00:00:02,336 --> 00:00:08,171
+The Guru doesn't give any presents to the disciple.
+
+3
+00:00:08,658 --> 00:00:10,999
+Mother can give, but not the guru
+
+4
+00:00:11,188 --> 00:00:15,938
+And that's why I'm sorry today
+I won't be given any present.
+
+5
+00:00:16,071 --> 00:00:20,462
+But  I have given a very good lecture for you.
+
+6
+00:00:38,196 --> 00:00:45,417
+Thank you very much from all the countries
+beautiful present they have given me.
+
+7
+00:00:45,648 --> 00:00:51,180
+It's very suprising how beautifully people are creating things
+
+8
+00:00:51,407 --> 00:00:56,000
+and you know a self realise people are creators.
+
+9
+00:00:56,057 --> 00:01:00,632
+You have to create sahaja yogis first and all other things.
+
+10
+00:01:00,800 --> 00:01:03,445
+So, you are creators you can do it.
+
+11
+00:01:03,644 --> 00:01:06,391
+It's not think a diffucult for you.
+
+12
+00:01:06,425 --> 00:01:10,158
+It is very simple and you learn the art very soon.
+
+13
+00:01:10,385 --> 00:01:13,066
+And I'm sure, it will workout very fast.
+
+14
+00:01:13,190 --> 00:01:17,817
+So you'll go ahead know for creating more sahaja yogis all over the world.
+
+15
+00:01:17,885 --> 00:01:19,961
+Thank you very much
+

--- a/talks/2000-07-23_Guru-Puja-Shraddha/Guru-Puja-Talk-Shraddha/source/en.srt
+++ b/talks/2000-07-23_Guru-Puja-Shraddha/Guru-Puja-Talk-Shraddha/source/en.srt
@@ -1,0 +1,2561 @@
+1
+00:00:00,001 --> 00:00:02,077
+Guru Puja Cabella Ligure (Italy), 23 July 2000.
+
+2
+00:00:02,198 --> 00:00:08,944
+Today we are here to know about guru principle.
+
+3
+00:00:14,540 --> 00:00:18,500
+What does a guru do.
+
+4
+00:00:29,735 --> 00:00:33,642
+Whatever you have,
+
+5
+00:00:34,890 --> 00:00:39,096
+all the precious things within you,
+
+6
+00:00:39,627 --> 00:00:47,880
+he discovers them for your knowledge.
+
+7
+00:00:51,870 --> 00:00:56,679
+Actually it is all there -
+
+8
+00:00:57,021 --> 00:00:59,044
+everything.
+
+9
+00:00:59,719 --> 00:01:05,520
+All the knowledge, all the spirituality,
+
+10
+00:01:05,783 --> 00:01:10,416
+all the joy, is there.
+
+11
+00:01:11,178 --> 00:01:13,557
+Right time!
+
+12
+00:01:23,060 --> 00:01:27,640
+It's all contained within you.
+
+13
+00:01:32,365 --> 00:01:36,230
+Only thing the Guru does
+
+14
+00:01:38,940 --> 00:01:43,924
+makes you knowledgeable about your knowledge,
+
+15
+00:01:46,139 --> 00:01:49,273
+about your own spirit.
+
+16
+00:01:50,996 --> 00:01:56,913
+Everyone has the Spirit within himself.
+
+17
+00:01:58,376 --> 00:02:04,058
+Everyone has the spirituality within himself.
+
+18
+00:02:04,772 --> 00:02:10,422
+There is nothing that you get from outside.
+
+19
+00:02:10,966 --> 00:02:15,876
+But before getting this knowledge, you are dealing,
+
+20
+00:02:16,077 --> 00:02:22,033
+or you are living in ignorance.
+
+21
+00:02:24,108 --> 00:02:27,764
+In that ignorance you do not know
+
+22
+00:02:27,965 --> 00:02:33,734
+what treasure you have got within yourself.
+
+23
+00:02:35,076 --> 00:02:41,059
+So the guru's job is to make you know what you are.
+
+24
+00:02:49,528 --> 00:02:53,488
+That is the first step.
+
+25
+00:02:53,782 --> 00:02:56,575
+That it starts,
+
+26
+00:02:56,829 --> 00:03:00,329
+that awakening within you
+
+27
+00:03:00,582 --> 00:03:04,757
+by which you know
+
+28
+00:03:05,003 --> 00:03:08,693
+that you are not this outside world,
+
+29
+00:03:08,899 --> 00:03:11,839
+this is all an illusion.
+
+30
+00:03:13,648 --> 00:03:19,583
+And you start getting enlightened within yourself.
+
+31
+00:03:20,508 --> 00:03:27,197
+Some people get full light and some people get it gradually.
+
+32
+00:03:27,912 --> 00:03:33,819
+Essence of all the religions is that you should know yourself.
+
+33
+00:03:35,376 --> 00:03:39,443
+Those people who are fighting in the name of religion,
+
+34
+00:03:39,689 --> 00:03:43,765
+you have to go and ask them,
+
+35
+00:03:43,966 --> 00:03:47,714
+you have to enquire from them,
+
+36
+00:03:48,019 --> 00:03:52,718
+"Did your religion make you know yourself?"
+
+37
+00:03:53,591 --> 00:03:56,902
+If all the religions have said one thing -
+
+38
+00:03:57,233 --> 00:04:03,168
+you have to do all these things just to know yourself.
+
+39
+00:04:05,399 --> 00:04:09,516
+But people get into rituals.
+
+40
+00:04:09,722 --> 00:04:15,696
+They think by doing all these rituals they are near God.
+
+41
+00:04:16,739 --> 00:04:22,683
+They live in ignorance absolutely about themselves, and
+
+42
+00:04:23,326 --> 00:04:27,841
+day in and day out they work out something,
+
+43
+00:04:28,042 --> 00:04:31,945
+which is nothing to do with yourself'.
+
+44
+00:04:33,687 --> 00:04:37,288
+Lots of acrobats, prayers,
+
+45
+00:04:37,489 --> 00:04:41,472
+pujas, these things go on.
+
+46
+00:04:41,734 --> 00:04:45,207
+Because it is all ignorance.
+
+47
+00:04:45,421 --> 00:04:48,276
+People go on paying them money
+
+48
+00:04:48,477 --> 00:04:51,985
+and they become very rich
+
+49
+00:04:52,186 --> 00:04:56,741
+and their interest is only money.
+
+50
+00:04:58,154 --> 00:05:03,197
+They want to take all your money, absolutely,
+
+51
+00:05:03,475 --> 00:05:06,610
+and make a fool out of you.
+
+52
+00:05:07,818 --> 00:05:11,088
+They pamper your ego.
+
+53
+00:05:11,580 --> 00:05:17,556
+With pampering of that ego you just start drifting
+
+54
+00:05:18,175 --> 00:05:21,499
+into the ocean of illusion
+
+55
+00:05:21,786 --> 00:05:27,476
+and you are drowned into that illusion,
+
+56
+00:05:27,753 --> 00:05:29,824
+thinking that you are very religious
+
+57
+00:05:30,102 --> 00:05:35,197
+and you are just in connection with God, which you are not.
+
+58
+00:05:35,499 --> 00:05:40,669
+To know God you should know your Self first.
+
+59
+00:05:40,947 --> 00:05:45,637
+Without knowing that, you cannot know God.
+
+60
+00:05:46,034 --> 00:05:51,848
+That's essential, that you should know your Self.
+
+61
+00:05:54,126 --> 00:05:58,578
+But when you know yourself, you know partly.
+
+62
+00:05:58,936 --> 00:06:03,056
+The experience is not sufficient.
+
+63
+00:06:03,985 --> 00:06:07,056
+The knowledge has to come.
+
+64
+00:06:07,318 --> 00:06:13,274
+And the guru gives the knowledge about your Self.
+
+65
+00:06:14,532 --> 00:06:18,274
+Now you have to tally it.
+
+66
+00:06:18,536 --> 00:06:22,578
+You should find out whatever your guru has told you.
+
+67
+00:06:22,816 --> 00:06:27,684
+Is it true or not? Is it correct or not?
+
+68
+00:06:27,951 --> 00:06:32,548
+Or is it just another illusion?
+
+69
+00:06:34,402 --> 00:06:40,314
+Now in this ascent people get into lots of problems.
+
+70
+00:06:40,528 --> 00:06:45,969
+First and foremost is the ego problem, especially in the west.
+
+71
+00:06:46,295 --> 00:06:50,652
+Ego stands up and you start thinking you are great,
+
+72
+00:06:50,853 --> 00:06:52,723
+you are better than others,
+
+73
+00:06:52,961 --> 00:06:56,930
+and there is something special about you.
+
+74
+00:06:57,168 --> 00:07:02,057
+This ignorance is more dangerous
+
+75
+00:07:02,343 --> 00:07:05,501
+than the worldly ignorance, I think,
+
+76
+00:07:05,723 --> 00:07:11,675
+because in the worldly ignorance, you do feel the
+
+77
+00:07:16,073 --> 00:07:19,876
+consequences of wrong things.
+
+78
+00:07:20,269 --> 00:07:23,881
+But when you are half way,
+
+79
+00:07:24,171 --> 00:07:29,932
+when your ignorance is that about yourself,
+
+80
+00:07:30,195 --> 00:07:34,148
+when you are going to a higher realm,
+
+81
+00:07:34,410 --> 00:07:40,399
+then one should always understand that you cannot have ego.
+
+82
+00:07:43,160 --> 00:07:47,929
+Then what starts is introspection.
+
+83
+00:07:56,001 --> 00:08:00,832
+You start looking at yourself,
+
+84
+00:08:01,062 --> 00:08:04,666
+what's wrong with you.
+
+85
+00:08:04,935 --> 00:08:07,958
+When you understand that you have ego,
+
+86
+00:08:08,158 --> 00:08:11,047
+you start looking at yourself.
+
+87
+00:08:11,261 --> 00:08:17,253
+Or when you find there is something missing
+
+88
+00:08:18,062 --> 00:08:20,727
+or something wrong,
+
+89
+00:08:20,927 --> 00:08:24,688
+then also, you start introspecting.
+
+90
+00:08:25,355 --> 00:08:31,797
+This should be a very, very honest, very honest effort.
+
+91
+00:08:33,044 --> 00:08:36,819
+Some people in Sahaja Yoga, at a very early stage
+
+92
+00:08:37,020 --> 00:08:40,009
+start thinking they that they are very great
+
+93
+00:08:40,210 --> 00:08:43,647
+and they don't need any introspection.
+
+94
+00:08:43,848 --> 00:08:49,790
+And they rise again into the clouds of ignorance
+
+95
+00:08:50,607 --> 00:08:56,551
+without achieving Selfhood or I can call it Self realisation.
+
+96
+00:08:58,257 --> 00:09:03,269
+So you have to introspect and see for yourself
+
+97
+00:09:03,470 --> 00:09:07,159
+what have you been doing, what are you,
+
+98
+00:09:07,360 --> 00:09:10,423
+how far you have come.
+
+99
+00:09:11,352 --> 00:09:14,444
+How much --
+
+100
+00:09:14,645 --> 00:09:18,775
+please don't translate just now all right? You can do it later on.
+
+101
+00:09:22,097 --> 00:09:25,287
+You must hear with full concentration.
+
+102
+00:09:25,565 --> 00:09:30,700
+Even if you don't understand it will work.
+
+103
+00:09:31,065 --> 00:09:36,565
+Now the style of such a person changes gradually. How?
+
+104
+00:09:36,922 --> 00:09:41,292
+First of all a person who is extremely aggressive,
+
+105
+00:09:41,493 --> 00:09:47,340
+hot-tempered and full of ego
+
+106
+00:09:47,776 --> 00:09:52,530
+starts becoming very gentle and mild.
+
+107
+00:09:53,889 --> 00:09:59,031
+Another type, which is frightened and afraid
+
+108
+00:09:59,292 --> 00:10:05,285
+and very cautious, starts becoming fearless.
+
+109
+00:10:07,689 --> 00:10:11,793
+At that stage you have no fears.
+
+110
+00:10:12,467 --> 00:10:16,415
+You are sure that you are on the right path
+
+111
+00:10:16,685 --> 00:10:20,705
+and you are moving on the right lines.
+
+112
+00:10:23,718 --> 00:10:26,559
+You are not easily disturbed there.
+
+113
+00:10:26,782 --> 00:10:32,067
+But still you have to rise higher and higher,
+
+114
+00:10:32,353 --> 00:10:36,584
+where, when you meditate, you understand,
+
+115
+00:10:36,886 --> 00:10:41,901
+that there is something wrong within yourself.
+
+116
+00:10:42,433 --> 00:10:45,537
+You have achieved your Self realisation.
+
+117
+00:10:45,775 --> 00:10:49,092
+You have got the blessings of Self realisation.
+
+118
+00:10:49,314 --> 00:10:52,076
+Your health is good,
+
+119
+00:10:52,362 --> 00:10:57,682
+you have got all kinds of blessings which you cannot count.
+
+120
+00:10:57,939 --> 00:11:01,573
+All that is there but...
+
+121
+00:11:03,413 --> 00:11:07,462
+still you have to go further.
+
+122
+00:11:08,961 --> 00:11:12,841
+And that is to understand
+
+123
+00:11:13,175 --> 00:11:19,095
+all the knowledge about Sahaja Yoga.
+
+124
+00:11:23,795 --> 00:11:28,187
+You have to understand through your mental capacity,
+
+125
+00:11:28,388 --> 00:11:32,980
+first, to begin with, and then you have to verify
+
+126
+00:11:33,290 --> 00:11:37,431
+how far it is correct.
+
+127
+00:11:37,658 --> 00:11:40,770
+How far you have understood it,
+
+128
+00:11:41,070 --> 00:11:44,919
+how far you have worked on it,
+
+129
+00:11:46,291 --> 00:11:49,306
+how far you know.
+
+130
+00:11:52,029 --> 00:11:57,984
+And when you start seeing yourself,
+
+131
+00:11:58,185 --> 00:12:01,661
+you start
+
+132
+00:12:01,875 --> 00:12:07,669
+entering into the realm of Bhakti.
+
+133
+00:12:08,182 --> 00:12:13,079
+You become a mild person, become a sweet person,
+
+134
+00:12:13,388 --> 00:12:18,388
+you don't talk too much, you don't harass anyone.
+
+135
+00:12:18,808 --> 00:12:23,831
+You are a very pleasant person, very gentle,
+
+136
+00:12:24,093 --> 00:12:28,220
+very understanding.
+
+137
+00:12:30,561 --> 00:12:35,715
+This person has to verify
+
+138
+00:12:35,916 --> 00:12:39,808
+how he is behaving towards others.
+
+139
+00:12:43,487 --> 00:12:49,072
+Now the attention starts moving from oneself to another
+
+140
+00:12:49,286 --> 00:12:53,365
+and you start seeing how you behave.
+
+141
+00:12:54,301 --> 00:12:58,373
+How you love.
+
+142
+00:12:58,848 --> 00:13:04,110
+What is the quality of your compassion?
+
+143
+00:13:07,459 --> 00:13:11,244
+When you love somebody
+
+144
+00:13:11,529 --> 00:13:17,085
+without any expectations, just love, then
+
+145
+00:13:17,450 --> 00:13:23,432
+you are absolutely dedicated to that person, absolutely.
+
+146
+00:13:24,514 --> 00:13:27,521
+you just obey.
+
+147
+00:13:28,081 --> 00:13:31,610
+You will do anything for that person.
+
+148
+00:13:31,811 --> 00:13:37,660
+If there is this love which you call as surrender.
+
+149
+00:13:39,492 --> 00:13:42,826
+This is just the love.
+
+150
+00:13:43,048 --> 00:13:45,969
+Surrender is nothing but the love,
+
+151
+00:13:46,199 --> 00:13:52,032
+and that love, which is extremely joy-giving,
+
+152
+00:13:53,500 --> 00:13:59,230
+this bhakti starts, this dedication starts,
+
+153
+00:13:59,691 --> 00:14:05,254
+and you are cleansed by that bhakti.
+
+154
+00:14:06,778 --> 00:14:12,069
+All the bad qualities you have,
+
+155
+00:14:12,270 --> 00:14:18,231
+you can call them, all the deficiencies you have,
+
+156
+00:14:19,160 --> 00:14:24,128
+all the problems you have,
+
+157
+00:14:24,779 --> 00:14:29,177
+you understand and you get over it.
+
+158
+00:14:29,439 --> 00:14:34,875
+Now if you see somebody with the same qualities,
+
+159
+00:14:35,113 --> 00:14:39,422
+with the same troubles,
+
+160
+00:14:39,676 --> 00:14:45,009
+you in the love of that person
+
+161
+00:14:45,279 --> 00:14:47,660
+you try to tolerate.
+
+162
+00:14:49,113 --> 00:14:52,748
+Such a person just tolerates.
+
+163
+00:15:02,683 --> 00:15:06,683
+There is no aggression,
+
+164
+00:15:06,937 --> 00:15:12,271
+and these people forgive.
+
+165
+00:15:12,906 --> 00:15:14,744
+Realised Souls go on forgiving,
+
+166
+00:15:14,945 --> 00:15:18,540
+their capacity to forgive is tremendous.
+
+167
+00:15:19,428 --> 00:15:25,015
+They do not bear any malice against anyone.
+
+168
+00:15:25,420 --> 00:15:29,015
+They don't have any anger about anyone.
+
+169
+00:15:29,245 --> 00:15:35,145
+They just go on tolerating and forgiving and forgiving.
+
+170
+00:15:35,852 --> 00:15:40,026
+This forgiveness is just
+
+171
+00:15:40,264 --> 00:15:46,211
+a music, I should say, of your bhakti.
+
+172
+00:15:46,983 --> 00:15:50,062
+The amount of forgiveness
+
+173
+00:15:50,268 --> 00:15:55,157
+these masters could have, can be seen from the life of Christ.
+
+174
+00:15:56,244 --> 00:16:01,080
+They are tortured, crucified - most of the saints were tortured.
+
+175
+00:16:01,281 --> 00:16:03,588
+People never liked them.
+
+176
+00:16:03,826 --> 00:16:09,746
+And they were crucified, but as you know
+
+177
+00:16:10,564 --> 00:16:14,810
+that they never resented,
+
+178
+00:16:15,112 --> 00:16:18,008
+they never take a revenge,
+
+179
+00:16:18,214 --> 00:16:24,163
+they never did anything which was not compassionate.
+
+180
+00:16:24,641 --> 00:16:30,431
+They had compassion and compassion for such people,
+
+181
+00:16:30,653 --> 00:16:36,622
+they felt that 'Oh God, please forgive them.
+
+182
+00:16:38,697 --> 00:16:42,962
+What they are doing they don't know'.
+
+183
+00:16:43,173 --> 00:16:45,761
+Extremely compassionate.
+
+184
+00:16:45,983 --> 00:16:49,965
+And they are that, that becomes their nature.
+
+185
+00:16:50,166 --> 00:16:54,055
+When it becomes their nature,
+
+186
+00:16:54,270 --> 00:17:00,917
+they become people with complete peace.
+
+187
+00:17:01,980 --> 00:17:04,969
+They are not disturbed.
+
+188
+00:17:05,169 --> 00:17:09,899
+They are never disturbed with whatever is happening
+
+189
+00:17:10,161 --> 00:17:14,303
+and they think it's God's will.
+
+190
+00:17:14,605 --> 00:17:17,400
+Because nothing can disturb them,
+
+191
+00:17:17,747 --> 00:17:20,898
+nothing can upset them.
+
+192
+00:17:22,628 --> 00:17:28,545
+They just enjoy their devotion.
+
+193
+00:17:30,116 --> 00:17:35,305
+Devotion to their guru maybe.
+
+194
+00:17:35,695 --> 00:17:39,202
+Devotion to God.
+
+195
+00:17:41,059 --> 00:17:45,805
+In that devotion they may write
+
+196
+00:17:46,114 --> 00:17:51,378
+beautiful poetry, they may go on dancing,
+
+197
+00:17:51,672 --> 00:17:56,330
+they may go on singing, because the peace is within
+
+198
+00:17:56,561 --> 00:18:01,509
+and they are enjoying themselves.
+
+199
+00:18:04,898 --> 00:18:09,544
+When they are alone, they are never alone,
+
+200
+00:18:09,814 --> 00:18:12,787
+they enjoy themselves.
+
+201
+00:18:13,012 --> 00:18:16,726
+They know that -
+
+202
+00:18:16,980 --> 00:18:22,085
+"We are one with the Divine"
+
+203
+00:18:22,363 --> 00:18:26,140
+- and the blessing of the Divine they enjoy.
+
+204
+00:18:27,185 --> 00:18:30,828
+Another thing is they never take to artificiality.
+
+205
+00:18:32,820 --> 00:18:37,685
+They are never worried, never upset,
+
+206
+00:18:37,899 --> 00:18:43,078
+they are neither futuristic nor think of the past,
+
+207
+00:18:43,279 --> 00:18:46,772
+but they are in the present.
+
+208
+00:18:49,703 --> 00:18:55,595
+When they are in the present, they are absolutely silent.
+
+209
+00:18:55,921 --> 00:19:01,889
+If there is any problem, or anything happens to them,
+
+210
+00:19:02,492 --> 00:19:08,177
+they immediately go into thoughtless awareness.
+
+211
+00:19:08,899 --> 00:19:12,645
+That is what their capacity is.
+
+212
+00:19:13,899 --> 00:19:18,756
+To become a guru you have to develop that personality.
+
+213
+00:19:19,859 --> 00:19:23,031
+Not to be bound by anything.
+
+214
+00:19:23,232 --> 00:19:26,007
+Now I'll tell you my own example.
+
+215
+00:19:26,207 --> 00:19:31,167
+I never hurry, I'm never bothered about time.
+
+216
+00:19:32,888 --> 00:19:35,864
+Once I was going to America -
+
+217
+00:19:36,126 --> 00:19:40,134
+because if you are sure the Divine has plans for you,
+
+218
+00:19:40,436 --> 00:19:42,298
+you are not bothered,
+
+219
+00:19:42,499 --> 00:19:45,999
+the Divine is looking after you, so why to bother --
+
+220
+00:19:46,277 --> 00:19:49,443
+I was going to America and one child fell down.
+
+221
+00:19:49,644 --> 00:19:52,849
+I was just about to get up and go -
+
+222
+00:19:53,143 --> 00:19:56,929
+and broke her arm.
+
+223
+00:19:57,421 --> 00:20:02,727
+And when I saw the child I said "All right, I'll put that child right".
+
+224
+00:20:02,973 --> 00:20:07,742
+But, they said, "You are going to America!"
+I said, "I'll go in any case!
+
+225
+00:20:08,035 --> 00:20:11,717
+"So I cured the child, it took about half an hour,
+
+226
+00:20:11,955 --> 00:20:15,400
+and then I came out "All right, let's go to the airport".
+
+227
+00:20:15,654 --> 00:20:20,519
+They said, "Mother you are very late". I said, "I'm never late.
+
+228
+00:20:21,241 --> 00:20:22,675
+Let's go!".
+
+229
+00:20:22,876 --> 00:20:26,360
+We went there to the airport,
+
+230
+00:20:26,561 --> 00:20:30,487
+and the plane by which I was going was out of order,
+
+231
+00:20:30,757 --> 00:20:33,802
+so there was another plane going to Washington not to New York,
+
+232
+00:20:34,003 --> 00:20:37,894
+and I wanted to go to Washington only!
+
+233
+00:20:38,648 --> 00:20:42,378
+So just imagine how things work out,
+
+234
+00:20:43,362 --> 00:20:49,052
+and we call them 'Sahaja'. It has worked out 'Sahaja'.
+
+235
+00:20:58,483 --> 00:21:02,372
+That means it's effortless.
+
+236
+00:21:03,467 --> 00:21:08,705
+But first of all your personality should be such
+
+237
+00:21:10,301 --> 00:21:16,200
+that your devotion
+
+238
+00:21:16,597 --> 00:21:18,800
+is so great
+
+239
+00:21:19,013 --> 00:21:24,971
+that Divine is compelled to look after you...
+
+240
+00:21:28,630 --> 00:21:31,645
+compelled to look after you!
+
+241
+00:21:33,719 --> 00:21:39,632
+You have to understand that Divine force is around you,
+
+242
+00:21:41,481 --> 00:21:45,252
+and this Divine force is
+
+243
+00:21:46,085 --> 00:21:50,696
+absolute guarantee for your safety.
+
+244
+00:21:50,982 --> 00:21:55,196
+For everything that you want to do.
+
+245
+00:21:58,585 --> 00:22:01,878
+You can say that "Mother you are very powerful".
+
+246
+00:22:02,079 --> 00:22:05,402
+You can become also very powerful!
+
+247
+00:22:05,603 --> 00:22:11,555
+If you get completely dedicated to the Divine work,
+
+248
+00:22:11,904 --> 00:22:14,956
+you will also have all the powers
+
+249
+00:22:15,157 --> 00:22:21,077
+and the Divine will provide all the necessary work
+
+250
+00:22:22,117 --> 00:22:26,875
+that you want to do, necessary time you have to have.
+
+251
+00:22:27,089 --> 00:22:32,065
+Everything is provided by the Divine.
+
+252
+00:22:33,169 --> 00:22:36,002
+But the compassion,
+
+253
+00:22:36,248 --> 00:22:41,010
+when it extends from other people to God,
+
+254
+00:22:41,265 --> 00:22:46,806
+or to Divine person or to your guru,
+
+255
+00:22:47,475 --> 00:22:53,387
+then it becomes very easy to live,
+
+256
+00:22:54,673 --> 00:22:59,126
+very simple to live, no complications,
+
+257
+00:22:59,341 --> 00:23:01,713
+everything is sorted out,
+
+258
+00:23:01,913 --> 00:23:06,214
+and you are not bothered about anything.
+
+259
+00:23:06,967 --> 00:23:11,975
+You just close your eyes and things work out.
+
+260
+00:23:13,301 --> 00:23:19,057
+Everything works out as if that's your will,
+
+261
+00:23:19,258 --> 00:23:24,361
+but you don't have to will it, don't have to think about it,
+
+262
+00:23:24,654 --> 00:23:28,937
+it just works out, but Divine looks after everything.
+
+263
+00:23:29,138 --> 00:23:31,241
+It looks after your comfort,
+
+264
+00:23:31,442 --> 00:23:37,407
+looks after your health, everything.
+
+265
+00:23:37,963 --> 00:23:42,750
+And this Divine help,
+
+266
+00:23:43,067 --> 00:23:47,790
+you do not seek, you do not ask for,
+
+267
+00:23:48,075 --> 00:23:50,785
+but you are a personality
+
+268
+00:23:50,991 --> 00:23:55,737
+for which the Divine is responsible.
+
+269
+00:23:55,959 --> 00:24:01,518
+You are a special responsibility of the Divine.
+
+270
+00:24:01,764 --> 00:24:06,804
+And it knows what is good for you and what is not.
+
+271
+00:24:07,534 --> 00:24:12,559
+It's an example, I can give many where I,
+
+272
+00:24:12,765 --> 00:24:17,717
+supposing, I thought somebody is coming to meet me,
+
+273
+00:24:18,035 --> 00:24:24,008
+and people told me "Mother, he's very negative", He will never come,
+
+274
+00:24:24,341 --> 00:24:26,230
+he'll never come.
+
+275
+00:24:26,444 --> 00:24:31,782
+All positive things will happen, and if a negative things take place,
+
+276
+00:24:32,020 --> 00:24:35,635
+then you will use your compassion.
+
+277
+00:24:35,835 --> 00:24:38,762
+If it is negative you'll use your compassion
+
+278
+00:24:38,963 --> 00:24:41,468
+and you'll solve the problem.
+
+279
+00:24:41,777 --> 00:24:45,886
+You can solve the problems of your own,
+
+280
+00:24:46,117 --> 00:24:50,506
+of your surroundings, of your community.
+
+281
+00:24:51,712 --> 00:24:55,562
+So now you have got your Self realisation.
+
+282
+00:24:55,824 --> 00:24:59,574
+How far you have gone in that I don't know.
+
+283
+00:24:59,775 --> 00:25:04,058
+I have a complaint about women, so many ladies,
+
+284
+00:25:04,259 --> 00:25:07,584
+that they don't meditate.
+
+285
+00:25:08,092 --> 00:25:11,743
+That they are not looking after themselves,
+
+286
+00:25:11,973 --> 00:25:14,105
+they are not realised souls,
+
+287
+00:25:14,306 --> 00:25:17,965
+and that's why many men want to divorce them
+
+288
+00:25:18,203 --> 00:25:23,875
+because they think these women are good for nothing,
+
+289
+00:25:24,153 --> 00:25:30,034
+and some men also are like that.
+
+290
+00:25:31,082 --> 00:25:36,988
+To solve this problem you have to have compassion,
+
+291
+00:25:37,512 --> 00:25:40,850
+and you have to, somehow or other, with compassion
+
+292
+00:25:41,051 --> 00:25:47,027
+you should win over the partner of your life.
+
+293
+00:25:48,455 --> 00:25:53,057
+After all men are much more busy than women are.
+
+294
+00:25:53,343 --> 00:25:58,712
+But women indulge into so many other things.
+
+295
+00:25:58,954 --> 00:26:04,923
+They have to look after their family, their children, their everything.
+
+296
+00:26:05,558 --> 00:26:11,510
+And their mind is involved into all such mundane things
+
+297
+00:26:11,947 --> 00:26:15,275
+that they have no time to meditate.
+
+298
+00:26:15,743 --> 00:26:18,419
+Without meditation you cannot rise.
+
+299
+00:26:18,640 --> 00:26:21,345
+You have to meditate.
+
+300
+00:26:21,546 --> 00:26:25,561
+People think that: "Now we have got realisation, so it's all right". No!
+
+301
+00:26:25,807 --> 00:26:28,309
+Every day you must meditate
+
+302
+00:26:28,510 --> 00:26:32,573
+because that's the cleansing that takes place.
+
+303
+00:26:32,819 --> 00:26:37,238
+With the cleansing you understand.
+
+304
+00:26:37,643 --> 00:26:42,960
+You understand what is needed
+
+305
+00:26:43,161 --> 00:26:46,918
+and what is not needed, you are cleansed out.
+
+306
+00:26:47,119 --> 00:26:48,819
+That is done by Divine.
+
+307
+00:26:49,020 --> 00:26:52,988
+But you must religiously meditate.
+
+308
+00:27:00,878 --> 00:27:06,308
+Gradually you will find your meditation will become very deep.
+
+309
+00:27:07,125 --> 00:27:10,283
+You will become very, very deep
+
+310
+00:27:10,498 --> 00:27:14,648
+and your powers will start showing.
+
+311
+00:27:19,739 --> 00:27:25,517
+When you are anywhere, negativity will run away.
+
+312
+00:27:25,954 --> 00:27:30,943
+All sorts of problems can be solved.
+
+313
+00:27:32,110 --> 00:27:36,544
+Whatever you want to do is available to you.
+
+314
+00:27:36,800 --> 00:27:42,381
+Whatever is your desire to help others
+
+315
+00:27:42,618 --> 00:27:46,514
+or give to someone, you just get it.
+
+316
+00:27:46,809 --> 00:27:50,777
+Is my own experience I'm telling you.
+
+317
+00:27:51,031 --> 00:27:56,433
+You have to meditate at least 10 minutes
+
+318
+00:27:56,634 --> 00:28:01,026
+every evening and morning about 5 minutes.
+
+319
+00:28:01,597 --> 00:28:07,343
+With complete devotion, with complete admiration.
+
+320
+00:28:07,612 --> 00:28:13,601
+I have seen some people here, such bhakti, such devotion,
+
+321
+00:28:14,434 --> 00:28:18,957
+which is shraddha - is higher than bhakti -
+
+322
+00:28:19,195 --> 00:28:24,004
+that it becomes part and parcel of your being.
+
+323
+00:28:24,290 --> 00:28:29,592
+It just envelops you completely.
+
+324
+00:28:29,806 --> 00:28:34,944
+When you have that shraddha, it is very miraculous.
+
+325
+00:28:35,166 --> 00:28:38,610
+It works so many miracles.
+
+326
+00:28:38,810 --> 00:28:41,395
+It's true some people were cured
+
+327
+00:28:41,596 --> 00:28:46,246
+only thinking of me, is a fact.
+
+328
+00:28:46,664 --> 00:28:51,545
+But that doesn't mean that they had the shraddha of that level,
+
+329
+00:28:51,791 --> 00:28:56,156
+but that means that they have to develop shraddha.
+
+330
+00:28:56,394 --> 00:28:58,534
+Now how to develop a shraddha,
+
+331
+00:28:58,735 --> 00:29:03,711
+is a natural light of the Spirit.
+
+332
+00:29:05,707 --> 00:29:10,929
+Because people are trying very hard
+
+333
+00:29:12,135 --> 00:29:15,190
+to develop shraddha,
+
+334
+00:29:15,429 --> 00:29:20,850
+but shraddha cannot be developed by mental activity,
+
+335
+00:29:21,175 --> 00:29:26,413
+by any activity, but meditation of silence.
+
+336
+00:29:26,738 --> 00:29:32,414
+If you do the meditation - I have always told you to do meditation.
+
+337
+00:29:32,615 --> 00:29:34,654
+I immediately know a person
+
+338
+00:29:34,855 --> 00:29:38,551
+who has been meditating and who has not been.
+
+339
+00:29:38,765 --> 00:29:41,312
+They'll come to my puja, all right,
+
+340
+00:29:41,542 --> 00:29:45,447
+and they'll talk about Sahaja Yoga,
+
+341
+00:29:45,709 --> 00:29:50,256
+they'll go out and do it for popularity.
+
+342
+00:29:50,510 --> 00:29:52,349
+Many people are like that.
+
+343
+00:29:52,550 --> 00:29:56,775
+They go out and for popularity they work it out.
+
+344
+00:29:56,989 --> 00:30:02,974
+But inside they have not yet traced their own Self.
+
+345
+00:30:04,315 --> 00:30:10,258
+So at this development stage you should be encouraged,
+
+346
+00:30:10,600 --> 00:30:16,584
+and should be understood that you can reach that state very easily
+
+347
+00:30:16,869 --> 00:30:22,154
+through meditation and introspection.
+
+348
+00:30:22,472 --> 00:30:28,436
+With introspection you will develop a new quality of understanding
+
+349
+00:30:28,793 --> 00:30:34,790
+that you will find solutions to things.
+
+350
+00:30:36,251 --> 00:30:41,703
+That is another quality a person who is a realised soul has.
+
+351
+00:30:41,925 --> 00:30:47,901
+It can find solutions to all your problems.
+
+352
+00:30:49,790 --> 00:30:54,446
+It can, he can suggest what is the way
+
+353
+00:30:54,647 --> 00:30:58,877
+you can be helped.
+
+354
+00:31:00,202 --> 00:31:05,968
+Then a kind of a brotherhood out of the shraddha develops.
+
+355
+00:31:06,238 --> 00:31:08,341
+You may be giving big lectures on Sahaja Yoga,
+
+356
+00:31:08,556 --> 00:31:10,824
+you may be doing all kinds of things,
+
+357
+00:31:11,024 --> 00:31:16,214
+but unless and until you have shraddha,
+
+358
+00:31:16,454 --> 00:31:18,881
+you cannot rise.
+
+359
+00:31:19,119 --> 00:31:23,458
+And this shraddha is a kind of a love within you,
+
+360
+00:31:23,696 --> 00:31:29,648
+I should say, which spreads like gentle fire
+
+361
+00:31:30,735 --> 00:31:35,688
+which doesn't burn, which doesn't give heat,
+
+362
+00:31:35,934 --> 00:31:41,847
+but cold, beautiful breeze-like feeling within,
+
+363
+00:31:42,823 --> 00:31:46,980
+which makes you understand.
+
+364
+00:31:47,258 --> 00:31:52,638
+You will never talk ill about a sahaja yogi, never.
+
+365
+00:31:52,861 --> 00:31:58,428
+I never listen to anybody who tells me something against sahaja yogi.
+
+366
+00:31:58,713 --> 00:32:04,642
+Up to a point, when it is a collective complaint,
+
+367
+00:32:05,039 --> 00:32:09,601
+then I am little bit bothered and I talk about it to the leader.
+
+368
+00:32:09,863 --> 00:32:14,189
+But otherwise if one person comes and tells me this and this,
+
+369
+00:32:14,411 --> 00:32:20,366
+I just tell that person, "You introspect yourself, it's not so".
+
+370
+00:32:20,646 --> 00:32:23,806
+Finding faults with others
+
+371
+00:32:29,745 --> 00:32:33,286
+is a common game all human beings play.
+
+372
+00:32:33,516 --> 00:32:35,839
+They never see their own faults.
+
+373
+00:32:36,040 --> 00:32:39,855
+What's the use of finding faults of others?
+
+374
+00:32:40,056 --> 00:32:45,645
+By finding faults with others you're not going to be helped.
+
+375
+00:32:45,883 --> 00:32:50,213
+Try to find faults within you, which you can cure,
+
+376
+00:32:50,414 --> 00:32:56,281
+which you can help, which you can work it out.
+
+377
+00:32:56,930 --> 00:33:02,652
+It's a responsibility you have, you must know to yourself
+
+378
+00:33:02,914 --> 00:33:06,397
+that you better find out your defects
+
+379
+00:33:06,598 --> 00:33:10,183
+and get them corrected.
+
+380
+00:33:10,906 --> 00:33:16,148
+But some people are very proud of their fondness --
+
+381
+00:33:16,349 --> 00:33:20,484
+they talk like this, "I like this, I like that".
+
+382
+00:33:20,770 --> 00:33:23,807
+What about the Spirit?
+
+383
+00:33:24,008 --> 00:33:28,965
+You like this, you like that, then what about your Spirit?
+
+384
+00:33:29,166 --> 00:33:30,988
+Does it like?
+
+385
+00:33:31,189 --> 00:33:36,339
+Does it enjoy?
+
+386
+00:33:36,681 --> 00:33:39,170
+They'll go on saying, "I like this, I don't like this,
+
+387
+00:33:39,371 --> 00:33:43,456
+I don't like that!" It's very common in the West.
+
+388
+00:33:43,657 --> 00:33:48,181
+Now see, some ladies have made this beautiful carpets for me.
+
+389
+00:33:48,412 --> 00:33:54,396
+They are so thick that when I walk on them I little bit lose balance,
+
+390
+00:33:54,721 --> 00:33:58,103
+but the love with which they are made,
+
+391
+00:33:58,397 --> 00:34:04,095
+makes me so joyous, so happy,
+
+392
+00:34:04,421 --> 00:34:09,797
+that you can't imagine, what I feel about them.
+
+393
+00:34:10,067 --> 00:34:15,210
+This joy, this ocean of joy, is within you.
+
+394
+00:34:15,424 --> 00:34:19,711
+And when it starts stirring up,
+
+395
+00:34:19,911 --> 00:34:25,879
+it doesn't torment you, it gives you beautiful --
+
+396
+00:34:26,149 --> 00:34:29,798
+I don't know how to use words to express that --
+
+397
+00:34:29,998 --> 00:34:34,902
+it's like a drizzle on your being,
+
+398
+00:34:35,148 --> 00:34:39,066
+it's like a grace on your being.
+
+399
+00:34:39,267 --> 00:34:44,513
+The love of other people enthrals you.
+
+400
+00:34:46,449 --> 00:34:51,410
+You don't ask for it, but if you see a person
+
+401
+00:34:51,696 --> 00:34:54,902
+who is very loving and kind,
+
+402
+00:34:55,172 --> 00:35:00,592
+there is real friendship in that kind of relationship.
+
+403
+00:35:00,894 --> 00:35:06,358
+But talking ill about sahaja yogis, it's very wrong.
+
+404
+00:35:06,558 --> 00:35:11,809
+And then talking to everyone that, "This is wrong with this person,
+
+405
+00:35:12,010 --> 00:35:17,954
+he had done this, he had done that", is very, very wrong
+
+406
+00:35:18,716 --> 00:35:22,329
+and creating a collective feeling against the person --
+
+407
+00:35:22,535 --> 00:35:26,358
+instead of helping that person.
+
+408
+00:35:26,628 --> 00:35:29,522
+Always people are in trouble.
+
+409
+00:35:29,723 --> 00:35:33,030
+Then collectively you must help that person.
+
+410
+00:35:33,231 --> 00:35:37,191
+Not talk ill of that person. May be some mistakes,
+
+411
+00:35:37,429 --> 00:35:42,805
+but if you start talking against that person and saying,
+
+412
+00:35:43,006 --> 00:35:47,022
+that 'This is wrong with him, that is wrong with him',
+
+413
+00:35:47,229 --> 00:35:50,670
+then you are not a sahaja yogi.
+
+414
+00:35:50,871 --> 00:35:53,852
+You are a sahaja yogi as long as you can see
+
+415
+00:35:54,053 --> 00:35:58,656
+your own defects through introspection.
+
+416
+00:36:01,403 --> 00:36:06,800
+Now many of you, I should say most of you, have got your realisation.
+
+417
+00:36:07,022 --> 00:36:09,713
+You had the experience.
+
+418
+00:36:09,951 --> 00:36:15,227
+But some of you don't have the knowledge.
+
+419
+00:36:16,179 --> 00:36:18,462
+That knowledge you should acquire
+
+420
+00:36:18,663 --> 00:36:24,129
+and verify whether that knowledge is really there or not.
+
+421
+00:36:28,207 --> 00:36:31,493
+Like in America,
+
+422
+00:36:31,944 --> 00:36:37,849
+in the NIH, which is an Institute for Health,
+
+423
+00:36:38,579 --> 00:36:43,652
+they wanted to test a sahaja yogi and there were doctors.
+
+424
+00:36:43,853 --> 00:36:46,151
+And one doctor came forward and said,
+
+425
+00:36:46,352 --> 00:36:51,440
+"All right, tell me on your vibration, what's wrong with me".
+
+426
+00:36:52,408 --> 00:36:57,023
+So the girl said, "Sir, something wrong with your heart".
+
+427
+00:36:57,277 --> 00:36:59,237
+He said, "It's correct".
+
+428
+00:36:59,467 --> 00:37:05,419
+Because he has had a bypass only one month back
+
+429
+00:37:06,626 --> 00:37:09,383
+and he was out of hospital.
+
+430
+00:37:09,636 --> 00:37:13,213
+Absolutely correct, and this surprised them.
+
+431
+00:37:13,414 --> 00:37:18,960
+That diagnosis, you see, kills the patient half way.
+
+432
+00:37:19,246 --> 00:37:22,603
+So this is the very easy way to diagnose a person,
+
+433
+00:37:22,817 --> 00:37:25,579
+just by feeling the vibration.
+
+434
+00:37:25,801 --> 00:37:30,976
+And they have given us such a good attention,
+
+435
+00:37:31,177 --> 00:37:36,446
+they want to develop Sahaja Yoga in their hospitals.
+
+436
+00:37:41,716 --> 00:37:46,269
+So you should also testify yourself,
+
+437
+00:37:46,477 --> 00:37:51,716
+examine yourself and find out about yourself,  what are you?
+
+438
+00:37:55,319 --> 00:38:01,280
+Say husband and wife -- now the wife meditates,
+
+439
+00:38:01,709 --> 00:38:06,232
+she knows everything, she knows about her husband,
+
+440
+00:38:06,447 --> 00:38:10,335
+what's wrong with him
+
+441
+00:38:21,439 --> 00:38:26,089
+and she doesn't tell him.
+
+442
+00:38:26,693 --> 00:38:29,937
+She tolerates,
+
+443
+00:38:30,138 --> 00:38:33,312
+she doesn't complain, she doesn't ask for anything,
+
+444
+00:38:33,598 --> 00:38:35,558
+she just tolerates.
+
+445
+00:38:35,812 --> 00:38:40,634
+And this tolerance convinces the husband
+
+446
+00:38:40,840 --> 00:38:45,872
+that she's a higher personality than himself.
+
+447
+00:38:46,128 --> 00:38:49,826
+He may be anything, but he then understands
+
+448
+00:38:50,072 --> 00:38:55,673
+that this is what she has achieved, a great personality.
+
+449
+00:38:56,659 --> 00:39:02,353
+We have so many imperfections, especially morally, in the West,
+
+450
+00:39:02,554 --> 00:39:08,131
+people are really, I tell you, like one snake has bitten them.
+
+451
+00:39:09,591 --> 00:39:11,604
+The things that people do here
+
+452
+00:39:11,805 --> 00:39:17,083
+never come into the minds of people who are not developed.
+
+453
+00:39:17,352 --> 00:39:22,818
+So development has meant all kinds of abandonment,
+
+454
+00:39:23,040 --> 00:39:29,004
+all kinds of vagabond temperament,
+
+455
+00:39:29,337 --> 00:39:34,940
+and they think they are very free and they can go about and enjoy.
+
+456
+00:39:35,551 --> 00:39:41,530
+This style is very common,
+
+457
+00:39:42,863 --> 00:39:47,363
+but you just judge yourself. Are you one of these type?
+
+458
+00:39:47,564 --> 00:39:53,334
+Or are you one of the people who are higher than you in their ascent.
+
+459
+00:39:56,048 --> 00:39:58,479
+It's a process, I must confess.
+
+460
+00:39:58,680 --> 00:40:03,187
+It is not just that you get to that point.
+
+461
+00:40:03,664 --> 00:40:06,351
+Sometimes even very new sahaja yogis
+
+462
+00:40:06,552 --> 00:40:09,409
+are better than very old sahaja yogis,
+
+463
+00:40:09,610 --> 00:40:15,512
+but because they had a very strong desire.
+
+464
+00:40:16,427 --> 00:40:18,361
+What are we seeking?
+
+465
+00:40:18,562 --> 00:40:22,507
+We should understand why we were seeking --
+
+466
+00:40:22,721 --> 00:40:26,625
+because we wanted to know ourselves.
+
+467
+00:40:26,895 --> 00:40:30,276
+Somehow, we knew that we have to know ourselves,
+
+468
+00:40:30,477 --> 00:40:33,429
+and we did not know, so we seek.
+
+469
+00:40:33,630 --> 00:40:36,183
+We seek. We do all kinds of things,
+
+470
+00:40:36,384 --> 00:40:39,812
+I mean all wrong things also in the name of seeking.
+
+471
+00:40:40,463 --> 00:40:45,904
+But it is this seeking
+
+472
+00:40:46,104 --> 00:40:49,230
+brings you to Sahaja Yoga.
+
+473
+00:40:49,453 --> 00:40:53,024
+Then you have to get your Self realisation,
+
+474
+00:40:53,310 --> 00:40:56,124
+which is very easy through Kundalini.
+
+475
+00:40:56,878 --> 00:41:00,812
+Kundalini works out most of the things, most of the things.
+
+476
+00:41:01,013 --> 00:41:04,354
+Like somebody told me that overnight
+
+477
+00:41:05,044 --> 00:41:10,417
+she gave up drinking and smoking -- overnight.
+
+478
+00:41:11,725 --> 00:41:15,238
+I mean I don't tell that, I never say that.
+
+479
+00:41:15,439 --> 00:41:18,191
+But just overnight she gave up,
+
+480
+00:41:18,392 --> 00:41:22,046
+and she said, "I was very particular about my hair dress
+
+481
+00:41:22,247 --> 00:41:25,911
+and I used to make my hair dress in a different manner,
+
+482
+00:41:26,112 --> 00:41:27,708
+going to the hairdressers,
+
+483
+00:41:27,909 --> 00:41:31,467
+spending so much time with the beautician, this, that".
+
+484
+00:41:31,668 --> 00:41:34,012
+She said, "I gave it up".
+
+485
+00:41:34,273 --> 00:41:40,170
+Also she said, "I used to wear dresses which were not very moral,
+
+486
+00:41:41,037 --> 00:41:43,941
+then I started respecting my body
+
+487
+00:41:44,142 --> 00:41:47,560
+and I started wearing proper dress".
+
+488
+00:41:48,396 --> 00:41:50,893
+All this knowledge comes to you,
+
+489
+00:41:51,094 --> 00:41:56,853
+spontaneously it is within you, because it is all your own.
+
+490
+00:41:57,054 --> 00:42:01,317
+Also if your guru tells you, you are guided.
+
+491
+00:42:01,518 --> 00:42:05,248
+Guru's job is to guide people.
+
+492
+00:42:05,448 --> 00:42:09,771
+So at this juncture, what is lacking?
+
+493
+00:42:09,993 --> 00:42:13,889
+What is lacking in Sahaja Yoga?
+
+494
+00:42:14,184 --> 00:42:16,342
+That I have to tell you.
+
+495
+00:42:16,588 --> 00:42:22,525
+There are so many collective disasters we have - all kinds of.
+
+496
+00:42:23,469 --> 00:42:27,668
+We had many earthquakes, we had many floods,
+
+497
+00:42:27,890 --> 00:42:32,744
+rain, then the muds - mud came down like a river
+
+498
+00:42:32,945 --> 00:42:35,347
+and so many disasters in the world
+
+499
+00:42:35,548 --> 00:42:40,223
+and sahaja yogis are saved from that.
+
+500
+00:42:40,589 --> 00:42:44,311
+All the sahaja yogis are saved from that, no doubt,
+
+501
+00:42:44,533 --> 00:42:49,586
+but after being saved, what is your understanding?
+
+502
+00:42:49,818 --> 00:42:52,101
+What do you know?
+
+503
+00:42:52,302 --> 00:42:55,875
+Why these disasters are coming?
+
+504
+00:42:56,113 --> 00:43:00,605
+Because Sahaja Yoga is not very collective.
+
+505
+00:43:00,835 --> 00:43:03,279
+It has to become very collective.
+
+506
+00:43:03,480 --> 00:43:07,571
+It has to spread much more, all over.
+
+507
+00:43:07,777 --> 00:43:11,894
+It has to go to many people, which we don't do.
+
+508
+00:43:12,095 --> 00:43:16,250
+We are at a standstill, or little bit we do it.
+
+509
+00:43:16,451 --> 00:43:21,329
+But go all out! Look at Christ's twelve disciples!
+
+510
+00:43:21,583 --> 00:43:26,123
+Of course the people went into wrong things.
+
+511
+00:43:26,329 --> 00:43:32,291
+But how they worked and how intensively they did it.
+
+512
+00:43:33,918 --> 00:43:37,897
+That intensity if you don't have,
+
+513
+00:43:38,111 --> 00:43:42,116
+and if you do not completely dedicate
+
+514
+00:43:42,331 --> 00:43:45,735
+to the spreading of Sahaja Yoga,
+
+515
+00:43:45,969 --> 00:43:51,108
+then collective problems cannot be solved.
+
+516
+00:43:52,423 --> 00:43:55,200
+You are busy with your daily mundane things,
+
+517
+00:43:55,401 --> 00:43:57,494
+and your other jobs and everything.
+
+518
+00:43:57,701 --> 00:44:01,256
+It's all right, in Sahaja Yoga no objection.
+
+519
+00:44:01,486 --> 00:44:07,402
+But you should have your attention more
+
+520
+00:44:08,267 --> 00:44:13,177
+on to this side of life that -
+
+521
+00:44:13,378 --> 00:44:17,526
+'What are we doing for the collective? Are we talking about it?
+
+522
+00:44:17,727 --> 00:44:19,486
+Are we spreading Sahaja Yoga?
+
+523
+00:44:19,687 --> 00:44:24,346
+Are we making people know about it?'
+
+524
+00:44:24,623 --> 00:44:28,203
+I was surprised, once I was coming by plane
+
+525
+00:44:28,442 --> 00:44:33,981
+and a lady sat next to me and had very bad vibrations.
+
+526
+00:44:40,290 --> 00:44:43,491
+I put myself into bandhan,
+
+527
+00:44:43,737 --> 00:44:48,287
+and I asked her what is she doing for her spirituality,
+
+528
+00:44:48,952 --> 00:44:53,031
+and she gave the name of 'Bahai' people.
+
+529
+00:44:53,332 --> 00:44:57,067
+"My God", I said. If these people spread out,
+
+530
+00:44:57,268 --> 00:45:01,789
+they are so spread out, they are so many!
+
+531
+00:45:01,990 --> 00:45:03,327
+So, what will happen?
+
+532
+00:45:03,528 --> 00:45:05,737
+Disasters!
+
+533
+00:45:05,938 --> 00:45:08,501
+They are such negative people,
+
+534
+00:45:08,702 --> 00:45:13,784
+impossible that they can do any good to the world.
+
+535
+00:45:13,985 --> 00:45:18,529
+And like that you see, anybody, false guru,
+
+536
+00:45:18,752 --> 00:45:23,162
+how people are driven to them, how they take to them,
+
+537
+00:45:23,362 --> 00:45:25,638
+and how they spread their message.
+
+538
+00:45:25,839 --> 00:45:29,266
+I have seen people singing on the road,
+
+539
+00:45:29,467 --> 00:45:31,888
+singing the praise of their guru,
+
+540
+00:45:32,134 --> 00:45:36,570
+and also wearing funny dresses --
+
+541
+00:45:36,840 --> 00:45:39,237
+we don't want that kind of a thing.
+
+542
+00:45:39,443 --> 00:45:43,297
+But of course you have got the knowledge,
+
+543
+00:45:43,498 --> 00:45:45,932
+of course you are realised souls.
+
+544
+00:45:46,133 --> 00:45:50,233
+But what have you done for Sahaja Yoga is the point.
+
+545
+00:45:50,463 --> 00:45:55,423
+You have to spread Sahaja Yoga...
+
+546
+00:45:55,939 --> 00:45:58,193
+...everywhere.
+
+547
+00:45:58,526 --> 00:46:02,753
+For example, you wear a badge,
+
+548
+00:46:02,954 --> 00:46:06,641
+then they will ask you, "What is this supposed to be?"
+
+549
+00:46:06,842 --> 00:46:10,776
+Then you have to tell them what is it, something.
+
+550
+00:46:10,977 --> 00:46:13,482
+You start talking about Sahaja Yoga only!
+
+551
+00:46:13,697 --> 00:46:16,670
+Talk nothing else but Sahaja Yoga.
+
+552
+00:46:16,871 --> 00:46:19,855
+You have to go on talking about Sahaja Yoga,
+
+553
+00:46:20,056 --> 00:46:23,704
+spreading Sahaja Yoga: unless and until you do it,
+
+554
+00:46:23,905 --> 00:46:27,497
+it won't become collective, and all the disasters,
+
+555
+00:46:27,698 --> 00:46:32,404
+which are due to collective nonsense, you get it.
+
+556
+00:46:35,037 --> 00:46:38,134
+You are saved from so many things.
+
+557
+00:46:38,396 --> 00:46:43,457
+Say even if there's pollution, for a sahaja yogi it won't matter.
+
+558
+00:46:43,658 --> 00:46:48,337
+Even if there is a disaster of an earthquake
+
+559
+00:46:48,538 --> 00:46:50,885
+the sahaja yogi will be saved.
+
+560
+00:46:51,086 --> 00:46:54,158
+But why not save the whole world?
+
+561
+00:46:54,571 --> 00:46:57,560
+Calamities after calamities are coming,
+
+562
+00:46:57,761 --> 00:47:02,973
+and if you have compassion you must think of the people
+
+563
+00:47:03,174 --> 00:47:07,861
+who can get into any calamity or into any trouble.
+
+564
+00:47:08,424 --> 00:47:13,567
+Of course I can cure many people, no doubt.
+
+565
+00:47:13,797 --> 00:47:17,980
+But I don't know how to make Sahaja Yoga very collective.
+
+566
+00:47:18,227 --> 00:47:20,692
+Now you are so many people here,
+
+567
+00:47:20,893 --> 00:47:26,731
+you all can start giving realisation to at least 100 people.
+
+568
+00:47:27,219 --> 00:47:28,627
+Go everywhere.
+
+569
+00:47:28,841 --> 00:47:31,799
+Talk about Sahaja Yoga.
+
+570
+00:47:32,000 --> 00:47:35,945
+Sing the praise of the Divine,
+
+571
+00:47:36,199 --> 00:47:39,629
+and you will save the whole world.
+
+572
+00:47:39,853 --> 00:47:43,203
+It is not by saving some few people
+
+573
+00:47:43,404 --> 00:47:47,811
+you can have the great Satya Yuga,
+
+574
+00:47:48,012 --> 00:47:50,886
+but you have also to save this Mother Earth.
+
+575
+00:47:51,087 --> 00:47:54,282
+You have to save the people who are in it.
+
+576
+00:47:54,483 --> 00:47:56,695
+I mean, the way these people are,
+
+577
+00:47:56,896 --> 00:48:00,725
+I have seen so many of them on the television.
+
+578
+00:48:00,956 --> 00:48:05,564
+Shamelessly they are talking about something which they don't know.
+
+579
+00:48:05,765 --> 00:48:09,376
+And they have thousands and thousands of people behind them.
+
+580
+00:48:09,577 --> 00:48:12,939
+Not that the people are stupid.
+
+581
+00:48:13,140 --> 00:48:16,598
+Not that they want to go on a wrong path,
+
+582
+00:48:16,799 --> 00:48:21,796
+but these people who are false,
+
+583
+00:48:21,997 --> 00:48:25,502
+or who are wrong, know how to entice them,
+
+584
+00:48:25,703 --> 00:48:28,976
+how to capture them, how to talk to them.
+
+585
+00:48:29,177 --> 00:48:33,039
+But a sahaja yogi, you see, if he sees somebody
+
+586
+00:48:33,240 --> 00:48:39,137
+with a negative vibrations will run away.
+
+587
+00:48:39,621 --> 00:48:43,764
+He will escape such a society, will not go near them,
+
+588
+00:48:43,978 --> 00:48:47,645
+and will say, "Oh, very bad vibrations, we don't want!".
+
+589
+00:48:47,883 --> 00:48:50,564
+So you have to be courageous
+
+590
+00:48:50,765 --> 00:48:55,874
+and get into these places, talk to people and make it collective.
+
+591
+00:48:56,075 --> 00:49:01,851
+Otherwise you cannot save this world from the wrath of God.
+
+592
+00:49:02,129 --> 00:49:04,960
+God is wrathful, no doubt.
+
+593
+00:49:05,161 --> 00:49:08,515
+For you, he'll save you, but what's the use?
+
+594
+00:49:08,716 --> 00:49:12,198
+We have to save this Mother Earth.
+
+595
+00:49:12,399 --> 00:49:16,166
+And for that you have to be prepared,
+
+596
+00:49:16,367 --> 00:49:20,753
+you have to work it out, and whenever you get a chance
+
+597
+00:49:20,954 --> 00:49:23,356
+you must spread Sahaja Yoga.
+
+598
+00:49:23,557 --> 00:49:27,159
+Some people told me, "Mother, if you come then it will be All right."
+
+599
+00:49:27,360 --> 00:49:32,899
+Why? What's so much? .... you can be also like me.
+
+600
+00:49:33,106 --> 00:49:35,875
+You can talk about it to people.
+
+601
+00:49:36,082 --> 00:49:38,719
+I started Sahaja Yoga with one person
+
+602
+00:49:38,926 --> 00:49:42,994
+and that time it was complete darkness everywhere.
+
+603
+00:49:43,195 --> 00:49:46,534
+No seekers, nothing, and horrible people,
+
+604
+00:49:46,735 --> 00:49:49,695
+but it worked and it cleared.
+
+605
+00:49:49,896 --> 00:49:52,928
+So one person can get so many sahaja yogis,
+
+606
+00:49:53,129 --> 00:49:57,036
+why not you people do the same and talk about it.
+
+607
+00:49:57,237 --> 00:50:00,833
+Your behaviour, your style,
+
+608
+00:50:01,034 --> 00:50:06,065
+everything will definitely impress them.
+
+609
+00:50:06,296 --> 00:50:10,651
+One has to work it out in such a manner
+
+610
+00:50:10,852 --> 00:50:16,757
+that you achieve our goal of collective consciousness.
+
+611
+00:50:17,288 --> 00:50:20,484
+It is not only for sahaja yogis, it's for everyone.
+
+612
+00:50:20,723 --> 00:50:24,529
+So that all these calamities that are happening,
+
+613
+00:50:24,730 --> 00:50:27,332
+horrible things that are happening, will stop.
+
+614
+00:50:27,532 --> 00:50:31,378
+Completely stop, I assure you, it can be stopped.
+
+615
+00:50:31,578 --> 00:50:33,686
+Because you are always saved.
+
+616
+00:50:33,887 --> 00:50:38,371
+So all people who will be getting realisation will be saved.
+
+617
+00:50:38,572 --> 00:50:40,714
+Why not talk openly about it
+
+618
+00:50:40,915 --> 00:50:45,667
+telling people that if we do wrong, if we are immoral,
+
+619
+00:50:45,889 --> 00:50:51,234
+if we are cheats, if we try to oppress others
+
+620
+00:50:51,434 --> 00:50:57,354
+and we become so much a power of destruction
+
+621
+00:50:57,924 --> 00:51:03,639
+then this collective
+
+622
+00:51:03,840 --> 00:51:09,726
+disasters will be there and I think we'll be responsible for that.
+
+623
+00:51:09,980 --> 00:51:11,167
+Everything you take up,
+
+624
+00:51:11,368 --> 00:51:14,961
+any subject you take up, you don't have to start an organisation
+
+625
+00:51:15,162 --> 00:51:16,477
+to fight it.
+
+626
+00:51:16,678 --> 00:51:20,238
+But only your power of convincing people
+
+627
+00:51:20,581 --> 00:51:25,182
+and bringing them to Sahaja Yoga will make such a difference.
+
+628
+00:51:25,383 --> 00:51:29,854
+I hope you will understand as a guru what you have to do.
+
+629
+00:51:30,458 --> 00:51:34,415
+As a guru there are so many things
+
+630
+00:51:34,616 --> 00:51:38,454
+and as your character, yesterday, as they showed
+
+631
+00:51:38,655 --> 00:51:43,391
+how Lao Tse has written about the masters,
+
+632
+00:51:43,592 --> 00:51:48,229
+how they were above all of it, above turmoil,
+
+633
+00:51:48,467 --> 00:51:54,237
+above jealousies, above talking loose.
+
+634
+00:51:54,832 --> 00:51:58,210
+They are so great, they are the masters
+
+635
+00:51:58,411 --> 00:52:00,078
+and they will be the masters
+
+636
+00:52:00,279 --> 00:52:04,948
+and you will be the gurus if you try to do that.
+
+637
+00:52:05,149 --> 00:52:07,709
+This is what you have to achieve.
+
+638
+00:52:07,963 --> 00:52:09,992
+I know some have achieved it,
+
+639
+00:52:10,193 --> 00:52:15,087
+but most of you have to achieve, with compassion and love.
+
+640
+00:52:15,317 --> 00:52:18,500
+May God Bless You All.
+

--- a/talks/2000-07-23_Guru-Puja-Shraddha/Guru-Puja/source/en.srt
+++ b/talks/2000-07-23_Guru-Puja-Shraddha/Guru-Puja/source/en.srt
@@ -1,0 +1,2110 @@
+1
+00:00:00,001 --> 00:00:01,880
+Guru Puja
+Cabella Ligure (Italy), 23 July 2000.
+
+2
+00:06:02,346 --> 00:06:14,724
+Today we are here to know about guru principle.
+
+3
+00:06:14,749 --> 00:06:24,146
+What does a guru do.
+
+4
+00:06:30,059 --> 00:06:49,180
+Whatever you have, all the precious things
+within you, he discovers them for your knowledge.
+
+5
+00:06:51,586 --> 00:06:58,620
+Actually it is all there - everything.
+
+6
+00:06:59,565 --> 00:07:11,281
+All the knowledge, all the spirituality, all
+the joy, is there.
+
+7
+00:07:11,320 --> 00:07:23,366
+(little laughter as a dog walks on stage)
+Right time! (more laughter).
+
+8
+00:07:23,391 --> 00:07:30,774
+It's all contained within you.
+
+9
+00:07:32,520 --> 00:07:51,361
+Only thing the Guru does (is) makes you knowledgeable
+about your knowledge, about your own spirit.
+
+10
+00:07:51,386 --> 00:07:58,705
+Everyone has the Spirit within himself.
+
+11
+00:07:58,776 --> 00:08:05,006
+Everyone has the spirituality within himself.
+
+12
+00:08:05,006 --> 00:08:10,976
+There is nothing that you get from outside.
+
+13
+00:08:10,976 --> 00:08:24,418
+But before getting this knowledge, you are
+dealing, or you are living in ignorance.
+
+14
+00:08:24,443 --> 00:08:35,440
+In that ignorance you do not know what treasure
+you have got within yourself.
+
+15
+00:08:35,559 --> 00:08:49,692
+So the guru's job is to make you know what
+you are.
+
+16
+00:08:49,914 --> 00:08:53,975
+That is the first step.
+
+17
+00:08:54,182 --> 00:09:08,126
+That it starts, that awakening within you
+by which you know that you are not this outside
+
+18
+00:09:08,126 --> 00:09:11,458
+world, this is all an illusion.
+
+19
+00:09:11,990 --> 00:09:20,616
+And you start getting enlightened within yourself.
+
+20
+00:09:20,862 --> 00:09:28,247
+Some people get full light and some people
+get it gradually.
+
+21
+00:09:28,358 --> 00:09:34,656
+Essence of all the religions is that you should
+know yourself.
+
+22
+00:09:34,656 --> 00:09:44,099
+Those people who are fighting in the name
+of religion, you have to go and ask them,
+
+23
+00:09:44,313 --> 00:09:53,859
+you have to enquire from them, "Did your religion
+make you know yourself?"
+
+24
+00:09:54,010 --> 00:10:00,116
+If all the religions have said one thing [it's
+that], you have to do all these things just
+
+25
+00:10:00,116 --> 00:10:03,522
+to know yourself.
+
+26
+00:10:05,625 --> 00:10:09,356
+But people get into rituals.
+
+27
+00:10:09,356 --> 00:10:16,116
+They think that [by] doing all these rituals
+they are near God.
+
+28
+00:10:16,116 --> 00:10:28,407
+They live in ignorance absolutely about themselves,
+and day in and day out they work out something,
+
+29
+00:10:28,432 --> 00:10:33,636
+which is nothing to do with yourself'.
+
+30
+00:10:33,661 --> 00:10:42,026
+Lots of acrobats, prayers, pujas, these things
+go on.
+
+31
+00:10:42,152 --> 00:10:45,681
+Because it is all ignorance.
+
+32
+00:10:45,887 --> 00:10:56,868
+People go on paying them money and they become
+very rich and their interest is only money.
+
+33
+00:10:57,096 --> 00:11:08,172
+They want to take all your money, absolutely,
+and make a fool out of you.
+
+34
+00:11:08,212 --> 00:11:11,126
+They pamper your ego.
+
+35
+00:11:11,126 --> 00:11:24,066
+With pampering of that ego you just start
+drifting into the ocean of illusion and you
+
+36
+00:11:24,066 --> 00:11:32,766
+are drowned into that illusion, thinking that
+you are very religious and you are just in
+
+37
+00:11:32,766 --> 00:11:35,886
+connection with God, which you are not.
+
+38
+00:11:36,036 --> 00:11:41,292
+To know God you should know your Self first.
+
+39
+00:11:41,419 --> 00:11:46,417
+Without knowing that, you cannot know God.
+
+40
+00:11:46,504 --> 00:11:53,106
+That's essential, that you should know your
+Self.
+
+41
+00:11:53,106 --> 00:11:58,646
+But when you know yourself, you know partly.
+
+42
+00:11:58,646 --> 00:12:03,766
+The experience is not sufficient.
+
+43
+00:12:03,766 --> 00:12:07,551
+The knowledge has to come.
+
+44
+00:12:07,765 --> 00:12:14,652
+And the guru gives the knowledge about your
+Self.
+
+45
+00:12:14,803 --> 00:12:18,852
+Now you have to tally it.
+
+46
+00:12:18,963 --> 00:12:23,235
+You should find out whatever your guru has
+told you.
+
+47
+00:12:23,298 --> 00:12:25,513
+Is it true or not?
+
+48
+00:12:25,538 --> 00:12:28,038
+Is it correct or not?
+
+49
+00:12:28,244 --> 00:12:33,016
+Or is it just another illusion?
+
+50
+00:12:33,016 --> 00:12:40,744
+Now in this ascent people get into lots of
+problems.
+
+51
+00:12:40,911 --> 00:12:46,016
+First and foremost is the ego problem, especially
+in the west.
+
+52
+00:12:46,016 --> 00:12:54,277
+Ego stands up and you start thinking you are
+great, you are better than others, and there
+
+53
+00:12:54,277 --> 00:12:57,606
+is something special about you.
+
+54
+00:12:57,662 --> 00:13:07,015
+This ignorance is more dangerous than the
+worldly ignorance, I think, because in the
+
+55
+00:13:07,040 --> 00:13:19,762
+worldly ignorance, you do feel the consequences
+of wrong things.
+
+56
+00:13:20,166 --> 00:13:32,860
+But when you are half way, when your ignorance
+is that about yourself, when you are going
+
+57
+00:13:33,034 --> 00:13:42,196
+to a higher realm, then one should always
+understand that you cannot have ego.
+
+58
+00:13:42,196 --> 00:13:56,061
+Then what starts is introspection.
+
+59
+00:13:56,355 --> 00:14:05,272
+You start looking at yourself, what's wrong
+with you.
+
+60
+00:14:05,360 --> 00:14:11,466
+When you understand that you have ego, you
+start looking at yourself.
+
+61
+00:14:11,466 --> 00:14:24,666
+Or when you find there is something missing
+or something wrong, then also, you start introspecting.
+
+62
+00:14:24,666 --> 00:14:33,331
+This should be a very, very honest, very honest
+effort.
+
+63
+00:14:33,474 --> 00:14:38,912
+Some people in Sahaja Yoga, at a very early
+stage start thinking they that they are very
+
+64
+00:14:38,937 --> 00:14:44,242
+great and they don't need any introspection.
+
+65
+00:14:44,290 --> 00:14:55,685
+And they rise again into the clouds of ignorance
+without achieving Selfhood, or I can call
+
+66
+00:14:55,685 --> 00:14:58,593
+it Self realisation.
+
+67
+00:14:58,648 --> 00:15:07,049
+So you have to introspect and see for yourself
+what have you been doing, what are you,
+
+68
+00:15:07,327 --> 00:15:11,515
+how far you have come.
+
+69
+00:15:11,594 --> 00:15:16,905
+How much -- please don't translate just now
+all right?
+
+70
+00:15:16,930 --> 00:15:22,216
+You can do it later on.
+
+71
+00:15:22,279 --> 00:15:26,786
+You must hear with full concentration.
+
+72
+00:15:26,786 --> 00:15:34,679
+Even if you don't understand it will work
+-- now the style of such a person changes
+
+73
+00:15:34,704 --> 00:15:35,719
+gradually.
+
+74
+00:15:35,744 --> 00:15:36,976
+How?
+
+75
+00:15:36,976 --> 00:15:50,055
+First of all a person who is extremely aggressive,
+hot-tempered, and full of ego, starts becoming
+
+76
+00:15:50,055 --> 00:15:54,126
+very gentle and mild.
+
+77
+00:15:54,206 --> 00:16:07,789
+Another type which is frightened and afraid
+and very cautious starts becoming fearless.
+
+78
+00:16:07,948 --> 00:16:13,516
+At that stage you have no fears.
+
+79
+00:16:13,516 --> 00:16:23,935
+You are sure that you are on the right path
+and you are moving on the right lines.
+
+80
+00:16:24,102 --> 00:16:27,316
+You are not easily disturbed there.
+
+81
+00:16:27,341 --> 00:16:38,365
+But still you have to rise higher and higher;
+where, when you meditate, you understand there
+
+82
+00:16:38,365 --> 00:16:42,790
+is something wrong within yourself.
+
+83
+00:16:42,853 --> 00:16:49,296
+You have achieved your Self realisation; you
+have got the blessings of Self realisation.
+
+84
+00:16:49,296 --> 00:16:58,236
+Your health is good, you have got all kinds
+of blessings which you cannot count.
+
+85
+00:16:58,236 --> 00:17:09,270
+All that is there but...still you have to
+go further.
+
+86
+00:17:09,357 --> 00:17:23,966
+And that is to understand all the knowledge
+about Sahaja Yoga.
+
+87
+00:17:24,149 --> 00:17:32,156
+You have to understand through your mental
+capacity, first, to begin with, then you have
+
+88
+00:17:32,156 --> 00:17:37,967
+to verify how far it is correct.
+
+89
+00:17:38,086 --> 00:17:52,316
+How far you have understood it, how far you
+have worked on it, how far you know.
+
+90
+00:17:52,459 --> 00:18:08,331
+And when you start seeing yourself, you start
+entering into the realm of Bhakti.
+
+91
+00:18:08,441 --> 00:18:18,200
+You become a mild person, become a sweet person,
+you don't talk too much, you don't harass
+
+92
+00:18:18,225 --> 00:18:30,016
+anyone; you are a very pleasant person, very
+gentle, very understanding.
+
+93
+00:18:30,016 --> 00:18:41,156
+This person has to verify how he is behaving
+towards others.
+
+94
+00:18:41,156 --> 00:18:54,643
+Now the attention starts moving from oneself
+to another and you start seeing how you behave.
+
+95
+00:18:54,755 --> 00:18:59,230
+How you love.
+
+96
+00:18:59,255 --> 00:19:04,121
+What is the quality of your compassion?
+
+97
+00:19:07,498 --> 00:19:20,536
+When you love somebody without any expectations,
+just love, then you are absolutely dedicated
+
+98
+00:19:20,536 --> 00:19:28,198
+to that person, absolutely; you just obey.
+
+99
+00:19:28,285 --> 00:19:31,990
+You will do anything for that person.
+
+100
+00:19:32,164 --> 00:19:39,445
+If there is this love which you call as surrender.
+
+101
+00:19:39,445 --> 00:19:43,146
+This is just the love.
+
+102
+00:19:43,146 --> 00:19:52,016
+Surrender is nothing but the love, and that
+love which is extremely joy-giving.
+
+103
+00:19:52,016 --> 00:20:07,081
+this bhakti starts, this dedication starts,
+and you are cleansed by that bhakti.
+
+104
+00:20:07,144 --> 00:20:20,505
+All the bad qualities you have, you can call
+them, all the deficiencies you have, all the
+
+105
+00:20:20,505 --> 00:20:29,692
+problems you have, you understand and you
+get over it.
+
+106
+00:20:29,867 --> 00:20:43,776
+Now if you see somebody with the same qualities,
+with the same troubles, you in the love of
+
+107
+00:20:43,801 --> 00:20:49,577
+that person you try to tolerate.
+
+108
+00:20:49,602 --> 00:20:57,535
+Such a person just tolerates.
+
+109
+00:21:02,889 --> 00:21:13,061
+There is no aggression, and these people forgive.
+
+110
+00:21:13,196 --> 00:21:19,255
+Realised Souls go on forgiving; their capacity
+to forgive is tremendous.
+
+111
+00:21:19,255 --> 00:21:25,892
+They do not bear any malice against anyone.
+
+112
+00:21:25,917 --> 00:21:29,575
+They don't have any anger about anyone.
+
+113
+00:21:29,639 --> 00:21:36,210
+They just go on tolerating and forgiving and
+forgiving.
+
+114
+00:21:36,313 --> 00:21:47,261
+This forgiveness is just a music, I should
+say, of your bhakti.
+
+115
+00:21:47,372 --> 00:21:55,065
+The amount of forgiveness these masters could
+have can be seen from [the] life of Christ.
+
+116
+00:21:55,065 --> 00:22:01,700
+They are tortured, crucified - most of the
+saints were tortured.
+
+117
+00:22:01,725 --> 00:22:04,272
+People never liked them.
+
+118
+00:22:04,297 --> 00:22:18,485
+And they were crucified, but as you know that
+they never resented, they never take a revenge,
+
+119
+00:22:18,620 --> 00:22:24,995
+they never did anything which was not compassionate.
+
+120
+00:22:24,995 --> 00:22:30,429
+They had compassion, and compassion for such
+people
+
+121
+00:22:30,623 --> 00:22:37,084
+they felt that 'Oh God, please forgive them.
+
+122
+00:22:38,615 --> 00:22:43,491
+What they are doing they don't know'.
+
+123
+00:22:43,516 --> 00:22:46,357
+Extremely compassionate.
+
+124
+00:22:46,382 --> 00:22:50,336
+And they are that, that becomes their nature.
+
+125
+00:22:50,336 --> 00:23:01,785
+When it becomes their nature they become people
+with complete peace.
+
+126
+00:23:01,785 --> 00:23:05,498
+They are not disturbed.
+
+127
+00:23:05,523 --> 00:23:15,029
+They are never disturbed with whatever is
+happening and they think it's God's will.
+
+128
+00:23:15,054 --> 00:23:23,020
+Because nothing can disturb them, nothing
+can upset them.
+
+129
+00:23:23,045 --> 00:23:30,471
+They just enjoy their devotion.
+
+130
+00:23:30,566 --> 00:23:36,060
+Devotion to their guru, maybe.
+
+131
+00:23:36,108 --> 00:23:41,291
+Devotion to God.
+
+132
+00:23:41,497 --> 00:23:53,046
+In that devotion they may write beautiful
+poetry, they may go on dancing, they may go
+
+133
+00:23:53,046 --> 00:24:01,796
+on singing, because the peace is within and
+they are enjoying themselves.
+
+134
+00:24:04,591 --> 00:24:13,468
+When they are alone, they are never alone,
+they enjoy themselves.
+
+135
+00:24:13,493 --> 00:24:27,562
+They know that - "We are one with the Divine"
+- and the blessing of the Divine they enjoy.
+
+136
+00:24:27,587 --> 00:24:33,058
+Another thing is they never take to artificiality.
+
+137
+00:24:33,083 --> 00:24:43,976
+They are never worried, never upset, they
+are neither futuristic nor think of the past,
+
+138
+00:24:43,976 --> 00:24:46,696
+but they are in the present.
+
+139
+00:24:49,327 --> 00:24:55,896
+When they are in the present, they are absolutely
+silent.
+
+140
+00:24:55,896 --> 00:25:02,749
+If there is any problem, or anything happens
+to them,
+
+141
+00:25:02,888 --> 00:25:07,460
+they immediately go into thoughtless awareness.
+
+142
+00:25:08,761 --> 00:25:14,445
+That is what their capacity is.
+
+143
+00:25:14,470 --> 00:25:22,426
+To become a guru you have to develop that
+personality; not to be bound by anything.
+
+144
+00:25:22,426 --> 00:25:26,402
+Now I'll tell you my own example.
+
+145
+00:25:26,561 --> 00:25:33,242
+I never hurry, I'm never bothered about time.
+
+146
+00:25:33,267 --> 00:25:41,776
+Once I was going to America - because if you
+are sure the Divine has plans for you, you
+
+147
+00:25:41,776 --> 00:25:48,574
+are not bothered, the Divine is looking after
+you so why to bother -- I was going to America
+
+148
+00:25:48,599 --> 00:25:50,506
+and one child fell down.
+
+149
+00:25:50,506 --> 00:25:57,794
+I was just about to get up and go and broke
+her arm.
+
+150
+00:25:57,819 --> 00:26:02,936
+And when I saw the child I said "All right,
+I'll put that child right".
+
+151
+00:26:02,936 --> 00:26:05,344
+"But," they said, "You are going to America!"
+
+152
+00:26:05,369 --> 00:26:08,429
+I said, "I'll go in any case!
+
+153
+00:26:08,454 --> 00:26:14,506
+"So I cured the child, it took about half
+an hour, and then I came out "All right, let's
+
+154
+00:26:14,506 --> 00:26:16,078
+go to the airport".
+
+155
+00:26:16,103 --> 00:26:20,606
+They said "Mother you are very late" I said,
+"I'm never late.
+
+156
+00:26:20,606 --> 00:26:22,790
+Let's go!".
+
+157
+00:26:22,815 --> 00:26:31,210
+We went there, to the airport, and the plane
+by which I was going was out of order, so
+
+158
+00:26:31,235 --> 00:26:35,027
+there was another plane going to Washington
+not to New York,
+
+159
+00:26:35,052 --> 00:26:38,871
+and I wanted to go to Washington only!
+
+160
+00:26:39,085 --> 00:26:46,796
+So just imagine how things work out, and we
+call them 'Sahaja'.
+
+161
+00:26:46,821 --> 00:26:54,430
+It has worked out 'Sahaja'.
+
+162
+00:26:58,799 --> 00:27:02,939
+That means it's a effortless.
+
+163
+00:27:03,971 --> 00:27:22,646
+But first of all your personality should be
+such that your devotion is so great that Divine
+
+164
+00:27:22,646 --> 00:27:34,128
+is compelled to look after you...compelled
+to look after you!
+
+165
+00:27:34,153 --> 00:27:47,469
+You have to understand that Divine force is
+around you, and this Divine force is absolute
+
+166
+00:27:47,494 --> 00:27:51,436
+guarantee for your safety.
+
+167
+00:27:51,436 --> 00:27:56,640
+For everything that you want to do.
+
+168
+00:27:58,005 --> 00:28:03,056
+You can say that "Mother you are very powerful".
+
+169
+00:28:03,056 --> 00:28:05,765
+You can become also very powerful!
+
+170
+00:28:05,861 --> 00:28:16,266
+If you get completely dedicated to the Divine
+work, you will also have all the powers and
+
+171
+00:28:16,266 --> 00:28:26,049
+the Divine will provide all the necessary
+work that you want to do, necessary time that
+
+172
+00:28:26,074 --> 00:28:27,565
+you have to have.
+
+173
+00:28:27,590 --> 00:28:33,563
+Everything is provided by the Divine.
+
+174
+00:28:33,609 --> 00:28:44,835
+But the compassion, when it extends from other
+people to God, or to Divine person, or to
+
+175
+00:28:44,869 --> 00:29:00,757
+your guru, then it becomes very easy to live,
+very simple to live, no complications, everything
+
+176
+00:29:00,757 --> 00:29:06,746
+is sorted out, and you are not bothered about
+anything.
+
+177
+00:29:06,746 --> 00:29:13,569
+You just close your eyes and things work out.
+
+178
+00:29:13,680 --> 00:29:23,576
+Everything works out as if that's your will,
+but you don't have to will it, don't have
+
+179
+00:29:23,576 --> 00:29:28,876
+to think about it, it just works out, but
+Divine looks after everything.
+
+180
+00:29:28,876 --> 00:29:38,016
+It looks after your comfort, looks after your
+health, everything.
+
+181
+00:29:38,016 --> 00:29:51,866
+And this Divine help, you do not seek, you
+do not ask for, but you are a personality
+
+182
+00:29:51,866 --> 00:29:56,035
+for which the Divine is responsible.
+
+183
+00:29:56,122 --> 00:30:02,029
+You are a special responsibility of the Divine.
+
+184
+00:30:02,054 --> 00:30:07,941
+And it knows what is good for you and what
+is not.
+
+185
+00:30:07,966 --> 00:30:16,866
+It's an example, I can give many where I,
+supposing, I thought somebody is coming to
+
+186
+00:30:16,866 --> 00:30:24,108
+meet me, and people told me "Mother, he's
+very negative", He will never come,
+
+187
+00:30:24,133 --> 00:30:26,674
+he'll never come.
+
+188
+00:30:26,881 --> 00:30:33,497
+All positive things will happen, and if a
+negative things take place, then you will
+
+189
+00:30:33,522 --> 00:30:36,164
+use your compassion.
+
+190
+00:30:36,189 --> 00:30:42,067
+If it is negative you'll use your compassion
+and you'll solve the problem.
+
+191
+00:30:42,131 --> 00:30:52,117
+You can solve the problems of your own, of
+your surroundings, of your community.
+
+192
+00:30:52,149 --> 00:30:56,265
+So now you have got your Self realisation.
+
+193
+00:30:56,290 --> 00:31:00,001
+How far you have gone in that I don't know.
+
+194
+00:31:00,081 --> 00:31:08,102
+I have a complaint about women, so many ladies,
+that they don't meditate.
+
+195
+00:31:08,459 --> 00:31:15,956
+That they are not looking after themselves,
+they are not realised souls, and that's why
+
+196
+00:31:15,956 --> 00:31:24,173
+many men want to divorce them because they
+think these women are good for nothing.
+
+197
+00:31:24,261 --> 00:31:31,411
+And some men also are like that.
+
+198
+00:31:31,451 --> 00:31:41,926
+To solve this problem you have to have compassion,
+and you have to, somehow or other, with compassion,
+
+199
+00:31:41,926 --> 00:31:48,716
+you should win over the partner of your life.
+
+200
+00:31:48,741 --> 00:31:54,216
+After all men are much more busy than women
+are.
+
+201
+00:31:54,216 --> 00:31:59,266
+But women indulge into so many other things.
+
+202
+00:31:59,266 --> 00:32:05,280
+They have to look after their family, their
+children, their everything.
+
+203
+00:32:05,795 --> 00:32:15,516
+And their mind is involved into all such mundane
+things that they have no time to meditate.
+
+204
+00:32:15,516 --> 00:32:19,073
+Without meditation you cannot rise.
+
+205
+00:32:19,098 --> 00:32:22,786
+You have to meditate.
+
+206
+00:32:22,786 --> 00:32:25,029
+People think that: "Now we have got realisation,
+so it's all right".
+
+207
+00:32:25,054 --> 00:32:26,218
+No!
+
+208
+00:32:26,243 --> 00:32:32,775
+Every day you must meditate because that's
+the cleansing that takes place.
+
+209
+00:32:33,276 --> 00:32:38,103
+With the cleansing you understand.
+
+210
+00:32:38,128 --> 00:32:47,254
+You understand what is needed and what is
+not needed, you are cleansed out.
+
+211
+00:32:47,341 --> 00:32:49,726
+That is done by Divine.
+
+212
+00:32:49,726 --> 00:32:58,486
+But you must religiously meditate.
+
+213
+00:32:58,486 --> 00:33:07,485
+Gradually you will find your meditation will
+become very deep.
+
+214
+00:33:07,516 --> 00:33:19,256
+You will become very, very deep and your powers
+will start showing.
+
+215
+00:33:19,256 --> 00:33:25,776
+When you are anywhere, negativity will run
+away.
+
+216
+00:33:25,776 --> 00:33:32,418
+All sorts of problems can be solved.
+
+217
+00:33:32,443 --> 00:33:37,053
+Whatever you want to do is available to you.
+
+218
+00:33:37,078 --> 00:33:46,936
+Whatever is your desire to help others or
+give to someone, you just get it.
+
+219
+00:33:46,936 --> 00:33:52,046
+Is my own experience I'm telling you.
+
+220
+00:33:52,046 --> 00:34:02,137
+You have to meditate at least 10 minutes every
+evening, and morning about 5 minutes.
+
+221
+00:34:02,162 --> 00:34:07,756
+With complete devotion, with complete admiration.
+
+222
+00:34:07,756 --> 00:34:18,546
+I have seen some people here, such bhakti,
+such devotion, which is shraddha - is higher
+
+223
+00:34:18,546 --> 00:34:24,446
+than bhakti - that it becomes part and parcel
+of your being.
+
+224
+00:34:24,446 --> 00:34:29,576
+It just envelops you completely.
+
+225
+00:34:29,576 --> 00:34:35,583
+When you have that shraddha, it is very miraculous.
+
+226
+00:34:35,608 --> 00:34:39,139
+It works so many miracles.
+
+227
+00:34:39,164 --> 00:34:46,891
+It's true some people were cured only thinking
+of me, is a fact.
+
+228
+00:34:47,018 --> 00:34:54,536
+But that doesn't mean that they had the shraddha
+of that level, but that means that they have
+
+229
+00:34:54,536 --> 00:34:57,145
+to develop shraddha.
+
+230
+00:34:57,170 --> 00:35:06,195
+Now how to develop a shraddha, which is a
+natural light of the Spirit.
+
+231
+00:35:06,220 --> 00:35:19,026
+Because people are trying very hard to develop
+shraddha, but shraddha cannot be developed
+
+232
+00:35:19,026 --> 00:35:26,576
+by mental activity, by any activity, but meditation
+of silence.
+
+233
+00:35:26,576 --> 00:35:33,556
+If you do the meditation .... I have always
+told you to do meditation.
+
+234
+00:35:33,556 --> 00:35:38,940
+I immediately know a person who has been meditating
+and who has not been.
+
+235
+00:35:39,225 --> 00:35:47,776
+They'll come to my puja, all right; and they'll
+talk about Sahaja Yoga, they'll go out and
+
+236
+00:35:47,776 --> 00:35:50,968
+do it for popularity.
+
+237
+00:35:50,993 --> 00:35:53,466
+Many people are like that.
+
+238
+00:35:53,466 --> 00:35:58,136
+They go out, and for popularity they work
+it out.
+
+239
+00:35:58,136 --> 00:36:04,701
+But inside they have not yet traced their
+own Self.
+
+240
+00:36:04,741 --> 00:36:12,928
+So at this development stage you should be
+encouraged, and [should be] understood that
+
+241
+00:36:12,968 --> 00:36:22,396
+you can reach that state very easily through
+meditation and introspection.
+
+242
+00:36:22,396 --> 00:36:33,386
+With introspection you will develop a new
+quality of understanding that, you will find
+
+243
+00:36:33,386 --> 00:36:36,646
+solutions to things.
+
+244
+00:36:36,671 --> 00:36:42,326
+That is another quality a person who is a
+realised soul has.
+
+245
+00:36:42,326 --> 00:36:50,020
+It can find solutions to all your problems.
+
+246
+00:36:50,115 --> 00:37:00,461
+It can, he can suggest what is the way you
+can be helped.
+
+247
+00:37:00,596 --> 00:37:05,899
+Then a kind of a brotherhood out of the shraddha
+develops.
+
+248
+00:37:05,924 --> 00:37:12,446
+You may be giving big lectures on Sahaja Yoga,
+you may be doing all kinds of things, but
+
+249
+00:37:12,446 --> 00:37:19,573
+unless and until you have shraddha, you cannot
+rise.
+
+250
+00:37:19,598 --> 00:37:29,115
+And this shraddha is a kind of a love within
+you, I should say, which spreads like gentle
+
+251
+00:37:29,140 --> 00:37:41,946
+fire which doesn't burn, which doesn't give
+heat, but cold, beautiful breeze-like feeling
+
+252
+00:37:41,946 --> 00:37:45,636
+within, which makes you understand.
+
+253
+00:37:45,636 --> 00:37:53,264
+You will never talk ill about a sahaja yogi,
+never.
+
+254
+00:37:53,289 --> 00:37:59,166
+I never listen to anybody who tells me something
+against sahaja yogi.
+
+255
+00:37:59,166 --> 00:38:08,105
+Up to a point, when it is a collective complaint,
+then I am little bit bothered and I talk about
+
+256
+00:38:08,130 --> 00:38:10,296
+it to the leader.
+
+257
+00:38:10,359 --> 00:38:16,976
+But otherwise if one person comes and tells
+me this and this, I just tell that person
+
+258
+00:38:16,976 --> 00:38:20,945
+"You introspect yourself , it's not so".
+
+259
+00:38:20,970 --> 00:38:33,906
+Finding faults with others is a common game
+all human beings play.
+
+260
+00:38:33,906 --> 00:38:36,445
+They never see their own faults.
+
+261
+00:38:36,477 --> 00:38:40,545
+What's the use of finding faults of others?
+
+262
+00:38:40,570 --> 00:38:46,369
+By finding faults with others you're not going
+to be helped.
+
+263
+00:38:46,394 --> 00:38:52,512
+Try to find faults within you, which you can
+cure, which you can help,
+
+264
+00:38:52,687 --> 00:38:57,347
+which you can work it out.
+
+265
+00:38:57,372 --> 00:39:05,882
+It's a responsibility you have, you must know,
+to yourself that you better find out your
+
+266
+00:39:05,907 --> 00:39:10,256
+defects and get them corrected.
+
+267
+00:39:10,256 --> 00:39:17,842
+But some people are very proud of their fondness
+-- they talk like this,
+
+268
+00:39:17,867 --> 00:39:20,546
+"I like this, I like that".
+
+269
+00:39:20,546 --> 00:39:24,465
+But what about the Spirit?
+
+270
+00:39:24,490 --> 00:39:29,236
+You like this, you like that, then what about
+your Spirit?
+
+271
+00:39:29,236 --> 00:39:31,026
+Does it like?
+
+272
+00:39:31,026 --> 00:39:36,036
+Does it enjoy?
+
+273
+00:39:36,036 --> 00:39:40,196
+They'll go on saying "I like this, I don't
+like this, I don't like that!"
+
+274
+00:39:40,196 --> 00:39:44,726
+It's very common in the West.
+
+275
+00:39:44,726 --> 00:39:48,956
+Now see, some ladies have made this beautiful
+carpets for me.
+
+276
+00:39:48,956 --> 00:39:57,026
+They are so thick that when I walk on them
+I little bit lose balance, but the love with
+
+277
+00:39:57,026 --> 00:40:06,641
+which they are made, makes me so joyous, so
+happy, that you can't imagine
+
+278
+00:40:06,666 --> 00:40:10,184
+what I feel about them.
+
+279
+00:40:10,184 --> 00:40:15,822
+This joy, this ocean of joy, is within you.
+
+280
+00:40:15,847 --> 00:40:27,504
+And when it starts stirring up, it doesn't
+torment you, it gives you beautiful -- I don't
+
+281
+00:40:27,505 --> 00:40:36,593
+know how to use words to express that -- it's
+like a drizzle on your being, it's like a
+
+282
+00:40:36,618 --> 00:40:39,305
+grace on your being.
+
+283
+00:40:39,305 --> 00:40:43,902
+The love of other people enthrals you.
+
+284
+00:40:44,822 --> 00:40:57,515
+You don't ask for it, but if you see a person
+who is very loving and kind, there is real
+
+285
+00:40:57,515 --> 00:41:00,755
+friendship in that kind of relationship.
+
+286
+00:41:00,755 --> 00:41:06,887
+But talking ill about sahaja yogis, it's very
+wrong.
+
+287
+00:41:06,912 --> 00:41:13,381
+And then talking to everyone that "this is
+wrong with this person, he had done this,
+
+288
+00:41:13,406 --> 00:41:22,944
+he had done that", is very, very wrong and
+creating a collective feeling against the
+
+289
+00:41:22,969 --> 00:41:26,716
+person -- instead of helping that person.
+
+290
+00:41:26,716 --> 00:41:30,218
+Always people are in trouble.
+
+291
+00:41:30,243 --> 00:41:33,649
+Then collectively you must help that person.
+
+292
+00:41:33,674 --> 00:41:35,197
+Not talk ill of that person.
+
+293
+00:41:35,222 --> 00:41:44,806
+May be some mistakes, but if you start talking
+against that person and saying that 'This
+
+294
+00:41:44,806 --> 00:41:51,254
+is wrong with him, that is wrong with him',
+then you are not a sahaja yogi.
+
+295
+00:41:51,279 --> 00:42:00,737
+You are a sahaja yogi as long as you can see
+your own defects through introspection.
+
+296
+00:42:01,753 --> 00:42:07,318
+Now many of you, I should say most of you,
+have got your realisation.
+
+297
+00:42:07,421 --> 00:42:10,413
+You had the experience.
+
+298
+00:42:10,438 --> 00:42:16,638
+But some of you don't have the knowledge.
+
+299
+00:42:16,663 --> 00:42:22,919
+That knowledge you should acquire, and verify
+whether that knowledge
+
+300
+00:42:22,944 --> 00:42:25,975
+is really there or not.
+
+301
+00:42:27,430 --> 00:42:40,626
+Like in America, in the N.I.H., which is an
+Institute for Health, they wanted to test
+
+302
+00:42:40,626 --> 00:42:45,015
+a sahaja yogi, and there were doctors.
+
+303
+00:42:45,015 --> 00:42:49,197
+And one doctor came forward and said "All
+right, tell me on your vibration
+
+304
+00:42:49,222 --> 00:42:51,515
+what's wrong with me".
+
+305
+00:42:51,515 --> 00:43:00,275
+So the girl said, "Sir, something wrong with
+your heart" and he said, "It's correct" because
+
+306
+00:43:00,275 --> 00:43:10,089
+he has had a bypass only one month back and
+he was out of hospital.
+
+307
+00:43:10,114 --> 00:43:13,835
+Absolutely correct, and this surprised them.
+
+308
+00:43:13,860 --> 00:43:19,205
+That diagnosis, you see, kills the patient
+half way.
+
+309
+00:43:19,205 --> 00:43:26,233
+So this is the very easy way to diagnose a
+person, just by feeling the vibration.
+
+310
+00:43:26,258 --> 00:43:31,226
+And they have given us such a good attention,
+
+311
+00:43:31,251 --> 00:43:37,856
+they want to develop Sahaja Yoga in their hospitals.
+
+312
+00:43:41,713 --> 00:43:50,741
+So you should also testify yourself, examine
+yourself and find out about yourself,
+
+313
+00:43:50,766 --> 00:43:54,906
+what are you?
+
+314
+00:43:55,683 --> 00:44:06,906
+Say husband and wife -- now the wife meditates,
+she knows everything, she knows about her
+
+315
+00:44:06,906 --> 00:44:27,024
+husband, what's wrong with him and she doesn't
+tell him.
+
+316
+00:44:27,175 --> 00:44:36,123
+She tolerates, she doesn't complain, she doesn't
+ask for anything, she just tolerates.
+
+317
+00:44:36,210 --> 00:44:46,435
+And this tolerance convinces the husband that
+she's a higher personality than himself.
+
+318
+00:44:46,482 --> 00:44:53,930
+He may be anything, but he then understands
+that this is what she has achieved,
+
+319
+00:44:53,955 --> 00:44:57,077
+a great personality.
+
+320
+00:44:57,102 --> 00:45:03,856
+We have so many imperfections, especially
+morally, in the West, people are really, I
+
+321
+00:45:03,856 --> 00:45:07,093
+tell you, like one snake has bitten them.
+
+322
+00:45:09,800 --> 00:45:17,856
+The things that people do here never come
+into the minds of people who are not developed.
+
+323
+00:45:17,856 --> 00:45:29,663
+So development has meant all kinds of abandonment,
+all kinds of vagabond temperament, and they
+
+324
+00:45:29,806 --> 00:45:35,948
+think they are very free and they can go about
+and enjoy.
+
+325
+00:45:35,973 --> 00:45:45,716
+This style is very common, but you just judge
+yourself.
+
+326
+00:45:45,741 --> 00:45:48,695
+Are you one of these type?
+
+327
+00:45:48,695 --> 00:45:55,336
+Or are you one of the people who are higher
+than you in their ascent.
+
+328
+00:45:55,336 --> 00:45:58,655
+It's a process, I must confess.
+
+329
+00:45:58,655 --> 00:46:04,125
+It is not just [that] you get to that point.
+
+330
+00:46:04,150 --> 00:46:13,596
+Sometimes even very new sahaja yogis are better
+than very old sahaja yogis, but because they
+
+331
+00:46:13,596 --> 00:46:16,876
+had a very strong desire.
+
+332
+00:46:16,901 --> 00:46:19,136
+What are we seeking?
+
+333
+00:46:19,136 --> 00:46:26,686
+We should understand why we were seeking -- because
+we wanted to know ourselves.
+
+334
+00:46:26,686 --> 00:46:32,562
+Somehow, we knew that we have to know ourselves,
+and we did not know.
+
+335
+00:46:32,601 --> 00:46:33,958
+So we seek.
+
+336
+00:46:33,983 --> 00:46:35,038
+We seek.
+
+337
+00:46:35,379 --> 00:46:40,911
+We do all kinds of things, I mean all wrong
+things also in the name of seeking.
+
+338
+00:46:40,958 --> 00:46:49,797
+But it is this seeking brings you to Sahaja
+Yoga.
+
+339
+00:46:49,932 --> 00:46:57,175
+Then you have to get your Self realisation,
+which is very easy through Kundalini.
+
+340
+00:46:57,175 --> 00:47:01,394
+Kundalini works out most of the things, most
+of the things.
+
+341
+00:47:01,419 --> 00:47:09,861
+Like somebody told me that overnight she gave
+up drinking and smoking -- overnight.
+
+342
+00:47:11,809 --> 00:47:15,946
+I mean I don't tell that, I never say that.
+
+343
+00:47:15,977 --> 00:47:22,446
+But just overnight she gave up, and she said
+"I was very particular about my hair dress
+
+344
+00:47:22,557 --> 00:47:29,165
+and I used to make my hair dress in a different
+manner, going to the hairdressers, spending
+
+345
+00:47:29,165 --> 00:47:32,386
+so much time with the beautician, this, that".
+
+346
+00:47:32,386 --> 00:47:34,730
+She said, "I gave it up".
+
+347
+00:47:34,755 --> 00:47:43,886
+Also she said "I used to wear dresses which
+were not very moral, then I started respecting
+
+348
+00:47:43,886 --> 00:47:47,876
+my body and I started wearing proper dress".
+
+349
+00:47:47,876 --> 00:47:57,445
+All this knowledge comes to you, spontaneously
+it is within you, because it is all your own.
+
+350
+00:47:57,470 --> 00:48:01,966
+Also if your guru tells you, you are guided.
+
+351
+00:48:01,991 --> 00:48:05,611
+Guru's job is to guide people.
+
+352
+00:48:05,802 --> 00:48:10,196
+So at this juncture, what is lacking?
+
+353
+00:48:10,196 --> 00:48:14,418
+What is lacking in Sahaja Yoga?
+
+354
+00:48:14,443 --> 00:48:16,918
+That I have to tell you.
+
+355
+00:48:16,973 --> 00:48:23,621
+There are so many collective disasters we
+have - all kinds of.
+
+356
+00:48:23,646 --> 00:48:33,435
+We had many earthquakes, we had many floods,
+rain, then the muds - mud came down like a
+
+357
+00:48:33,435 --> 00:48:41,035
+river; and so many disasters in the world
+and sahaja yogis are saved from that.
+
+358
+00:48:41,060 --> 00:48:46,891
+All the sahaja yogis are saved from that,
+no doubt, but after being saved,
+
+359
+00:48:46,916 --> 00:48:50,043
+what is your understanding?
+
+360
+00:48:50,140 --> 00:48:52,767
+What do you know?
+
+361
+00:48:52,792 --> 00:48:56,513
+Why these disasters are coming?
+
+362
+00:48:56,538 --> 00:49:01,254
+Because Sahaja Yoga is not very collective.
+
+363
+00:49:01,279 --> 00:49:04,035
+It has to become very collective.
+
+364
+00:49:04,060 --> 00:49:08,142
+It has to spread much more, all over.
+
+365
+00:49:08,221 --> 00:49:12,366
+It has to go to many people, which we don't
+do.
+
+366
+00:49:12,391 --> 00:49:16,858
+We are at a standstill, or little bit we do
+it.
+
+367
+00:49:16,937 --> 00:49:18,954
+But go all out!
+
+368
+00:49:18,979 --> 00:49:21,989
+Look at Christ's twelve disciples!
+
+369
+00:49:22,014 --> 00:49:26,714
+Of course the people went into wrong things.
+
+370
+00:49:26,793 --> 00:49:34,279
+But how they worked and how intensively they
+did it.
+
+371
+00:49:34,304 --> 00:49:44,046
+That intensity if you don't have, and if you
+do not completely dedicate to the spreading
+
+372
+00:49:44,046 --> 00:49:52,396
+of Sahaja Yoga, then collective problems cannot
+be solved.
+
+373
+00:49:52,421 --> 00:49:58,126
+You are busy with your daily mundane things,
+and your other jobs and everything; it's all
+
+374
+00:49:58,151 --> 00:50:01,880
+right, in Sahaja Yoga no objection.
+
+375
+00:50:01,905 --> 00:50:14,371
+But you should have your attention more on
+to this side of life that - 'What are we doing
+
+376
+00:50:14,396 --> 00:50:16,201
+for the collective?
+
+377
+00:50:16,226 --> 00:50:18,177
+Are we talking about it?
+
+378
+00:50:18,202 --> 00:50:20,107
+Are we spreading Sahaja Yoga?
+
+379
+00:50:20,132 --> 00:50:24,686
+Are we making people know about it?'
+
+380
+00:50:24,686 --> 00:50:28,786
+I was surprised, once I was coming by plane
+
+381
+00:50:28,811 --> 00:50:36,803
+and a lady sat next to me and had very bad vibrations.
+
+382
+00:50:40,138 --> 00:50:49,893
+I put myself into bandhan, and I asked her
+what is she doing for her spirituality, and
+
+383
+00:50:49,918 --> 00:50:53,445
+she gave the name of 'Bahai' people.
+
+384
+00:50:53,445 --> 00:50:56,505
+"My God" I said.
+
+385
+00:50:56,505 --> 00:51:01,995
+If these people spread out, they are so spread
+out, they are so many!
+
+386
+00:51:01,995 --> 00:51:03,986
+So, what will happen?
+
+387
+00:51:04,011 --> 00:51:06,186
+Disasters!
+
+388
+00:51:06,186 --> 00:51:14,235
+They are such negative people, impossible
+that they can do any good to the world.
+
+389
+00:51:14,235 --> 00:51:23,716
+And like that you see, anybody, false guru,
+how people are driven to them, how they take
+
+390
+00:51:23,716 --> 00:51:26,306
+to them, and how they spread their message.
+
+391
+00:51:26,306 --> 00:51:35,186
+I have seen people singing on the road, singing
+the praise of their guru, and also wearing
+
+392
+00:51:35,186 --> 00:51:39,966
+funny dresses -- we don't want that kind of
+a thing.
+
+393
+00:51:39,991 --> 00:51:46,608
+But of course you have got the knowledge,
+of course you are realised souls.
+
+394
+00:51:46,633 --> 00:51:50,859
+But what have you done for Sahaja Yoga is
+the point.
+
+395
+00:51:50,914 --> 00:51:57,468
+You have to spread Sahaja Yoga...everywhere.
+
+396
+00:51:57,753 --> 00:52:07,285
+For example, you wear a badge, then they will
+ask you "What is this supposed to be?"
+
+397
+00:52:07,285 --> 00:52:11,430
+Then you have to tell them what is it, something.
+
+398
+00:52:11,455 --> 00:52:14,155
+You start talking about Sahaja Yoga only!
+
+399
+00:52:14,180 --> 00:52:17,296
+Talk nothing else but Sahaja Yoga.
+
+400
+00:52:17,321 --> 00:52:24,076
+You have to go on talking about Sahaja Yoga,
+spreading Sahaja Yoga: unless and until you
+
+401
+00:52:24,076 --> 00:52:29,856
+do it, it won't become collective, and all
+the disasters, which are due to collective
+
+402
+00:52:29,856 --> 00:52:34,430
+nonsense, you get it.
+
+403
+00:52:35,391 --> 00:52:38,817
+You are saved from so many things.
+
+404
+00:52:38,842 --> 00:52:44,063
+Say even if there's pollution, for a sahaja
+yogi it won't matter.
+
+405
+00:52:44,088 --> 00:52:51,494
+Even if there is a disaster of an earthquake
+the sahaja yogi will be saved.
+
+406
+00:52:51,519 --> 00:52:55,046
+But why not save the whole world?
+
+407
+00:52:55,071 --> 00:53:03,086
+Calamities after calamities are coming, and
+if you have compassion you must think of the
+
+408
+00:53:03,086 --> 00:53:08,954
+people who can get into any calamity or into
+any trouble.
+
+409
+00:53:08,979 --> 00:53:13,966
+Of course I can cure many people, no doubt.
+
+410
+00:53:13,966 --> 00:53:18,435
+But I don't know how to make Sahaja Yoga very
+collective.
+
+411
+00:53:18,435 --> 00:53:27,285
+Now you are so many people here, you all can
+start giving realisation to at least 100 people.
+
+412
+00:53:27,285 --> 00:53:29,096
+Go everywhere.
+
+413
+00:53:29,096 --> 00:53:32,433
+Talk about Sahaja Yoga.
+
+414
+00:53:32,458 --> 00:53:40,405
+Sing the praise of the Divine, and you will
+save the whole world.
+
+415
+00:53:40,405 --> 00:53:49,496
+It is not by saving some few people you can
+have the great Satya Yuga, but you have also
+
+416
+00:53:49,496 --> 00:53:52,076
+to save this Mother Earth.
+
+417
+00:53:52,076 --> 00:53:54,655
+You have to save the people who are in it.
+
+418
+00:53:54,655 --> 00:54:01,311
+I mean, the way these people are, I have seen
+so many of them on the television.
+
+419
+00:54:01,336 --> 00:54:06,277
+They, shamelessly they are talking about something
+which they don't know.
+
+420
+00:54:06,302 --> 00:54:10,035
+And they have thousands and thousands of people
+behind them.
+
+421
+00:54:10,060 --> 00:54:13,608
+Not that the people are stupid.
+
+422
+00:54:13,633 --> 00:54:23,715
+Not that they want to go on a wrong path,
+but these people who are false, or who are
+
+423
+00:54:23,715 --> 00:54:29,508
+wrong, know how to entice them, how to capture
+them, how to talk to them.
+
+424
+00:54:29,564 --> 00:54:39,475
+But a sahaja yogi, you see, if he sees somebody
+with a negative vibrations will run away.
+
+425
+00:54:39,704 --> 00:54:46,473
+He will escape such a society, will not go
+near them, and will say "Oh, very bad vibrations,
+
+426
+00:54:46,515 --> 00:54:48,328
+we don't want!".
+
+427
+00:54:48,353 --> 00:54:56,488
+So you have to be courageous and get into
+these places, talk to people and make it collective.
+
+428
+00:54:56,513 --> 00:55:02,005
+Otherwise you cannot save this world from
+the wrath of God.
+
+429
+00:55:02,005 --> 00:55:04,930
+God is wrathful, no doubt.
+
+430
+00:55:05,462 --> 00:55:09,195
+For you, he'll save you, but what's the use?
+
+431
+00:55:09,195 --> 00:55:13,093
+We have to save this Mother Earth.
+
+432
+00:55:13,118 --> 00:55:20,906
+And for that you have to be prepared, you
+have to work it out, and whenever you get
+
+433
+00:55:20,906 --> 00:55:24,040
+a chance you must spread Sahaja Yoga.
+
+434
+00:55:24,065 --> 00:55:28,566
+Some people told me "Mother, if you come then
+it will be All right" Why?
+
+435
+00:55:28,566 --> 00:55:34,106
+What's so much? .... you can be also like
+me.
+
+436
+00:55:34,106 --> 00:55:36,539
+You can talk about it to people.
+
+437
+00:55:36,564 --> 00:55:43,562
+I started Sahaja Yoga with one person and,
+that time, it was complete darkness everywhere.
+
+438
+00:55:43,587 --> 00:55:50,340
+No seekers, nothing, and horrible people,
+but it worked and it cleared.
+
+439
+00:55:50,365 --> 00:55:55,680
+So one person can get so many sahaja yogis,
+why not you people do the same
+
+440
+00:55:55,705 --> 00:55:57,624
+and talk about it.
+
+441
+00:55:57,649 --> 00:56:06,594
+Your behaviour, your style, everything will
+definitely impress them.
+
+442
+00:56:06,619 --> 00:56:17,312
+One has to work it out in such a manner that
+you achieve our goal of collective consciousness.
+
+443
+00:56:17,494 --> 00:56:21,158
+It is not only for sahaja yogis, it's for
+everyone.
+
+444
+00:56:21,191 --> 00:56:27,886
+So that all these calamities that are happening,
+horrible things that are happening, will stop.
+
+445
+00:56:27,886 --> 00:56:31,829
+Completely stop, I assure you, it can be stopped.
+
+446
+00:56:31,932 --> 00:56:34,364
+Because you are always saved.
+
+447
+00:56:34,389 --> 00:56:38,955
+So all people who will be getting realisation
+will be saved.
+
+448
+00:56:38,980 --> 00:56:46,015
+Why not talk openly about it telling people
+that if we do wrong, if we are immoral, if
+
+449
+00:56:46,040 --> 00:56:58,206
+we are cheats, if we try to oppress others
+and we become so much a power of destruction
+
+450
+00:56:58,231 --> 00:57:10,038
+then this collective disasters will be there
+and I think we'll be responsible for that.
+
+451
+00:57:10,307 --> 00:57:15,366
+Everything you take up, any subject you take
+up, you don't have to start an organisation
+
+452
+00:57:15,391 --> 00:57:17,176
+to fight it.
+
+453
+00:57:17,201 --> 00:57:23,764
+But only your power of convincing people and
+bringing them to Sahaja Yoga will make such
+
+454
+00:57:23,789 --> 00:57:25,435
+a difference.
+
+455
+00:57:25,435 --> 00:57:30,066
+I hope you will understand as a guru what
+you have to do.
+
+456
+00:57:30,066 --> 00:57:39,785
+As a guru there are so many things and as
+your character, yesterday, as they showed
+
+457
+00:57:39,785 --> 00:57:48,856
+how Lao Tse has written about the masters,
+how they were above all of it, above turmoil,
+
+458
+00:57:48,881 --> 00:57:55,213
+above jealousies, above talking loose.
+
+459
+00:57:55,269 --> 00:58:02,100
+They are so great, they are the masters and
+they will be the masters and you will be the
+
+460
+00:58:02,125 --> 00:58:05,725
+gurus if you try to do that.
+
+461
+00:58:05,725 --> 00:58:08,332
+This is what you have to achieve.
+
+462
+00:58:08,357 --> 00:58:15,409
+I know some have achieved it, but most of
+you have to achieve, with compassion and love.
+
+463
+00:58:15,436 --> 00:58:18,436
+May God Bless You All
+


### PR DESCRIPTION
## Why

The talk was added in #886 at 09:52 UTC on 2026-07-27. The Vimeo 401 fix
(#889 — hand yt-dlp the `player.vimeo.com` embed URL) only merged at 12:34.
So `new-talk.yml`'s `setup` job ran against the pre-fix code and failed on all
four videos:

```
ERROR: [vimeo] 336833139: Failed to fetch macos OAuth token: HTTP Error 401: Unauthorized
```

`new-talk.yml` triggers on `pull_request` `opened`/`synchronize` only, so the
already-merged PR never picked the fix up and no `source/en.srt` was ever
committed.

Knock-on effects: `timing_source: auto` resolved to `whisper` (see
`Guru-Puja/final/build_manifest.yaml`), and the three secondary videos got no
`uk.srt` at all, since `build_secondary_srts` skips videos without
`source/en.srt`.

## What

Backfilled all four `source/en.srt` using the post-fix `download_vimeo_subs`.

| Video | Blocks | Span | Coverage vs whisper speech |
|---|---|---|---|
| `Guru-Puja` | 463 | 00:00–58:18 | 28% (see note) |
| `Guru-Puja-Talk-Shraddha` | 640 | 00:00–52:18 | 100% |
| `Guru-Puja-1st-Talk-after-Puja` | 25 | 00:02–02:23 | 103% |
| `Guru-Puja-2nd-Talk-after-Puja` | 15 | 00:00–01:20 | 101% |

Note on `Guru-Puja`: that video is the full ~3.5h ceremony recording, while its
Vimeo EN track subtitles only the main talk (06:02–58:18). The partial coverage
is the source's, not a download error.

## Verification

Structural check on all four: sequential numbering, no overlapping or
zero-length cues, no empty text blocks — 0 issues.

## Follow-up (not in this PR)

Do **not** rebuild the primary `Guru-Puja` with `timing_source=en-srt`:
`transcript_en.txt` also covers the post-puja talks (present in the 3.5h
recording, up to 03:29 in the current `uk.srt`), and en-srt mode drops blocks
without an EN counterpart — that would silently truncate them. Whisper timing
stays correct for the primary. The secondary videos can now get their `uk.srt`
via `build_secondary_srts`.