### PR TITLE
fix(pipeline): keep a claimed review claimed across rebuilds

### DIFF
--- a/.github/workflows/subtitle-pipeline.yml
+++ b/.github/workflows/subtitle-pipeline.yml
@@ -1197,9 +1197,21 @@ jobs:
           SPA_BASE="https://${OWNER_LC}.github.io/${REPO#*/}"
           EXISTING=$(gh issue list --search "Review: $TALK_ID in:title" --json number --jq '.[0].number')
           if [ -n "$EXISTING" ]; then
-            echo "Review issue #$EXISTING already exists — resetting to pending"
+            # A rebuild invalidates an approval, but never a claim: an
+            # assigned issue stays review:in-progress. Resetting it to
+            # review:pending left the assignee in place while the SPA
+            # advertised the talk as needing a reviewer (issue #895).
+            CLAIMED=$(gh issue view "$EXISTING" --json assignees --jq '.assignees | length')
+            if [ "$CLAIMED" -gt 0 ]; then
+              NEXT_LABEL="review:in-progress"
+              DROP_LABELS="review:approved,review:pending"
+            else
+              NEXT_LABEL="review:pending"
+              DROP_LABELS="review:approved,review:in-progress"
+            fi
+            echo "Review issue #$EXISTING already exists — resetting to $NEXT_LABEL"
             gh issue reopen "$EXISTING"
-            gh issue edit "$EXISTING" --remove-label "review:approved,review:in-progress" --add-label "review:pending,talk-review"
+            gh issue edit "$EXISTING" --remove-label "$DROP_LABELS" --add-label "$NEXT_LABEL,talk-review"
           else
             META_TITLE=$(python3 -c "import yaml; print(yaml.safe_load(open('talks/$TALK_ID/meta.yaml'))['title'])" 2>/dev/null || echo "$TALK_ID")
             gh issue create \

--- a/tests/test_workflow_audit_regressions.py
+++ b/tests/test_workflow_audit_regressions.py
@@ -173,3 +173,31 @@ def test_review_issue_is_only_touched_on_main() -> None:
     for step in issue_steps:
         cond = str(step.get("if", ""))
         assert "github.ref_name == 'main'" in cond, f"review-issue step must be gated on main, got if: {cond!r}"
+
+
+def test_review_issue_reset_keeps_a_claimed_review_claimed() -> None:
+    """A rebuild invalidates an approval, but never a claim.
+
+    The reset dropped `review:in-progress` unconditionally while leaving the
+    assignee in place, so a talk rebuilt after someone claimed it went back to
+    `review:pending` — and the SPA, which reads the label via
+    review-status.json, advertised it as needing a reviewer while that
+    reviewer was still on it. Observed on issue #895: assigned 2026-07-27,
+    reset by the 2026-07-30 rebuild.
+
+    An assigned issue must therefore land on `review:in-progress`; only an
+    unassigned one resets to `review:pending`.
+    """
+    wf = yaml.safe_load((WORKFLOWS / "subtitle-pipeline.yml").read_text(encoding="utf-8"))
+    step = next(s for s in wf["jobs"]["commit"]["steps"] if "review tracking issue" in (s.get("name") or "").lower())
+    run = step["run"]
+    # The reset branch only — everything between the existing-issue test and
+    # the `else` that creates a fresh issue (which is pending by definition).
+    start = run.find('if [ -n "$EXISTING" ]')
+    assert start != -1, "existing-issue branch not found"
+    reset = run[start : run.find("\n          else", start)]
+    assert "--json assignees" in reset, "reset must read the issue's assignees before picking a label"
+    assert '--add-label "review:pending' not in reset.replace("'", '"'), (
+        "reset must not unconditionally re-apply review:pending — an assigned issue stays in-progress"
+    )
+    assert "review:in-progress" in reset, "reset must be able to land on review:in-progress"


### PR DESCRIPTION
## Problem

Issue #895 (`2000-07-23_Guru-Puja-Shraddha`) was assigned to a reviewer on
2026-07-27 and the sync workflow correctly moved it to `review:in-progress`.
The talk was then rebuilt on 2026-07-30 — and the pipeline's
*Create review tracking issue* step reset it back to `review:pending` while
leaving the assignee in place.

Result: the SPA (which reads the label through `review-status.json`)
advertised the talk as needing a reviewer while that reviewer was still on
it. Timeline of #895:

```
2026-07-27T14:18:21Z  assigned          IrynaFilSY
2026-07-27T14:18:35Z  -review:pending  +review:in-progress   (sync-review-status)
2026-07-30T08:12:47Z  -review:in-progress  +review:pending   (pipeline rebuild)  <-- the bug
```

## Fix

A rebuild invalidates an *approval*, never a *claim*. The reset now reads the
issue's assignees: an assigned issue lands on `review:in-progress`, only an
unassigned one on `review:pending`. `review:approved` is dropped either way,
which is the behaviour a rebuild is meant to have.

## Testing

`tests/test_workflow_audit_regressions.py::test_review_issue_reset_keeps_a_claimed_review_claimed`
— written first, verified failing against the old step ("reset must read the
issue's assignees before picking a label"), passing with the fix. Full
workflow/pipeline lane green (196 passed).

The label on #895 itself was already restored by hand, so the SPA is correct
today; this stops the next rebuild from undoing it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)