### PR TITLE
fix(burn): hold the gradient band through inter-cue gaps (no flicker)

### DIFF
--- a/tests/test_burn_subtitles.py
+++ b/tests/test_burn_subtitles.py
@@ -433,7 +433,9 @@ class TestBuildAssDocument:
         layers = [ln.split(",")[0] for ln in _doc().splitlines() if ln.startswith("Dialogue:")]
         assert layers == (["Dialogue: 0"] * DEFAULT_GRADIENT_STEPS + ["Dialogue: 1"]) * 2
 
-    def test_band_and_text_share_exact_timings(self):
+    def test_band_and_text_share_exact_timings_when_cues_touch(self):
+        # CUES are back-to-back, so bridging has nothing to add: the band
+        # still starts and ends exactly with its text.
         band_times = None
         checked = 0
         for line in _doc().splitlines():
@@ -474,6 +476,70 @@ class TestBuildAssDocument:
     def test_header_precedes_events(self):
         doc = _doc()
         assert doc.index("[Events]") < doc.index("Dialogue:")
+
+
+def _event_times(doc):
+    """(layer, start, end) per Dialogue line, in document order."""
+    times = []
+    for line in doc.splitlines():
+        if line.startswith("Dialogue:"):
+            layer, start, end = line.split(",")[0:3]
+            times.append((layer, start, end))
+    return times
+
+
+class TestBandBridgesGaps:
+    """The band must hold through the gap between cues, as the SPA does.
+
+    The web overlay pins its height when a cue ends, so the gradient stays up
+    through the deliberate 80ms gaps instead of flashing off and on. The ASS
+    counterpart: a cue's band runs until the next visible cue starts; only the
+    text keeps the cue's exact timings.
+    """
+
+    GAPPED = [
+        {"idx": 1, "start_ms": 0, "end_ms": 2000, "text": "Перше речення."},
+        {"idx": 2, "start_ms": 2080, "end_ms": 4000, "text": "Друге речення."},
+    ]
+
+    def test_band_extends_to_next_cue_start(self):
+        events = _event_times(_doc(self.GAPPED))
+        first_bands = [e for e in events if e[0] == "Dialogue: 0"][:DEFAULT_GRADIENT_STEPS]
+        assert all(e[1] == "0:00:00.00" and e[2] == "0:00:02.08" for e in first_bands)
+
+    def test_text_keeps_the_cue_timings(self):
+        events = _event_times(_doc(self.GAPPED))
+        texts = [e for e in events if e[0] == "Dialogue: 1"]
+        assert texts[0] == ("Dialogue: 1", "0:00:00.00", "0:00:02.00")
+        assert texts[1] == ("Dialogue: 1", "0:00:02.08", "0:00:04.00")
+
+    def test_last_cue_band_ends_with_its_text(self):
+        events = _event_times(_doc(self.GAPPED))
+        last_bands = [e for e in events if e[0] == "Dialogue: 0"][DEFAULT_GRADIENT_STEPS:]
+        assert all(e[2] == "0:00:04.00" for e in last_bands)
+
+    def test_blank_cue_is_not_a_bridge_anchor(self):
+        # A blank cue draws nothing, so bridging to its start would end the
+        # band on an invisible event and reintroduce the flash.
+        cues = [
+            {"idx": 1, "start_ms": 0, "end_ms": 1000, "text": "Перше."},
+            {"idx": 2, "start_ms": 1500, "end_ms": 1600, "text": "   "},
+            {"idx": 3, "start_ms": 3000, "end_ms": 4000, "text": "Третє."},
+        ]
+        events = _event_times(_doc(cues))
+        first_bands = [e for e in events if e[0] == "Dialogue: 0"][:DEFAULT_GRADIENT_STEPS]
+        assert all(e[2] == "0:00:03.00" for e in first_bands)
+
+    def test_overlapping_cues_never_shrink_the_band(self):
+        # Pathological SRT where the next cue starts before this one ends:
+        # the band must still cover its own text.
+        cues = [
+            {"idx": 1, "start_ms": 0, "end_ms": 2000, "text": "Перше."},
+            {"idx": 2, "start_ms": 1000, "end_ms": 3000, "text": "Друге."},
+        ]
+        events = _event_times(_doc(cues))
+        first_bands = [e for e in events if e[0] == "Dialogue: 0"][:DEFAULT_GRADIENT_STEPS]
+        assert all(e[2] == "0:00:02.00" for e in first_bands)
 
     def test_ends_with_a_newline(self):
         assert _doc().endswith("\n")

--- a/tools/burn_subtitles.py
+++ b/tools/burn_subtitles.py
@@ -246,9 +246,9 @@ def band_event(start_ms, end_ms, width, band_top, band_height, steps=DEFAULT_GRA
     separate \\pos-ed events drew the full-width gradient correctly. Each strip
     therefore draws from its own origin and carries its absolute frame Y in \\pos.
 
-    All strips share the cue's exact timings, which reproduces the CSS behaviour
-    of the band being visible only while a subtitle is on screen. The caller
-    joins them into the document with the rest of the events.
+    All strips share the given timings. The caller decides the span: the text's
+    own cue timings, or a longer window that bridges the gap to the next cue —
+    see build_ass_document.
     """
     if steps < 1:
         raise ValueError(f"steps must be >= 1, got {steps}")
@@ -301,7 +301,10 @@ def build_ass_document(
     """Assemble the full ASS document for a cue list.
 
     Each cue contributes its band — one Layer-0 event per gradient strip — and
-    then a single Layer-1 text event, all sharing the cue's timings. Cues whose
+    then a single Layer-1 text event. The text keeps the cue's exact timings;
+    the band runs on until the next visible cue starts, holding the gradient
+    through the deliberate 80ms gaps the way the SPA overlay pins its height —
+    the band flashing off and on between cues reads as flicker. Cues whose
     text is blank are skipped entirely: a band with nothing on it would flash a
     dark strip across an otherwise clean frame.
     """
@@ -311,19 +314,23 @@ def build_ass_document(
     padtop_px = round(padtop_ratio * height)
     wrap_width = width - 2 * margin_h
 
+    # Escape first: wrapping then measures the escaped form, so the one
+    # backslash each escaped brace adds is counted although libass will not
+    # draw it. Braces are vanishingly rare here, and the 2% wrap safety
+    # margin absorbs it; measuring the raw text would instead let a line
+    # grow past the margin.
+    visible = [(cue, text) for cue in cues if (text := escape_ass_text(cue["text"]))]
+
     lines = [build_ass_header(width, height, font_size, font_name, margin_h, margin_v)]
-    for cue in cues:
-        # Escape first: wrapping then measures the escaped form, so the one
-        # backslash each escaped brace adds is counted although libass will not
-        # draw it. Braces are vanishingly rare here, and the 2% wrap safety
-        # margin absorbs it; measuring the raw text would instead let a line
-        # grow past the margin.
-        text = escape_ass_text(cue["text"])
-        if not text:
-            continue
+    for i, (cue, text) in enumerate(visible):
         wrapped = wrap_text(text, measure, wrap_width)
         band_top, band_height = band_geometry(height, font_size, len(wrapped), margin_v, padtop_px)
-        lines.extend(band_event(cue["start_ms"], cue["end_ms"], width, band_top, band_height, steps))
+        # max(): a pathological overlapping SRT must not end the band before
+        # its own text. The last band ends with its text — nothing to hold for.
+        band_end = cue["end_ms"]
+        if i + 1 < len(visible):
+            band_end = max(band_end, visible[i + 1][0]["start_ms"])
+        lines.extend(band_event(cue["start_ms"], band_end, width, band_top, band_height, steps))
         lines.append(dialogue_event(cue["start_ms"], cue["end_ms"], wrapped, font_size))
     return "\n".join(lines) + "\n"
 


### PR DESCRIPTION
## Problem

In burned-in videos the gradient band behind the subtitles disappeared and reappeared at every gap between blocks — including the deliberate 80 ms gaps the optimizer inserts — reading as bottom-of-frame flicker. The web SPA does not flicker: when a subtitle ends, the overlay pins its height and the gradient holds through the gap (`renderOverlayAt` in `site/index.html`).

## Fix

`build_ass_document` now extends each cue's band events until the next **visible** cue starts; the text events keep their exact cue timings. Details:

- Blank cues (screen remarks stripped to nothing) are not bridge anchors — the band bridges past them to the next cue that actually draws.
- A pathological overlapping SRT can never shrink a band below its own text (`max(end, next_start)`).
- The last cue's band still ends with its text — nothing to hold for.

This matches the web exactly: the band holds at the previous block's height through the pause and switches height together with the next text.

## Verification

- TDD: new `TestBandBridgesGaps` (bridge, text timings intact, last-cue release, blank-cue anchor skip, overlap guard); full fast lane green (1025 passed).
- Pixel-wise through mpv/libass on a white clip with a 500 ms gap: band luma identical during the cue and inside the gap (38 = 38), pure white (255) after the last cue, zero stray dark pixels above the band in every frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)