### PR TITLE
fix(spa): byte counter for the buffered (Firefox) video download

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -5074,6 +5074,12 @@ function streamBurnedMp4(url, token, file) {
 // refuses. It holds the whole video in memory, so past a point the allocation
 // simply fails and the tab dies with an untranslated error the user cannot act
 // on: say the size and point at the run instead.
+//
+// The body is read chunk by chunk ONLY so the byte counter can move: this is
+// the whole transfer UI a Firefox reviewer gets. GitHub's artifact host can
+// crawl for minutes, and a silent arrayBuffer() gulp over that left the item
+// saying "downloading, please wait" with no sign of life — reported as broken
+// while the transfer was in fact running.
 function downloadBurnedBuffered(url, token, art) {
   if (art.size_in_bytes > BURN_MAX_DOWNLOAD_BYTES) {
     throw new Error(t('burn.too_large')
@@ -5082,9 +5088,30 @@ function downloadBurnedBuffered(url, token, art) {
   return fetch(url, { headers: { Authorization: 'Bearer ' + token } })
     .then(function(resp) {
       if (!resp.ok) throw new Error(t('burn.download_failed').replace('{status}', resp.status));
-      return resp.arrayBuffer();
-    }).then(function(buf) {
-      return extractBurnedMp4(new Uint8Array(buf));
+      if (!resp.body || !resp.body.getReader) return resp.arrayBuffer().then(function(buf) {
+        return new Uint8Array(buf);
+      });
+      // The ZIP is stored (compression-level 0), so the body length matches
+      // the API's size_in_bytes; Content-Length corroborates where exposed.
+      var total = Number(resp.headers && resp.headers.get
+        && resp.headers.get('Content-Length')) || art.size_in_bytes || 0;
+      var reader = resp.body.getReader();
+      var chunks = [], loaded = 0;
+      return (function step() {
+        return reader.read().then(function(r) {
+          if (r.done) {
+            var out = new Uint8Array(loaded), off = 0;
+            for (var i = 0; i < chunks.length; i++) { out.set(chunks[i], off); off += chunks[i].length; }
+            return out;
+          }
+          chunks.push(r.value);
+          loaded += (r.value && r.value.length) || 0;
+          advanceBurnDownload(loaded, total);
+          return step();
+        });
+      })();
+    }).then(function(bytes) {
+      return extractBurnedMp4(bytes);
     }).then(function(file) {
       return saveMp4(file.bytes, file.name);
     });

--- a/tests/test_burn_video.js
+++ b/tests/test_burn_video.js
@@ -169,9 +169,6 @@ describe('BURN_WORKFLOW', () => {
 const {
   FONT_RATIO_MAX,
   FONT_RATIO_MIN,
-  FS_FONT_MAX_PX,
-  FS_PADBOT_PX,
-  FS_PADTOP_PX,
   displayedVideoHeight,
   fullscreenFontPx,
   measureBurnRatios,
@@ -318,7 +315,6 @@ function job(steps, status, conclusion) {
   };
 }
 const T0 = 1700000000000;
-const HOUR_MS = 3600 * 1000;
 const done = (name) => ({ name, status: 'completed', conclusion: 'success' });
 
 describe('BURN_STEP_WEIGHTS', () => {

--- a/tests/test_spa_cache.js
+++ b/tests/test_spa_cache.js
@@ -5736,6 +5736,118 @@ describe('burn video driver behaviour', () => {
     assert.strictEqual(env.els['btn-burn-video'].disabled, false);
   });
 
+  it('the buffered fallback reports the same byte counter as the streaming path', async () => {
+    // Firefox has no save-file dialog, so the whole artifact buffers through
+    // memory — and for the minutes a slow artifact host takes, the item was the
+    // only possible sign of life and it never moved. The reviewer's words:
+    // «змінюється напис на завантажується але самого завантаження не
+    // відбувається» — the transfer WAS running, silently.
+    const zip = skewedZip(Buffer.alloc(20000, 7), 11);
+    const half = Math.floor(zip.bytes.length / 2);
+    const seen = [];
+    let sent = 0;
+    const env = makeHarness(Object.assign({}, FINISHED, {
+      window: { screen: { width: 1280, height: 720 } },   // no showSaveFilePicker
+      listRunArtifacts: function () {
+        return Promise.resolve([{ id: 9, size_in_bytes: zip.bytes.length }]);
+      },
+      fetch: function () {
+        return Promise.resolve({
+          ok: true, status: 200,
+          headers: { get: function (h) {
+            return /^content-length$/i.test(h) ? String(zip.bytes.length) : null; } },
+          // The old code path swallowed the body whole; keeping arrayBuffer()
+          // here means that path still SUCCEEDS — this test must fail on the
+          // missing counter, not on a broken fixture.
+          arrayBuffer: function () {
+            return Promise.resolve(zip.bytes.buffer.slice(
+              zip.bytes.byteOffset, zip.bytes.byteOffset + zip.bytes.byteLength));
+          },
+          body: { getReader: function () { return { read: function () {
+            if (sent === 0) {
+              sent = 1;
+              return Promise.resolve({
+                value: new Uint8Array(zip.bytes.subarray(0, half)), done: false });
+            }
+            if (sent === 1) {
+              sent = 2;
+              // Between the chunks: chunk 1 must already be on the counter.
+              seen.push({
+                meta: env.els['burn-step'].textContent,
+                value: env.els['burn-track'].attrs['aria-valuenow']
+              });
+              return Promise.resolve({
+                value: new Uint8Array(zip.bytes.subarray(half)), done: false });
+            }
+            return Promise.resolve({ done: true });
+          } }; } }
+        });
+      }
+    }));
+    env.localStorage.setItem('burn:t:v', JSON.stringify({
+      requestId: 'old', runId: 7, runUrl: '', startedAt: Date.now(),
+      talkId: 't', videoSlug: 'v', editsSig: '' }));
+    env.api.resumeBurnWatch('t', 'v');
+    await settle();
+    await env.api.downloadBurned();
+    assert.strictEqual(env.els['burn-error'].textContent || '', '',
+      'the transfer must not fail');
+    assert.ok(seen.length,
+      'the body must be read chunk by chunk — a silent arrayBuffer() gulp shows nothing');
+    assert.strictEqual(seen[0].meta, 'T:burn.downloaded',
+      'the byte counter is the only sign of movement Firefox gets');
+    assert.ok(Number(seen[0].value) >= 40 && Number(seen[0].value) <= 60,
+      'and it must stand at the first chunk, got: ' + seen[0].value);
+    assert.ok(env.created.length,
+      'the finished file still lands through the anchor download');
+  });
+
+  it('keeps a real percentage when the host hides Content-Length', async () => {
+    // Content-Range/Content-Length exposure over CORS is the host's choice, not
+    // ours. The artifact ZIP is stored uncompressed, so the API's own
+    // size_in_bytes is the same number — the counter must fall back to it
+    // rather than degrade to a percentless crawl.
+    const zip = skewedZip(Buffer.alloc(20000, 7), 11);
+    const half = Math.floor(zip.bytes.length / 2);
+    const seen = [];
+    let sent = 0;
+    const env = makeHarness(Object.assign({}, FINISHED, {
+      window: { screen: { width: 1280, height: 720 } },
+      listRunArtifacts: function () {
+        return Promise.resolve([{ id: 9, size_in_bytes: zip.bytes.length }]);
+      },
+      fetch: function () {
+        return Promise.resolve({
+          ok: true, status: 200,
+          headers: { get: function () { return null; } },
+          body: { getReader: function () { return { read: function () {
+            if (sent === 0) {
+              sent = 1;
+              return Promise.resolve({
+                value: new Uint8Array(zip.bytes.subarray(0, half)), done: false });
+            }
+            if (sent === 1) {
+              sent = 2;
+              seen.push({ value: env.els['burn-track'].attrs['aria-valuenow'] });
+              return Promise.resolve({
+                value: new Uint8Array(zip.bytes.subarray(half)), done: false });
+            }
+            return Promise.resolve({ done: true });
+          } }; } }
+        });
+      }
+    }));
+    env.localStorage.setItem('burn:t:v', JSON.stringify({
+      requestId: 'old', runId: 7, runUrl: '', startedAt: Date.now(),
+      talkId: 't', videoSlug: 'v', editsSig: '' }));
+    env.api.resumeBurnWatch('t', 'v');
+    await settle();
+    await env.api.downloadBurned();
+    assert.ok(seen.length, 'the second chunk must have been asked for');
+    assert.ok(Number(seen[0].value) >= 40 && Number(seen[0].value) <= 60,
+      'size_in_bytes must carry the percentage, got: ' + seen[0].value);
+  });
+
   it('does not start a second poll loop when the menu is reopened mid-request', async () => {
     // openExportMenu() re-arms the follow and calls pollBurn(). A close+reopen
     // inside one network round-trip left the first chain's continuation to find

--- a/tools/burn_subtitles.py
+++ b/tools/burn_subtitles.py
@@ -180,10 +180,14 @@ def build_ass_header(width, height, font_size, font_name, margin_h, margin_v):
             "YCbCr Matrix: None",
             "",
             "[V4+ Styles]",
-            "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, "
-            "OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, "
-            "ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, "
-            "Alignment, MarginL, MarginR, MarginV, Encoding",
+            # One ASS header line, split only for line length — parenthesized so
+            # the concatenation is visibly deliberate, not a missing comma.
+            (
+                "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, "
+                "OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, "
+                "ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, "
+                "Alignment, MarginL, MarginR, MarginV, Encoding"
+            ),
             # OutlineColour alpha 1A ~ the CSS 0 0 2px rgba(0,0,0,.9) halo.
             # BackColour (alpha 26 ~ the 0 2px 8px rgba(0,0,0,.85) drop shadow)
             # is the shadow's colour. It draws nothing while the Shadow field


### PR DESCRIPTION
Firefox has no `showSaveFilePicker`, so the burned-video download takes the buffered path — a single `fetch` swallowed whole by `arrayBuffer()`. That gulp reports no progress, and GitHub's artifact blob host can crawl at a few hundred KB/s: for the minutes a ~180 MB video takes, the export item said "downloading, please wait" with no sign of life. Reported as broken while the transfer was in fact running.

**Diagnosis path (all verified live):**
- CORS preflight, the 302 → Azure blob redirect, and `Range` → 206 are all clean from both origins;
- the service worker passes the artifact fetches through untouched (A/B with the prod SW registered on the stand);
- the streaming (Chrome) path works end-to-end with the App token — counter and all;
- Firefox repro against a real 174 MB artifact showed the buffered fetch running silently past 8 minutes at the host's ~0.25 MB/s.

**Fix:** the buffered path now reads the body chunk by chunk and feeds the same `advanceBurnDownload()` readout the streaming path uses, so Firefox gets the moving "N MB of M MB" counter too. Total falls back from `Content-Length` to the API's `size_in_bytes` (the ZIP is stored uncompressed, so they match). Browsers without `ReadableStream` keep the old whole-body gulp.

Mutation-verified (dropping the counter call, forcing the gulp, zeroing the size fallback each fail a test) and verified live in headless Firefox: the counter ticks 0 → 2 → 3 → 5 MB of 174 MB within the first half minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)