### PR TITLE
Edit sync: 1998-05-10_Sahasrara-Puja-Blessing-of-Divine-Pours-Only-If-Sahasrara-is-Completely-Open (SlavaSubotskiy)

### DIFF
--- a/.review-sync/1998-05-10_Sahasrara-Puja-Blessing-of-Divine-Pours-Only-If-Sahasrara-is-Completely-Open/Sahasrara-Puja-Talk-uk.json
+++ b/.review-sync/1998-05-10_Sahasrara-Puja-Blessing-of-Divine-Pours-Only-If-Sahasrara-is-Completely-Open/Sahasrara-Puja-Talk-uk.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "revision": 1,
+  "updatedAt": "2026-08-13T11:25:42.829Z",
+  "client": "i9y1tg",
+  "talkId": "1998-05-10_Sahasrara-Puja-Blessing-of-Divine-Pours-Only-If-Sahasrara-is-Completely-Open",
+  "entries": {
+    "srt_edits_1998-05-10_Sahasrara-Puja-Blessing-of-Divine-Pours-Only-If-Sahasrara-is-Completely-Open_Sahasrara-Puja-Talk_uk": {
+      "645": "тому що Калі Юга все ще завдає своїх мук, а Сатья Юга намагається проявитися."
+    }
+  }
+}


### PR DESCRIPTION
Automated **draft** PR carrying in-progress review/preview edits from the SPA.

- State file: `.review-sync/1998-05-10_Sahasrara-Puja-Blessing-of-Divine-Pours-Only-If-Sahasrara-is-Completely-Open/Sahasrara-Puja-Talk-uk.json`
- Branch: `sync/SlavaSubotskiy/1998-05-10_Sahasrara-Puja-Blessing-of-Divine-Pours-Only-If-Sahasrara-is-Completely-Open--Sahasrara-Puja-Talk-uk`

It is updated in the background while the user edits, and is flipped to ready-for-review (real files committed, state file removed) when the user finalizes from the app. Do not merge while draft.