### PR TITLE
fix(ci): bot PRs target the dispatch ref, not always main

### DIFF
--- a/.github/scripts/bot-pr.sh
+++ b/.github/scripts/bot-pr.sh
@@ -7,6 +7,9 @@
 # Example:
 #   .github/scripts/bot-pr.sh bot/whisper "Add Whisper data" talks/*/*/source/whisper.json
 #
+# The PR targets the ref the run was dispatched from (GITHUB_REF_NAME),
+# falling back to main. Override with BOT_PR_BASE.
+#
 # Requirements:
 #   - GH_TOKEN must be set (for gh CLI)
 #   - Must be run from repo root with git configured
@@ -45,6 +48,17 @@ if git diff --cached --quiet; then
   exit 0
 fi
 
+# Target the ref this run was dispatched from, NOT always main. The bot branch
+# is cut from the current checkout, so basing the PR on main would merge that
+# whole checkout into main — a workflow dispatched from a feature branch would
+# ship every unreviewed commit on it as a side effect of asking for artifacts.
+# `pull_request` runs report a synthetic `123/merge` ref that cannot be a base.
+BASE="${BOT_PR_BASE:-${GITHUB_REF_NAME:-main}}"
+case "$BASE" in
+  */merge|*/head|"") BASE="main" ;;
+esac
+echo "PR base: $BASE"
+
 # Create branch with timestamp to avoid collisions
 BRANCH="${BRANCH_PREFIX}/$(date +%Y%m%d-%H%M%S)-${RANDOM}"
 
@@ -57,7 +71,7 @@ git push -u origin "$BRANCH"
 PR_URL=$(gh pr create \
   --title "$COMMIT_MSG" \
   --body "Automated PR by GitHub Actions." \
-  --base main \
+  --base "$BASE" \
   --head "$BRANCH")
 
 echo "Created PR: $PR_URL"

--- a/.github/workflows/subtitle-pipeline.yml
+++ b/.github/workflows/subtitle-pipeline.yml
@@ -1169,7 +1169,10 @@ jobs:
         # Only when subtitles were actually built and committed this run —
         # resetting the issue to review:pending after a failed build would
         # wipe the real review status without shipping anything to review.
-        if: success() && needs.build-timecodes.result == 'success'
+        # And only on main: a run dispatched from a feature branch commits to
+        # that branch (bot-pr.sh), so nothing is on main to announce, and
+        # resetting an approved issue would wipe a real review status.
+        if: success() && needs.build-timecodes.result == 'success' && github.ref_name == 'main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TALK_ID: ${{ needs.discover.outputs.talk_id }}

--- a/tests/test_bot_pr_base.py
+++ b/tests/test_bot_pr_base.py
@@ -1,0 +1,146 @@
+"""`bot-pr.sh` must open its PR against the ref the workflow ran from.
+
+The base was hardcoded to `main`. Dispatching a workflow from a feature branch
+therefore cut the bot branch off that feature branch and opened a PR from it
+into `main` — auto-merged, so the *whole* feature branch landed on main as a
+side effect of asking for a build. That happened on 2026-07-31: a build-only
+pipeline run dispatched from `rebuild/2000-07-23-guru-puja` merged an entire
+unreviewed tooling PR into main.
+
+Artifacts belong on the branch that asked for them.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BOT_PR = REPO_ROOT / ".github" / "scripts" / "bot-pr.sh"
+
+# Records every argv it is called with, one call per line, then answers the
+# two questions bot-pr.sh asks: the PR URL, and whether merging worked.
+FAKE_GH = """#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$GH_CALL_LOG"
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  echo "https://github.com/o/r/pull/1"
+fi
+exit 0
+"""
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A work repo on branch `feature/x`, with a bare `origin` to push to."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)], check=True, capture_output=True)
+
+    work = tmp_path / "work"
+    work.mkdir()
+    _git("init", "-b", "main", cwd=work)
+    _git("config", "user.email", "t@t", cwd=work)
+    _git("config", "user.name", "t", cwd=work)
+    (work / "review-status.json").write_text("{}\n", encoding="utf-8")
+    _git("add", "-A", cwd=work)
+    _git("commit", "-m", "init", cwd=work)
+    _git("remote", "add", "origin", str(origin), cwd=work)
+    _git("push", "-u", "origin", "main", cwd=work)
+
+    _git("checkout", "-b", "feature/x", cwd=work)
+    (work / "review-status.json").write_text('{"changed": true}\n', encoding="utf-8")
+    return work
+
+
+def _run_bot_pr(repo: Path, tmp_path: Path, **env_overrides: str) -> list[str]:
+    """Run bot-pr.sh with a fake `gh`; return the argv line of each gh call."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    gh = bin_dir / "gh"
+    gh.write_text(FAKE_GH, encoding="utf-8")
+    gh.chmod(0o755)
+
+    log = tmp_path / "gh_calls.log"
+    log.write_text("", encoding="utf-8")
+
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "GH_CALL_LOG": str(log),
+        "GH_TOKEN": "fake",
+    }
+    env.pop("GITHUB_REF_NAME", None)
+    env.pop("BOT_PR_BASE", None)
+    env.update(env_overrides)
+
+    result = subprocess.run(
+        ["bash", str(BOT_PR), "bot/test", "Test commit", "review-status.json"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"bot-pr.sh failed:\n{result.stdout}\n{result.stderr}"
+    return [ln for ln in log.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+
+def _pr_create_call(calls: list[str]) -> str:
+    matches = [c for c in calls if c.startswith("pr create")]
+    assert len(matches) == 1, f"expected exactly one `gh pr create`, got: {calls}"
+    return matches[0]
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git required")
+def test_pr_base_is_the_dispatch_ref_not_main(repo: Path, tmp_path: Path) -> None:
+    """Dispatched from a feature branch → the PR targets that branch.
+
+    Regression: `--base main` merged the entire dispatch branch into main.
+    """
+    calls = _run_bot_pr(repo, tmp_path, GITHUB_REF_NAME="feature/x")
+    assert "--base feature/x" in _pr_create_call(calls)
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git required")
+def test_pr_base_is_main_when_running_on_main(repo: Path, tmp_path: Path) -> None:
+    """The normal path is unchanged: on main, the PR targets main."""
+    _git("checkout", "main", cwd=repo)
+    (repo / "review-status.json").write_text('{"changed": true}\n', encoding="utf-8")
+    calls = _run_bot_pr(repo, tmp_path, GITHUB_REF_NAME="main")
+    assert "--base main" in _pr_create_call(calls)
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git required")
+def test_pr_base_falls_back_to_main_outside_actions(repo: Path, tmp_path: Path) -> None:
+    """No GITHUB_REF_NAME (a local run) → main, as before."""
+    calls = _run_bot_pr(repo, tmp_path)
+    assert "--base main" in _pr_create_call(calls)
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git required")
+def test_pr_base_can_be_overridden_explicitly(repo: Path, tmp_path: Path) -> None:
+    """A caller that genuinely wants another target can say so."""
+    calls = _run_bot_pr(repo, tmp_path, GITHUB_REF_NAME="feature/x", BOT_PR_BASE="main")
+    assert "--base main" in _pr_create_call(calls)
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git required")
+def test_pr_base_ignores_a_pull_request_merge_ref(repo: Path, tmp_path: Path) -> None:
+    """On a `pull_request` event GITHUB_REF_NAME is `123/merge`, which is not a
+    branch anyone can merge into. Fall back to main rather than open a PR
+    against a ref that cannot be a base."""
+    calls = _run_bot_pr(repo, tmp_path, GITHUB_REF_NAME="123/merge")
+    assert "--base main" in _pr_create_call(calls)
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git required")
+def test_bot_branch_is_pushed_before_the_pr_is_opened(repo: Path, tmp_path: Path) -> None:
+    """Sanity: the script still does its job end to end under the fake gh."""
+    calls = _run_bot_pr(repo, tmp_path, GITHUB_REF_NAME="feature/x")
+    assert any(c.startswith("pr merge") for c in calls), calls
+    branches = subprocess.run(["git", "branch", "-r"], cwd=repo, capture_output=True, text=True, check=True).stdout
+    assert "origin/bot/test/" in branches, branches

--- a/tests/test_workflow_audit_regressions.py
+++ b/tests/test_workflow_audit_regressions.py
@@ -155,3 +155,21 @@ def test_ytdlp_steps_decode_video_ref_to_player_url() -> None:
         assert decodes, f"{name}: no video_ref decode found"
         for call in decodes:
             assert "--player" in call, f"{name}: yt-dlp needs the embed form: decode {call}"
+
+
+def test_review_issue_is_only_touched_on_main() -> None:
+    """The review tracking issue is main-scoped shared state: creating it —
+    or resetting an approved one back to review:pending — announces that new
+    subtitles are on main and ready to review.
+
+    A run dispatched from a feature branch commits its artifacts to that
+    branch (see bot-pr.sh), so nothing reached main and the issue must be
+    left alone. Regression guard for the 2026-07-31 branch-dispatch fallout.
+    """
+    wf = yaml.safe_load((WORKFLOWS / "subtitle-pipeline.yml").read_text(encoding="utf-8"))
+    steps = wf["jobs"]["commit"]["steps"]
+    issue_steps = [s for s in steps if "review tracking issue" in (s.get("name") or "").lower()]
+    assert issue_steps, "review tracking issue step not found"
+    for step in issue_steps:
+        cond = str(step.get("if", ""))
+        assert "github.ref_name == 'main'" in cond, f"review-issue step must be gated on main, got if: {cond!r}"


### PR DESCRIPTION
## The bug

`.github/scripts/bot-pr.sh` hardcoded `--base main`. It cuts the bot branch from the **current checkout**, so a workflow dispatched from a feature branch opened a PR *from that branch* into `main` — and auto-merged it.

Asking a workflow for artifacts therefore shipped every unreviewed commit on the branch, as a side effect.

Not theoretical. On 2026-07-31 a build-only pipeline run dispatched from `rebuild/2000-07-23-guru-puja` merged an entire unreviewed tooling PR into `main` via bot PR #906 — 52 files, none of them reviewed, including `tools/`, `tests/` and fixtures.

## The fix

| | Base |
|---|---|
| dispatched from `main` (the normal path) | `main` — unchanged |
| dispatched from a feature branch | that branch |
| run outside Actions (no `GITHUB_REF_NAME`) | `main` |
| `pull_request` event (synthetic `123/merge` ref) | `main` — a merge ref cannot be a base |
| `BOT_PR_BASE` set | that value |

Same reasoning applied to the pipeline's **review tracking issue** step: creating that issue announces "new subtitles are on main, ready to review", and re-running resets an *approved* issue back to `review:pending`. A branch run put nothing on main, so it must leave that shared state alone — now gated on `github.ref_name == 'main'`.

All three `bot-pr.sh` callers (`subtitle-pipeline.yml`, `whisper.yml`, `sync-review-status.yml`) inherit the behaviour. `sync-review-status.yml` runs via `workflow_call`, where `GITHUB_REF_NAME` is the caller's ref — so it follows the pipeline onto the same branch, which is what you want.

## Testing

TDD — `tests/test_bot_pr_base.py` (new, 6 tests) drives the script **behaviourally**, not structurally: a temp git repo with a bare `origin`, and a fake `gh` on `PATH` that records every argv. One test failed for the right reason before the fix:

```
E  assert '--base feature/x' in 'pr create … --base main --head bot/test/…'
```

It covers each row of the table above, plus an end-to-end sanity check that the bot branch still reaches `origin` and the merge is still attempted.

`tests/test_workflow_audit_regressions.py` +1 pins the review-issue gate.

`735 passed` (`pytest -m "not e2e"`), `ruff check` + `ruff format --check` clean, `bash -n` clean.

## Note on #906

The content merged by #906 is the (green, but unreviewed) work from #904. It is on `main` and the suite passes there — but it never got the review it was opened for. Worth a look after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)