### PR TITLE
feat(spa): «Відео з субтитрами завантажено» until the menu is reopened

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1002,6 +1002,7 @@ var I18N = {
     'export.video_working': '\u0421\u0442\u0432\u043e\u0440\u044e\u0454\u0442\u044c\u0441\u044f \u0432\u0456\u0434\u0435\u043e \u0437 \u0441\u0443\u0431\u0442\u0438\u0442\u0440\u0430\u043c\u0438, \u0437\u0430\u0447\u0435\u043a\u0430\u0439\u0442\u0435',
     'export.video_download': '\u0417\u0430\u0432\u0430\u043d\u0442\u0430\u0436\u0438\u0442\u0438 \u0432\u0456\u0434\u0435\u043e \u0437 \u0441\u0443\u0431\u0442\u0438\u0442\u0440\u0430\u043c\u0438',
     'export.video_downloading': '\u0417\u0430\u0432\u0430\u043d\u0442\u0430\u0436\u0443\u0454\u0442\u044c\u0441\u044f \u0432\u0456\u0434\u0435\u043e, \u0437\u0430\u0447\u0435\u043a\u0430\u0439\u0442\u0435',
+    'export.video_downloaded': '\u0412\u0456\u0434\u0435\u043e \u0437 \u0441\u0443\u0431\u0442\u0438\u0442\u0440\u0430\u043c\u0438 \u0437\u0430\u0432\u0430\u043d\u0442\u0430\u0436\u0435\u043d\u043e',
     'burn.downloaded': '{done} \u041c\u0411 \u0437 {total} \u041c\u0411',
     'export.srt_failed': '\u041d\u0435 \u0432\u0434\u0430\u043b\u043e\u0441\u044f \u0437\u0430\u0432\u0430\u043d\u0442\u0430\u0436\u0438\u0442\u0438 \u0441\u0443\u0431\u0442\u0438\u0442\u0440\u0438 (HTTP {status})',
     'burn.saved': '\u0412\u0456\u0434\u0435\u043e \u0437\u0431\u0435\u0440\u0435\u0436\u0435\u043d\u043e: {name}',
@@ -1206,6 +1207,7 @@ var I18N = {
     'export.video_working': 'Building the video with subtitles, please wait',
     'export.video_download': 'Download the video with subtitles',
     'export.video_downloading': 'Downloading the video, please wait',
+    'export.video_downloaded': 'The video with subtitles has been downloaded',
     'burn.downloaded': '{done} MB of {total} MB',
     'export.srt_failed': 'Subtitle download failed (HTTP {status})',
     'burn.saved': 'Video saved: {name}',
@@ -3919,6 +3921,27 @@ function burnDownloadIsHere() {
     && burnDownload.videoSlug === (previewState && previewState.videoSlug);
 }
 
+// The transfer that LANDED, {talkId, videoSlug} — set only where a file
+// verifiably reached disk, cleared when the menu closes. While set, the item
+// says "the video has been downloaded" instead of offering the download again
+// as if nothing happened; closing and reopening the menu re-arms the offer.
+var burnDownloaded = null;
+
+function burnDownloadedIsHere() {
+  return !!burnDownloaded
+    && burnDownloaded.talkId === (previewState && previewState.talkId)
+    && burnDownloaded.videoSlug === (previewState && previewState.videoSlug);
+}
+
+// Called beside each success toast — those are exactly the "file landed"
+// points. The scope comes from the transfer slot, not from previewState: the
+// transfer may outlive the preview it started on, and the claim belongs to
+// ITS video, not to whichever one is on screen when the bytes finish.
+function markBurnDownloaded() {
+  if (!burnDownload) return;
+  burnDownloaded = { talkId: burnDownload.talkId, videoSlug: burnDownload.videoSlug };
+}
+
 // The workflow reads talks/{id}/{slug}/final/uk.srt and declares no language
 // input, so this is the one language a render can be about.
 var BURN_LANG = 'uk';
@@ -4028,11 +4051,13 @@ function renderVideoItem() {
     following: burnFollowing || burnConfirming,
     done: !!(burnLastProgress && burnLastProgress.done),
     stale: burnStale(),
-    expired: /export-item-group--expired/.test(group.className)
+    expired: /export-item-group--expired/.test(group.className),
+    justDownloaded: burnDownloadedIsHere()
   });
   var key = s.state === 'working' ? 'export.video_working'
     : (s.state === 'downloading' ? 'export.video_downloading'
-    : (s.state === 'download' ? 'export.video_download' : 'export.video_make'));
+    : (s.state === 'downloaded' ? 'export.video_downloaded'
+    : (s.state === 'download' ? 'export.video_download' : 'export.video_make')));
   // The key travels with the text so translatePage() repaints the right label.
   label.setAttribute('data-i18n', key);
   label.textContent = t(key);
@@ -4694,6 +4719,9 @@ function closeExportMenu() {
   menu.hidden = true;
   var btn = document.getElementById('btn-export');
   if (btn) btn.setAttribute('aria-expanded', 'false');
+  // Closing the menu retires the "video has been downloaded" claim: the next
+  // open offers the download again.
+  burnDownloaded = null;
   stopBurnTimer();
   setBurnFollowing(false);
   updateExportUi();
@@ -5064,6 +5092,7 @@ function streamBurnedMp4(url, token, file) {
           // (The subtitle file goes through an anchor and DOES appear there,
           // so without this the two downloads behaved differently for no
           // reason the user could see.)
+          markBurnDownloaded();
           showToast(t('burn.saved').replace('{name}', file.name));
         });
       });
@@ -5180,6 +5209,7 @@ function saveMp4(bytes, name) {
       }).then(function() {
         // Same silence as the streaming path: written through the dialog's own
         // handle, this lands in no downloads list and behind no shelf.
+        markBurnDownloaded();
         showToast(t('burn.saved').replace('{name}', name));
       });
     }).catch(function(err) {
@@ -5195,6 +5225,7 @@ function saveMp4(bytes, name) {
   // without asking — and, unlike the streaming path, it was assembled in
   // memory first. The toast says both, because the memory is why a long talk
   // can fail here and not in a browser that has a picker.
+  markBurnDownloaded();
   showToast(t('burn.memory_fallback'));
   saveBlob(blob, name);
   return Promise.resolve();

--- a/site/js/export_menu.js
+++ b/site/js/export_menu.js
@@ -28,13 +28,14 @@
 
   // Which face the video item wears, and whether it can be pressed.
   //
-  //   writeUser     the session can dispatch a workflow run at all
-  //   langMismatch  the preview shows subtitles the render would not burn
-  //   downloading   the finished video is transferring to disk right now
-  //   following     a run is in flight and being polled
-  //   done          the followed run finished successfully
-  //   stale         the subtitles changed since that run was dispatched
-  //   expired       the run's artifact is past the 7-day retention
+  //   writeUser      the session can dispatch a workflow run at all
+  //   langMismatch   the preview shows subtitles the render would not burn
+  //   downloading    the finished video is transferring to disk right now
+  //   following      a run is in flight and being polled
+  //   done           the followed run finished successfully
+  //   stale          the subtitles changed since that run was dispatched
+  //   expired        the run's artifact is past the 7-day retention
+  //   justDownloaded the file landed and the menu has not been closed since
   //
   // Order matters: a transfer in progress outranks a run in flight (they cannot
   // both be true, and the transfer is the one the user just started), and both
@@ -60,6 +61,10 @@
     // The file already exists; which subtitles happen to be on screen cannot
     // unmake it, so the language guard does not reach the download.
     if (o.done && !o.stale && !o.expired) {
+      // Right after the transfer lands the item is a statement, not a button:
+      // flipping straight back to "Download..." reads as if nothing happened.
+      // Closing the menu retires the claim; reopening offers the download again.
+      if (o.justDownloaded) return { state: 'downloaded', disabled: true, reasonKey: '' };
       return { state: 'download', disabled: false, reasonKey: '' };
     }
     return {

--- a/site/styleguide.html
+++ b/site/styleguide.html
@@ -285,6 +285,13 @@ A failed phase is marked on the segment <em>body</em>, so it shows even at zero 
       { name: 'transferring', tint: 'export-item-group--done export-item-group--transfer',
         disabled: true, label: 'Downloading the video, please wait',
         transfer: 0.43, status: ['120 MB of 281 MB', '', ''], link: true },
+      // The file has just landed. A statement, not a button: flipping straight
+      // back to "Download..." read as if nothing happened. The group keeps the
+      // render's --done green; closing and reopening the menu re-arms the offer.
+      { name: 'downloaded', tint: 'export-item-group--done', disabled: true,
+        label: 'The video with subtitles has been downloaded',
+        p: { fraction: 1, done: true },
+        status: ['', '', 'done in 21 min'], link: true },
       // Offered, but refused: the preview shows subtitles the render would not
       // burn. The reason lives on the control's own title, as in the app.
       { name: 'wrong language', tint: '', disabled: true,

--- a/tests/test_export_menu.js
+++ b/tests/test_export_menu.js
@@ -95,6 +95,40 @@ describe('export menu — the video item while the file is transferring', () => 
   });
 });
 
+describe('export menu — the video item after the file has landed', () => {
+  // A completed transfer flips the item straight back to "Download the video
+  // with subtitles" — which reads as if nothing happened. The item keeps a
+  // "downloaded" face until the menu is closed; reopening offers the download
+  // again.
+  const base = { writeUser: true, done: true, justDownloaded: true };
+
+  it('says the video has been downloaded, and is not a button', () => {
+    const s = M.videoItemState(base);
+    assert.strictEqual(s.state, 'downloaded');
+    assert.strictEqual(s.disabled, true,
+      'the label is a statement, not an action — reopening re-arms the download');
+  });
+
+  it('withdraws the claim once the subtitles have moved on', () => {
+    // An edit makes the downloaded file no longer the text on screen: the item
+    // goes back to offering a build, exactly as the plain download face does.
+    const s = M.videoItemState(Object.assign({}, base, { stale: true }));
+    assert.strictEqual(s.state, 'start');
+  });
+
+  it('yields to a transfer in flight', () => {
+    // One slot: a new transfer for another video can be running while this
+    // item's file already landed. The moving bytes outrank the finished claim.
+    const s = M.videoItemState(Object.assign({}, base, { downloading: true }));
+    assert.strictEqual(s.state, 'downloading');
+  });
+
+  it('still hides from a session that cannot render at all', () => {
+    const s = M.videoItemState(Object.assign({}, base, { writeUser: false }));
+    assert.strictEqual(s.state, 'hidden');
+  });
+});
+
 describe('export menu — transfer arithmetic', () => {
   it('is the fraction of the file that has landed', () => {
     assert.strictEqual(M.downloadFraction(0, 200), 0);

--- a/tests/test_spa_cache.js
+++ b/tests/test_spa_cache.js
@@ -5731,8 +5731,45 @@ describe('burn video driver behaviour', () => {
     assert.strictEqual(seen[0].disabled, true,
       'a second click must not start a second transfer');
     assert.ok(seen[0].meta, 'the byte counter is the only sign of movement');
+    // Not straight back to "Download the video with subtitles": that reads as
+    // if nothing happened. The landed file gets said out loud.
+    assert.strictEqual(env.els['burn-item-label'].textContent, 'T:export.video_downloaded',
+      'the item must say the file has landed');
+    assert.strictEqual(env.els['btn-burn-video'].disabled, true,
+      'a statement, not a button — reopening the menu re-arms the download');
+  });
+
+  it('re-arms the download when the menu is closed and reopened', async () => {
+    const zip = skewedZip(Buffer.alloc(20000, 7), 11);
+    const env = downloadableHarness(zip.bytes);
+    await settle();
+    env.api.openExportMenu();   // a download always starts from the open menu
+    await env.api.downloadBurned();
+    assert.strictEqual(env.els['burn-item-label'].textContent, 'T:export.video_downloaded',
+      'precondition: the item says the file has landed');
+    env.api.closeExportMenu();
+    env.api.openExportMenu();
     assert.strictEqual(env.els['burn-item-label'].textContent, 'T:export.video_download',
-      'and it must hand the item back afterwards, not hold it forever');
+      'a fresh look at the menu offers the download again');
+    assert.strictEqual(env.els['btn-burn-video'].disabled, false);
+  });
+
+  it('does not claim a download the save dialog cancelled', async () => {
+    // Escape in the picker resolves the flow without a file. "The video has
+    // been downloaded" over a cancel would be a lie the reviewer acts on.
+    const zip = skewedZip(Buffer.alloc(20000, 7), 11);
+    const abort = new Error('cancelled');
+    abort.name = 'AbortError';
+    const env = downloadableHarness(zip.bytes, {
+      window: {
+        screen: { width: 1280, height: 720 },
+        showSaveFilePicker: function () { return Promise.reject(abort); }
+      }
+    });
+    await settle();
+    await env.api.downloadBurned();
+    assert.strictEqual(env.els['burn-item-label'].textContent, 'T:export.video_download',
+      'no file landed, so the item still offers the download');
     assert.strictEqual(env.els['btn-burn-video'].disabled, false);
   });
 


### PR DESCRIPTION
A completed video transfer flipped the export item straight back to «Завантажити відео з субтитрами» — as if nothing had happened. The file lands through the save dialog's own handle (no downloads-list entry, no shelf), so the item's label is the only witness.

**The item now wears a fifth face after the bytes land:** «Відео з субтитрами завантажено», disabled — a statement, not a button. Closing the export menu retires the claim; reopening offers the download again.

Details:
- The mark is set only where a file **verifiably reached disk** — beside each success toast (streaming write, picker save, memory fallback). A picker cancel never earns it.
- Scoped to the transfer's own talk/video (a transfer deliberately outlives its preview), and withdrawn when an edit makes the finished file stale, exactly like the plain download face.
- New `justDownloaded` input on `videoItemState` (model-tested), i18n keys uk/en, styleguide row for the new face.

TDD: model + driver tests first (watched fail), three mutations killed (dropping the landing mark, keeping the claim across a close, never wearing the face). 1160 JS + 1020 Python + smoke green; verified in the browser against the live styleguide and the booted app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)